### PR TITLE
ci: split lint into separate job for branch protection

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,2 @@
+reviews:
+  request_changes_workflow: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,15 +7,10 @@ on:
     branches: [main]
 
 jobs:
-  test:
-    name: Unit tests (Node ${{ matrix.node }})
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
-    timeout-minutes: 5
-    strategy:
-      fail-fast: false
-      matrix:
-        node: ['18', '20', '22']
-
+    timeout-minutes: 3
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -23,7 +18,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node }}
+          node-version: '22'
 
       - name: Verify lockfile sync
         run: |
@@ -47,6 +42,30 @@ jobs:
 
       - name: Lint (isolation check)
         run: npm run lint:isolation
+
+  test:
+    name: Unit tests (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['18', '20', '22']
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts || npm install --ignore-scripts
+
+      - name: Build artifacts
+        run: npm run build:hooks && npm run build:machines
 
       - name: Run CI tests
         run: npm run test:ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    timeout-minutes: 3
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -44,6 +44,7 @@ jobs:
         run: npm run lint:isolation
 
   test:
+    needs: lint
     name: Unit tests (Node ${{ matrix.node }})
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
## Summary
- Extract lockfile sync, asset staleness, and isolation lint checks into a dedicated **Lint** job
- Test matrix jobs now only run install → build → test (no duplicate lint steps)
- After merge, add `Lint` as a required status check in branch protection

## Test plan
- [ ] Verify `Lint` job appears as a separate check on this PR
- [ ] Verify `Unit tests (Node 18/20/22)` jobs still pass without lint steps
- [ ] After merge: add `Lint` to required status checks via GitHub settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI reorganized: added a dedicated lint job that runs before tests and a separate test job that runs afterward.
  * Test job restored with multi-version coverage and rebuilds before running tests to improve reliability.
  * Added configuration to enable a review "request changes" workflow for change-request handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->