### PR TITLE
chore(release): 0.41.4 — Loop 1 + Loop 2 Full Execution Path Coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.41.4] - 2026-03-27 — Loop 1 + Loop 2 Full Execution Path Coverage
+
+Incremental on [0.41.3]. Wires debug routing (Loop 1) and formal simulation (Loop 2) into all default phase execution paths.
+
+### Added
+- `feat(quick-362)`: wire debug routing (Loop 1 + task classification + `debug_context` injection) into `execute-phase.md` — Step 1.5 classifies each plan via Haiku as bug_fix/feature/refactor, routes bug_fix plans through `/nf:debug` before executor spawn, injects `<debug_context>` block into executor prompt
+- `feat(quick-363)`: push Loop 2 (`formal_coverage_auto_detection` + `solution-simulation-loop`) and `debug_context` passthrough into `execute-plan.md` Pattern A spawn prompt — nested child executors now inherit both verification loops
+
+### Changed
+- **Changelog rewrite** — all 0.41.x entries rewritten from git history; every `feat`/`fix`/`req` commit now has a corresponding entry with git prefix for traceability
+
+### Coverage matrix
+
+| Path | Loop 1 | Loop 2 |
+|------|--------|--------|
+| `quick.md` | Yes | Yes |
+| `execute-phase.md` → Pattern A | Yes | Yes (new) |
+| `execute-phase.md` → Pattern B | Yes | Yes |
+| `execute-phase.md` → Pattern C | Yes | Yes |
+| `execute-phase.md` → Pattern D | Yes | No (opt-in, deferred) |
+
 ## [0.41.3] - 2026-03-27 — Live Health Dashboard Fix
 
 Incremental on [0.41.2]. Fixes TUI health dashboard that silently skipped all subprocess providers.

--- a/docs/assets/terminal.svg
+++ b/docs/assets/terminal.svg
@@ -80,7 +80,7 @@
     <path d="M100.8,143.0 H96.6 V132.0" stroke="#7dcfff" stroke-width="1.5" stroke-linecap="square" fill="none"/>
     <line x1="100.8" y1="143.0" x2="109.2" y2="143.0" stroke="#7dcfff" stroke-width="1.5" stroke-linecap="square" fill="none"/>
     <path d="M109.2,143.0 H113.4 V132.0" stroke="#7dcfff" stroke-width="1.5" stroke-linecap="square" fill="none"/>
-    <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="198" xml:space="preserve"><tspan fill="#c0caf5">  nForma </tspan><tspan fill="#c0caf5">— Consensus before code. Proof before production. </tspan><tspan fill="#565f89">v0.41.3</tspan></text>
+    <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="198" xml:space="preserve"><tspan fill="#c0caf5">  nForma </tspan><tspan fill="#c0caf5">— Consensus before code. Proof before production. </tspan><tspan fill="#565f89">v0.41.4</tspan></text>
     <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="220" xml:space="preserve"><tspan fill="#565f89">  Built on GSD-CC by TÂCHES.</tspan></text>
     <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="264" xml:space="preserve"><tspan fill="#7dcfff">  The task of leadership is to create an alignment of strengths</tspan></text>
     <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="286" xml:space="preserve"><tspan fill="#7dcfff">   so strong that it makes the system’s weaknesses irrelevant.</tspan></text>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nforma.ai/nforma",
-  "version": "0.41.3",
+  "version": "0.41.4",
   "description": "nForma — Multi-agent coding orchestrator with quorum consensus and formal verification (TLA+, Alloy, PRISM). Consensus before code, proof before production.",
   "bin": {
     "nforma": "bin/nforma-cli.js",


### PR DESCRIPTION
## Summary
- Wires Loop 1 (debug routing via `/nf:debug` + autoresearch-refine) and Loop 2 (solution-simulation pre-commit gate) into all default phase execution paths
- Version bump 0.41.3 → 0.41.4
- CHANGELOG + terminal.svg regenerated

## Test plan
- [ ] CI passes (all 3 Node versions)
- [ ] `npm run check:assets` passes
- [ ] CHANGELOG gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)