### PR TITLE
release: 0.41.13 — formal-verify CI fix, track CLAUDE.md

### DIFF
--- a/.github/workflows/formal-verify.yml
+++ b/.github/workflows/formal-verify.yml
@@ -24,28 +24,10 @@ on:
       - 'bin/check-trace-redaction.cjs'
       - 'bin/check-trace-schema-drift.cjs'
       - '.planning/formal/trace/**'
+  # Always trigger on PRs — this is a required check for branch protection.
+  # Without this, PRs that don't touch formal files never get the check,
+  # and branch protection blocks the merge.
   pull_request:
-    paths:
-      - 'src/machines/nf-workflow.machine.ts'
-      - '.planning/formal/tla/**'
-      - '.planning/formal/alloy/**'
-      - '.planning/formal/prism/**'
-      - 'bin/run-tlc.cjs'
-      - 'bin/run-alloy.cjs'
-      - 'bin/run-prism.cjs'
-      - 'bin/generate-formal-specs.cjs'
-      - 'bin/check-spec-sync.cjs'
-      - 'bin/verify-quorum-health.cjs'
-      - 'bin/xstate-to-tla.cjs'
-      - 'bin/run-formal-verify.cjs'
-      - 'bin/run-oauth-rotation-prism.cjs'
-      - 'bin/run-account-pool-alloy.cjs'
-      - 'bin/run-account-manager-tlc.cjs'
-      - 'bin/write-check-result.cjs'
-      - 'bin/check-results-exit.cjs'
-      - 'bin/check-trace-redaction.cjs'
-      - 'bin/check-trace-schema-drift.cjs'
-      - '.planning/formal/trace/**'
   workflow_dispatch:  # manual trigger
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ node_modules/
 .npmrc
 .vscode/
 TO-DOS.md
-CLAUDE.md
+
 /research.claude/
 commands.html
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.41.13] - 2026-04-06 — Formal verify CI fix & CLAUDE.md tracking
+
+### Fixed
+- `fix(ci)`: remove `paths` filter from `formal-verify.yml` `pull_request` trigger — formal verification is a required branch protection check, so it must run on every PR regardless of which files changed
+
+### Changed
+- `chore`: track `CLAUDE.md` in git — release process docs, CI troubleshooting, and key commands are now available to all contributors and fresh clones
+
 ## [0.41.12] - 2026-04-06 — Skill distribution via installer
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,109 @@
+# CLAUDE.md — nForma
+
+## Versioning
+
+nForma uses milestone-based semver:
+
+- `0.{milestone}` — milestone release (e.g., 0.40 = 40th milestone)
+- `0.{milestone}.{patch}` — quick task release within a milestone (e.g., 0.40.1, 0.40.2)
+- `0.{milestone}.{patch}-rc.N` — prerelease for `next` dist-tag (e.g., 0.40.2-rc.1)
+
+Dist-tag mapping:
+- `latest` — stable versions (0.40.1)
+- `next` — prereleases (0.40.2-rc.1)
+
+When asked for a "new release", always ask: **latest or next?** Then check `npm view @nforma.ai/nforma dist-tags --json` to determine the next version number.
+
+### Release process
+
+**latest release** (stable) — use `prepare-release.sh`:
+```bash
+# Preferred: automated script handles everything
+bash scripts/prepare-release.sh 0.41.10        # specific version
+bash scripts/prepare-release.sh --auto          # auto-increment patch
+bash scripts/prepare-release.sh --auto --dry-run  # preview first
+```
+
+The script will:
+1. Verify clean working tree (stash first if needed)
+2. Create fresh branch `release/{VERSION}` from `origin/main`
+3. Bump `package.json` to the target version
+4. **Sync `package-lock.json`** via `npm install --package-lock-only`
+5. Validate CHANGELOG.md entry exists (aborts if missing — add it first)
+6. Regenerate assets (`npm run generate-terminal`)
+7. Run all CI gates locally (`npm ci`, `check:assets`, `lint:isolation`, `test:ci`)
+8. Commit, push, and open PR to main
+9. After merge, CI automatically: tests → tags → GitHub Release → npm publish @latest
+
+**Manual steps (if not using the script):**
+1. Stash any unrelated work: `git stash push --include-untracked -m "pre-release"`
+2. `git checkout -b release/{VERSION} origin/main` (fresh branch from main)
+3. Bump `package.json`: `npm version {VERSION} --no-git-tag-version`
+4. **Sync lockfile**: `npm install --package-lock-only`
+5. Verify sync: lockfile version must match package.json version
+6. Add `## [{VERSION}]` entry to CHANGELOG.md
+7. `npm run generate-terminal`
+8. Run gates: `npm ci --ignore-scripts && npm run check:assets && npm run lint:isolation`
+9. Commit, push branch, open PR to main
+10. Merge triggers release pipeline → publishes to `@latest`
+
+**next release** (prerelease) — use `release.sh`:
+```bash
+bash scripts/release.sh                # release current package.json version
+bash scripts/release.sh --dry-run      # preview first
+```
+
+Manual steps:
+1. Bump `package.json` to `0.{milestone}.{N+1}-rc.1`
+2. **Sync lockfile**: `npm install --package-lock-only`
+3. Add `## [0.{milestone}.{N+1}]` entry to CHANGELOG.md (gate checks base version)
+4. `npm run generate-terminal` (asset staleness gate)
+5. Commit, push to main, tag `v0.{milestone}.{N+1}-rc.1`, push tag
+6. Prerelease pipeline publishes to `@next`
+
+### Critical: lockfile sync
+
+**Always run `npm install --package-lock-only` after changing `package.json`.**
+
+The version field in `package-lock.json` must match `package.json`. If they drift, `npm ci` fails in CI — and because GitHub PR checks run against a merge-ref commit, the failure can be impossible to fix without starting from a clean branch.
+
+Quick check: `node -p "require('./package-lock.json').version"` should match `node -p "require('./package.json').version"`.
+
+### CI gates to remember
+- **Lockfile sync**: `package-lock.json` version must match `package.json` version
+- CHANGELOG gate: requires `## [{base_version}]` in CHANGELOG.md
+- Asset staleness: `npm run check:assets` — regenerate with `npm run generate-terminal`
+- Lint isolation: `npm run lint:isolation` — require paths must use `$HOME/.claude/nf-bin/` with CWD fallback
+- CLI version test: regex accepts prerelease suffixes (`X.Y.Z-rc.N`)
+
+### Troubleshooting CI failures
+
+**`npm ci` fails with EUSAGE (lockfile mismatch):**
+- Root cause: `package-lock.json` version doesn't match `package.json`
+- Fix: `npm install --package-lock-only` then commit the updated lockfile
+- If a PR keeps failing despite lockfile fixes, the merge-ref may be stale. Create a fresh branch from `origin/main` and redo the release there.
+
+**Assets stale after version bump:**
+- Run `npm run generate-terminal` — the SVG embeds the version string
+
+## Git workflow
+
+- Always use PRs with CI gates for stable releases — never direct push to main
+- Direct push to main is acceptable for prerelease version bumps and CI fixes
+- Branch naming:
+  - `release/{VERSION}` — release branches (e.g., `release/0.41.10`)
+  - `nf/quick-{N}-{description}` — quick task branches
+
+## Key commands
+
+- `npm run test:ci` — full test suite
+- `npm run lint:isolation` — portable require path checks
+- `npm run check:assets` — verify generated assets are up to date
+- `npm run generate-terminal` — regenerate terminal.svg after version bump
+- `npm run build:hooks && npm run build:machines` — build step before publish
+
+## Release scripts
+
+- `bash scripts/prepare-release.sh {VERSION}` — prepare stable release via PR (recommended)
+- `bash scripts/release.sh` — tag + push prerelease (direct push flow)
+- `bash scripts/publish.sh` — manual npm publish (reads NPM_TOKEN from .env)

