### PR TITLE
release: 0.42.4 — Adversarial Hardening

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nforma.ai/nforma",
-  "version": "0.42.4-rc.1",
+  "version": "0.42.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nforma.ai/nforma",
-      "version": "0.42.4-rc.1",
+      "version": "0.42.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nforma.ai/nforma",
-  "version": "0.42.4-rc.1",
+  "version": "0.42.4",
   "description": "nForma — Multi-agent coding orchestrator with quorum consensus and formal verification (TLA+, Alloy, PRISM). Consensus before code, proof before production.",
   "bin": {
     "nforma": "bin/nforma-cli.js",


### PR DESCRIPTION
## Summary

Stable release for Adversarial Hardening milestone.

### What's included
- Benchmark regression gate: full 230-challenge suite blocks PRs with zero tolerance
- Auto-baseline update in nForma repo on push to main when score improves
- 8 adversarial edge-case tests across 4 test files
- `nf-benchmark` submodule integrated for full 230-challenge suite

### Publish
- `@latest` → `0.42.4`
- `@next` already at `0.42.4-rc.1` (will be updated to stable after this)