### PR TITLE
release: 0.42.4-rc.1 — Adversarial Hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,22 @@ All notable changes to nForma will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [0.42.4] - 2026-04-21
 
 ### Added
 - Six human phase skills ship with nForma: `nf:idea`, `nf:plan`, `nf:build`, `nf:ship`, `nf:debug`, `nf:observe` — each `SKILL.md` documents sub-skills, commands, entry/exit conditions, and routing across the full development lifecycle (closes #94)
-- Adversarial test coverage for aggregate-requirements, continuous-verify, oscillation-detector, and solve-cycle-detector modules (`bin/*-adversarial.test.cjs`)
-- `bin/resolve-formal-tools.test.cjs` — new test suite for formal tool resolution
+- `benchmarks/full-benchmark-baseline.json` — source of truth for nForma's benchmark score (15.2% / 35/230)
+- `nf-benchmark` submodule integrated for full 230-challenge benchmark suite
+
+### Changed
+- Benchmark CI gate now runs full 230-challenge suite on PRs with zero-tolerance regression blocking
+- Baseline auto-updates in nForma repo on push to main when score improves
 
 ### Fixed
-- `fix(set-secret)`: restore Usage message when stdin value is missing
-- `fix(continuous-verify)`: correctness bugs surfaced during adversarial testing
-- `fix(solve-cycle-detector)`: edge-case fixes found during adversarial testing
-- `fix(secrets)`: hardening identified during adversarial test runs
+- `fix(nf-stop)`: `parseQuorumSizeFlag` now rejects fractional values (`--n 1.5`) instead of silently truncating to solo mode
+- `fix(nf-stop)`: adversarial hardening added `--n 0` boundary handling and `is_error: true` propagation checks
+- `fix(config-loader)`: `slotToToolCall` fallback invariants verified
+- `fix(nf-circuit-breaker)`: `makeFileSetHash` order-independence and empty-array handling confirmed
 
 ## [0.42.3] - 2026-04-11 — Repowise Intelligence Integration (v0.42 milestone)
 

--- a/docs/assets/terminal.svg
+++ b/docs/assets/terminal.svg
@@ -80,7 +80,7 @@
     <path d="M100.8,143.0 H96.6 V132.0" stroke="#7dcfff" stroke-width="1.5" stroke-linecap="square" fill="none"/>
     <line x1="100.8" y1="143.0" x2="109.2" y2="143.0" stroke="#7dcfff" stroke-width="1.5" stroke-linecap="square" fill="none"/>
     <path d="M109.2,143.0 H113.4 V132.0" stroke="#7dcfff" stroke-width="1.5" stroke-linecap="square" fill="none"/>
-    <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="198" xml:space="preserve"><tspan fill="#c0caf5">  nForma </tspan><tspan fill="#c0caf5">— Consensus before code. Proof before production. </tspan><tspan fill="#565f89">v0.42.3</tspan></text>
+    <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="198" xml:space="preserve"><tspan fill="#c0caf5">  nForma </tspan><tspan fill="#c0caf5">— Consensus before code. Proof before production. </tspan><tspan fill="#565f89">v0.42.4-rc.1</tspan></text>
     <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="220" xml:space="preserve"><tspan fill="#565f89">  Built on GSD-CC by TÂCHES.</tspan></text>
     <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="264" xml:space="preserve"><tspan fill="#7dcfff">  The task of leadership is to create an alignment of strengths</tspan></text>
     <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="286" xml:space="preserve"><tspan fill="#7dcfff">   so strong that it makes the system’s weaknesses irrelevant.</tspan></text>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nforma.ai/nforma",
-  "version": "0.42.3",
+  "version": "0.42.4-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nforma.ai/nforma",
-      "version": "0.42.3",
+      "version": "0.42.4-rc.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nforma.ai/nforma",
-  "version": "0.42.3",
+  "version": "0.42.4-rc.1",
   "description": "nForma — Multi-agent coding orchestrator with quorum consensus and formal verification (TLA+, Alloy, PRISM). Consensus before code, proof before production.",
   "bin": {
     "nforma": "bin/nforma-cli.js",


### PR DESCRIPTION
## Summary

Prerelease for Adversarial Hardening milestone.

### What's included
- Benchmark regression gate: full 230-challenge suite blocks PRs with zero tolerance
- Auto-baseline update in nForma repo on push to main when score improves
- Adversarial hardening: 8 edge-case tests across 4 test files
  - `parseQuorumSizeFlag` fractional value rejection (`--n 1.5`)
  - `slotToToolCall` fallback invariants
  - `makeFileSetHash` order-independence and empty-array handling
- nf-benchmark submodule updated with gitignore fixes

### Publish
- `@next` → `0.42.4-rc.1`