--- a/docs/assets/terminal.svg
+++ b/docs/assets/terminal.svg
@@ -80,7 +80,7 @@
     <path d="M100.8,143.0 H96.6 V132.0" stroke="#7dcfff" stroke-width="1.5" stroke-linecap="square" fill="none"/>
     <line x1="100.8" y1="143.0" x2="109.2" y2="143.0" stroke="#7dcfff" stroke-width="1.5" stroke-linecap="square" fill="none"/>
     <path d="M109.2,143.0 H113.4 V132.0" stroke="#7dcfff" stroke-width="1.5" stroke-linecap="square" fill="none"/>
-    <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="198" xml:space="preserve"><tspan fill="#c0caf5">  nForma </tspan><tspan fill="#c0caf5">— Consensus before code. Proof before production. </tspan><tspan fill="#565f89">v0.41.12</tspan></text>
+    <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="198" xml:space="preserve"><tspan fill="#c0caf5">  nForma </tspan><tspan fill="#c0caf5">— Consensus before code. Proof before production. </tspan><tspan fill="#565f89">v0.41.13</tspan></text>
     <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="220" xml:space="preserve"><tspan fill="#565f89">  Built on GSD-CC by TÂCHES.</tspan></text>
     <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="264" xml:space="preserve"><tspan fill="#7dcfff">  The task of leadership is to create an alignment of strengths</tspan></text>
     <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="286" xml:space="preserve"><tspan fill="#7dcfff">   so strong that it makes the system’s weaknesses irrelevant.</tspan></text>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nforma.ai/nforma",
-  "version": "0.41.12",
+  "version": "0.41.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nforma.ai/nforma",
-      "version": "0.41.12",
+      "version": "0.41.13",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nforma.ai/nforma",
-  "version": "0.41.12",
+  "version": "0.41.13",
   "description": "nForma — Multi-agent coding orchestrator with quorum consensus and formal verification (TLA+, Alloy, PRISM). Consensus before code, proof before production.",
   "bin": {
     "nforma": "bin/nforma-cli.js",


### PR DESCRIPTION
## Summary

- **fix(ci)**: Remove `paths` filter from `formal-verify.yml` `pull_request` trigger — the `TLC + Alloy + PRISM model checks` job is a required branch protection check, so it must run on every PR regardless of which files changed. The `push` trigger retains its `paths` filter (only runs on main/staging when formal files change).
- **chore**: Track `CLAUDE.md` in git (removed from `.gitignore`) — release process docs, CI troubleshooting, and key commands are now available to all contributors and fresh clones.

## CI Gates (local)

- `check:assets` — passed
- `lint:isolation` — passed
- `test:ci` — **1392 tests, 0 failures**

## Files Changed

| File | Change |
|------|--------|
| `.github/workflows/formal-verify.yml` | Remove `paths` filter from `pull_request` trigger |
| `.gitignore` | Remove `CLAUDE.md` from ignore list |
| `CLAUDE.md` | **New**: release process, CI gates, troubleshooting docs |
| `CHANGELOG.md` | Add 0.41.13 entry |
| `package.json` | Bump to 0.41.13 |
| `package-lock.json` | Sync with package.json |
| `docs/assets/terminal.svg` | Regenerated for 0.41.13 |

## Key validation

This PR itself validates the formal-verify fix — the `TLC + Alloy + PRISM model checks` should now trigger automatically since we removed the paths filter.