### PR TITLE
release: 0.41.12 — skill distribution via installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.41.12] - 2026-04-06 — Skill distribution via installer
+
+### Added
+- `feat(install)`: distribute skills from `agents/skills/` to `~/.claude/skills/` during installation — currently installs `task-intake` skill
+
 ## [0.41.11] - 2026-04-06 — Multi-runtime installer & bug fixes
 
 ### Added

--- a/bin/install.js
+++ b/bin/install.js
@@ -2375,6 +2375,26 @@ function install(isGlobal, runtime = 'claude') {
     }
   }
 
+  // Copy skills to skills directory (Claude Code / OpenCode only)
+  const skillsSrc = path.join(agentsSrc, 'skills');
+  if (fs.existsSync(skillsSrc)) {
+    const skillsDest = path.join(targetDir, 'skills');
+    let skillCount = 0;
+    for (const entry of fs.readdirSync(skillsSrc, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const skillDir = path.join(skillsSrc, entry.name);
+      const skillFile = path.join(skillDir, 'SKILL.md');
+      if (!fs.existsSync(skillFile)) continue;
+      const destDir = path.join(skillsDest, entry.name);
+      fs.mkdirSync(destDir, { recursive: true });
+      fs.copyFileSync(skillFile, path.join(destDir, 'SKILL.md'));
+      skillCount++;
+    }
+    if (skillCount > 0) {
+      console.log(`  ${green}✓${reset} Installed ${skillCount} skill${skillCount > 1 ? 's' : ''} to skills/`);
+    }
+  }
+
   // Write VERSION file
   const versionDest = path.join(targetDir, 'nf', 'VERSION');
   fs.writeFileSync(versionDest, pkg.version);

--- a/docs/assets/terminal.svg
+++ b/docs/assets/terminal.svg
@@ -80,7 +80,7 @@
     <path d="M100.8,143.0 H96.6 V132.0" stroke="#7dcfff" stroke-width="1.5" stroke-linecap="square" fill="none"/>
     <line x1="100.8" y1="143.0" x2="109.2" y2="143.0" stroke="#7dcfff" stroke-width="1.5" stroke-linecap="square" fill="none"/>
     <path d="M109.2,143.0 H113.4 V132.0" stroke="#7dcfff" stroke-width="1.5" stroke-linecap="square" fill="none"/>
-    <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="198" xml:space="preserve"><tspan fill="#c0caf5">  nForma </tspan><tspan fill="#c0caf5">— Consensus before code. Proof before production. </tspan><tspan fill="#565f89">v0.41.11</tspan></text>
+    <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="198" xml:space="preserve"><tspan fill="#c0caf5">  nForma </tspan><tspan fill="#c0caf5">— Consensus before code. Proof before production. </tspan><tspan fill="#565f89">v0.41.12</tspan></text>
     <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="220" xml:space="preserve"><tspan fill="#565f89">  Built on GSD-CC by TÂCHES.</tspan></text>
     <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="264" xml:space="preserve"><tspan fill="#7dcfff">  The task of leadership is to create an alignment of strengths</tspan></text>
     <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="286" xml:space="preserve"><tspan fill="#7dcfff">   so strong that it makes the system’s weaknesses irrelevant.</tspan></text>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nforma.ai/nforma",
-  "version": "0.41.11",
+  "version": "0.41.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nforma.ai/nforma",
-      "version": "0.41.11",
+      "version": "0.41.12",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nforma.ai/nforma",
-  "version": "0.41.11",
+  "version": "0.41.12",
   "description": "nForma — Multi-agent coding orchestrator with quorum consensus and formal verification (TLA+, Alloy, PRISM). Consensus before code, proof before production.",
   "bin": {
     "nforma": "bin/nforma-cli.js",


### PR DESCRIPTION
## Summary

- **Skill distribution**: Installer now copies skills from `agents/skills/` to `~/.claude/skills/` during installation. Currently distributes the `task-intake` skill.

## CI gates (all pass locally)
- `npm run test:ci` — 1392 tests, 0 failures
- `npm run check:assets` — all 3 assets up to date
- `npm run lint:isolation` — all portable-path checks passed