### PR TITLE
refactor(formal-loops): migrate all consumers to shared convergent loops

### DIFF
--- a/bin/autoresearch-refine.cjs
+++ b/bin/autoresearch-refine.cjs
@@ -4,6 +4,10 @@
 /**
  * autoresearch-refine.cjs
  *
+ * @deprecated Use formal-model-loop.cjs instead. This module uses callback-driven
+ * architecture (onTweak). The replacement uses callLlm injection for better
+ * testability and reuse. Kept for backward compatibility only.
+ *
  * Autoresearch-style micro-loop for formal model refinement.
  * Module-only API (not a CLI). The calling Agent subprocess require()s this
  * module and passes an onTweak callback to perform model edits.

--- a/bin/bench-formal-spec.cjs
+++ b/bin/bench-formal-spec.cjs
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * @deprecated Intermediate single-shot spec generator. Superseded by
+ * formal-model-loop.cjs which provides convergent refinement.
+ * Kept for backward compatibility only.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const args = process.argv.slice(2);
+const stubIdx = args.indexOf('--stub');
+const testIdx = args.indexOf('--test');
+const tierIdx = args.indexOf('--tier');
+const formatIdx = args.indexOf('--format');
+
+if (stubIdx === -1 || testIdx === -1) {
+  process.stderr.write('Usage: node bin/bench-formal-spec.cjs --stub <path> --test <path> [--tier <tier>] [--format json|text]\n');
+  process.exit(1);
+}
+
+const stubPath = path.resolve(args[stubIdx + 1]);
+const testPath = path.resolve(args[testIdx + 1]);
+const tier = tierIdx !== -1 ? args[tierIdx + 1] : 'easy';
+const format = formatIdx !== -1 ? args[formatIdx + 1] : 'json';
+const ROOT = process.cwd();
+
+const FORMALISM_MAP = {
+  easy: 'alloy',
+  medium: 'alloy',
+  hard: 'tla',
+  extreme: 'tla',
+  legendary: 'tla'
+};
+
+const formalism = FORMALISM_MAP[tier] || 'alloy';
+
+const stubSource = fs.readFileSync(stubPath, 'utf8');
+const testSource = fs.readFileSync(testPath, 'utf8');
+
+function buildAlloyPrompt(stub, test) {
+  return [
+    'You are a formal methods expert. Given a JavaScript function and its test cases,',
+    'generate an Alloy specification that encodes the CORRECT behavior as a formal invariant.',
+    '',
+    'Rules:',
+    '- The spec must define a signature for the function inputs and output',
+    '- The spec must include a FACT that captures the correct function behavior',
+    '- The fact should be expressed as a universally quantified assertion',
+    '- Derive the correct behavior from the test expectations, NOT from the buggy implementation',
+    '- Output ONLY the Alloy spec in a code block. No explanation.',
+    '',
+    'Buggy implementation (DO NOT copy its logic — it has a bug):',
+    '```js',
+    stub,
+    '```',
+    '',
+    'Test cases (these define the CORRECT behavior):',
+    '```js',
+    test,
+    '```',
+  ].join('\n');
+}
+
+function buildTlaPrompt(stub, test) {
+  return [
+    'You are a formal methods expert. Given a JavaScript function and its test cases,',
+    'generate a TLA+ specification that encodes the CORRECT behavior as a formal invariant.',
+    '',
+    'Rules:',
+    '- Define variables and a type invariant',
+    '- Include an operator that captures the correct function behavior',
+    '- The invariant should be derivable from the test expectations',
+    '- Output ONLY the TLA+ spec in a code block. No explanation.',
+    '',
+    'Buggy implementation (DO NOT copy its logic — it has a bug):',
+    '```js',
+    stub,
+    '```',
+    '',
+    'Test cases (these define the CORRECT behavior):',
+    '```js',
+    test,
+    '```',
+  ].join('\n');
+}
+
+function buildConstraintPrompt(stub, test) {
+  return [
+    'Given the following JavaScript function and its test cases, extract the SINGLE',
+    'most important behavioral constraint that the correct implementation must satisfy.',
+    '',
+    'Express it as:',
+    '1. A formal invariant (mathematical notation)',
+    '2. A plain English description',
+    '',
+    'Buggy implementation (has a bug):',
+    '```js',
+    stub,
+    '```',
+    '',
+    'Test cases:',
+    '```js',
+    test,
+    '```',
+    '',
+    'Output format (strict):',
+    'INVARIANT: <mathematical expression of the correct behavior>',
+    'ENGLISH: <plain English description of what the function must do>',
+  ].join('\n');
+}
+
+function callLlm(prompt, model, timeout) {
+  const resolveCli = require('./resolve-cli.cjs').resolveCli;
+  const claudeCli = resolveCli('claude') || 'claude';
+  const result = spawnSync(claudeCli, [
+    '-p', prompt,
+    '--dangerously-skip-permissions',
+    '--model', model || 'claude-haiku-4-5-20251001'
+  ], {
+    cwd: ROOT,
+    encoding: 'utf8',
+    maxBuffer: 4 * 1024 * 1024,
+    timeout: timeout || 60000
+  });
+
+  return {
+    status: result.status,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+    signal: result.signal
+  };
+}
+
+function extractSpec(response) {
+  const codeMatch = response.match(/```(?:alloy|tla|tla\+)?\n?([\s\S]*?)\n?```/);
+  if (codeMatch) return codeMatch[1].trim();
+  return response.trim();
+}
+
+function extractConstraint(response) {
+  const invMatch = response.match(/INVARIANT:\s*(.+)/);
+  const engMatch = response.match(/ENGLISH:\s*(.+)/);
+  return {
+    invariant: invMatch ? invMatch[1].trim() : null,
+    english: engMatch ? engMatch[1].trim() : null,
+    raw: response
+  };
+}
+
+async function main() {
+  const startTime = Date.now();
+
+  const specPrompt = formalism === 'tla'
+    ? buildTlaPrompt(stubSource, testSource)
+    : buildAlloyPrompt(stubSource, testSource);
+
+  const specResult = callLlm(specPrompt, 'claude-haiku-4-5-20251001', 60000);
+  if (specResult.status !== 0 || !specResult.stdout) {
+    const output = {
+      status: 'error',
+      error: 'spec_generation_failed',
+      formalism,
+      elapsed_ms: Date.now() - startTime
+    };
+    process.stdout.write(JSON.stringify(output, null, 2) + '\n');
+    process.exit(1);
+  }
+
+  const formalSpec = extractSpec(specResult.stdout);
+
+  const constraintPrompt = buildConstraintPrompt(stubSource, testSource);
+  const constraintResult = callLlm(constraintPrompt, 'claude-haiku-4-5-20251001', 60000);
+
+  let constraint = { invariant: null, english: null, raw: '' };
+  if (constraintResult.status === 0 && constraintResult.stdout) {
+    constraint = extractConstraint(constraintResult.stdout);
+  }
+
+  const output = {
+    status: 'ok',
+    formalism,
+    spec: formalSpec,
+    constraint,
+    elapsed_ms: Date.now() - startTime
+  };
+
+  if (format === 'text') {
+    process.stdout.write('Formal spec (' + formalism + '):\n');
+    process.stdout.write(formalSpec + '\n\n');
+    if (constraint.english) {
+      process.stdout.write('Constraint: ' + constraint.english + '\n');
+    }
+    if (constraint.invariant) {
+      process.stdout.write('Invariant: ' + constraint.invariant + '\n');
+    }
+  } else {
+    process.stdout.write(JSON.stringify(output, null, 2) + '\n');
+  }
+
+  process.exit(0);
+}
+
+main().catch(function(err) {
+  process.stderr.write('Fatal: ' + err.message + '\n');
+  process.exit(1);
+});

--- a/bin/formal-fix-loop.cjs
+++ b/bin/formal-fix-loop.cjs
@@ -1,0 +1,286 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * formal-fix-loop.cjs
+ *
+ * Loop 2: Iterate fix until all 3 gates pass.
+ *   Gate 1: Fix satisfies the formal invariant (LLM validation)
+ *   Gate 2: Fix passes the test (test runner)
+ *   Gate 3: No regressions (LLM validation)
+ *
+ * Shared by: nf-debug-runner, nf:quick --full executor, nf:debug
+ *
+ * Module exports: { refineFix }
+ *
+ * Usage:
+ *   const { refineFix } = require('./formal-fix-loop.cjs');
+ *   const result = await refineFix({
+ *     buggySource: '...',
+ *     testSource: '...',
+ *     testPath: '/abs/path/test.cjs',
+ *     stubPath: '/abs/path/stub.cjs',
+ *     constraint: { invariant: '...', english: '...' },
+ *     spec: '...',
+ *     bugExplanation: '...',
+ *     maxIterations: 3,
+ *     callLlm: async (prompt) => spawnSync('claude', ['-p', prompt, ...]),
+ *     onLog: (msg) => console.error(msg)
+ *   });
+ */
+
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+
+function buildFixPrompt(buggySource, testFailureOutput, constraint, spec, bugExplanation, rejectionReason) {
+  const constraintBlock = constraint && constraint.english ? [
+    '',
+    '[FORMAL CONSTRAINT — HARD REQUIREMENT]',
+    'The following invariant was derived from formal analysis:',
+    constraint.english,
+    constraint.invariant ? ('Formal: ' + constraint.invariant) : '',
+    '',
+    'Your fix MUST satisfy this constraint. Fixes that violate it will be REJECTED.',
+    '[END FORMAL CONSTRAINT]',
+  ].join('\n') : '';
+
+  const specBlock = spec ? [
+    '',
+    '[FORMAL SPECIFICATION]',
+    spec,
+    '[END SPECIFICATION]',
+  ].join('\n') : '';
+
+  const bugBlock = bugExplanation ? [
+    '',
+    '[BUG ANALYSIS]',
+    bugExplanation,
+    '[END BUG ANALYSIS]',
+  ].join('\n') : '';
+
+  const rejectionBlock = rejectionReason ? [
+    '',
+    '[PREVIOUS FIX REJECTED]',
+    rejectionReason,
+    'Address this rejection in your new fix. Do NOT repeat the same mistake.',
+    '[END REJECTION]',
+  ].join('\n') : '';
+
+  return [
+    'Fix the following buggy JavaScript function.',
+    'The test is failing with this output:',
+    testFailureOutput.slice(0, 500),
+    '',
+    'Buggy source (file: fn.cjs):',
+    '```js',
+    buggySource,
+    '```',
+    constraintBlock,
+    specBlock,
+    bugBlock,
+    rejectionBlock,
+    '',
+    'Return ONLY the fixed source code in a ```js ... ``` code block. Do not explain.',
+  ].join('\n');
+}
+
+function buildInvariantValidationPrompt(fixedSource, constraint) {
+  return [
+    'You are verifying a bug fix against a formal specification.',
+    '',
+    'Proposed fix:',
+    '```js',
+    fixedSource,
+    '```',
+    '',
+    'Formal invariant that the fix MUST satisfy:',
+    constraint.english,
+    constraint.invariant ? ('Formal expression: ' + constraint.invariant) : '',
+    '',
+    'Does the proposed fix satisfy the invariant?',
+    'Answer ONLY: VALID or INVALID followed by a one-line reason.',
+  ].join('\n');
+}
+
+function buildRegressionPrompt(buggySource, fixedSource, testSource) {
+  return [
+    'You are checking a bug fix for regressions.',
+    '',
+    'Original buggy code:',
+    '```js',
+    buggySource,
+    '```',
+    '',
+    'Proposed fix:',
+    '```js',
+    fixedSource,
+    '```',
+    '',
+    'Full test file:',
+    '```js',
+    testSource,
+    '```',
+    '',
+    'Does the fix maintain correct behavior for ALL test cases, including edge cases?',
+    'Could the fix break any case that the original code handled correctly?',
+    '',
+    'Answer ONLY: SAFE or REGRESSION followed by a one-line reason.',
+  ].join('\n');
+}
+
+function extractCodeBlock(response) {
+  if (!response) return null;
+  const codeMatch = response.match(/```(?:js|javascript)?\n?([\s\S]*?)\n?```/);
+  if (codeMatch) return codeMatch[1].trim();
+  const stripped = response.replace(/^[^\n]*\n+/, '').trim();
+  if (stripped.length > 0 && stripped.includes('function')) return stripped;
+  return null;
+}
+
+function validateSyntax(source) {
+  try { new Function(source); return true; } catch (_) { return false; }
+}
+
+async function refineFix(input) {
+  const {
+    buggySource,
+    testSource,
+    testPath,
+    stubPath,
+    testFailureOutput,
+    constraint = null,
+    spec = null,
+    bugExplanation = null,
+    maxIterations = 3,
+    callLlm,
+    onLog = function() {}
+  } = input;
+
+  if (!callLlm) throw new Error('callLlm is required');
+  if (!buggySource || !testPath || !stubPath) {
+    throw new Error('buggySource, testPath, and stubPath are required');
+  }
+
+  const originalSource = fs.readFileSync(stubPath, 'utf8');
+  let converged = false;
+  let iterations = 0;
+  let fixedSource = null;
+  let rejectionReason = null;
+  const rejectionReasons = [];
+  const gates = { gate1_invariant: false, gate2_test: false, gate3_regression: false };
+
+  for (let i = 1; i <= maxIterations; i++) {
+    iterations = i;
+    onLog('[formal-fix-loop] iteration ' + i + '/' + maxIterations);
+
+    const prompt = buildFixPrompt(
+      buggySource, testFailureOutput,
+      constraint, spec, bugExplanation,
+      rejectionReason
+    );
+    const fixResult = await callLlm(prompt);
+
+    if (!fixResult || fixResult.status !== 0 || !fixResult.stdout) {
+      rejectionReason = 'LLM call failed';
+      rejectionReasons.push(rejectionReason);
+      onLog('[formal-fix-loop] LLM call failed (iteration ' + i + ')');
+      continue;
+    }
+
+    const proposed = extractCodeBlock(fixResult.stdout);
+    if (!proposed) {
+      rejectionReason = 'Previous attempt returned no code block. Output exactly the fixed source code in a ```js code block.';
+      rejectionReasons.push(rejectionReason);
+      onLog('[formal-fix-loop] no code block found');
+      continue;
+    }
+
+    if (!validateSyntax(proposed)) {
+      rejectionReason = 'Previous fix had invalid JavaScript syntax.';
+      rejectionReasons.push(rejectionReason);
+      onLog('[formal-fix-loop] invalid syntax');
+      continue;
+    }
+
+    // ── Gate 1: Invariant check ────────────────────────────────────────────
+    gates.gate1_invariant = true;
+    if (constraint && constraint.english) {
+      onLog('[formal-fix-loop] Gate 1: invariant check...');
+      const validResult = await callLlm(
+        buildInvariantValidationPrompt(proposed, constraint)
+      );
+      if (validResult && validResult.status === 0 && validResult.stdout) {
+        const validText = validResult.stdout.trim().toUpperCase();
+        if (validText.includes('INVALID')) {
+          gates.gate1_invariant = false;
+          rejectionReason = 'Gate 1 FAILED (invariant): ' + validResult.stdout.trim();
+          rejectionReasons.push(rejectionReason);
+          onLog('[formal-fix-loop] ' + rejectionReason);
+          continue;
+        }
+      }
+      onLog('[formal-fix-loop] Gate 1 PASSED');
+    }
+
+    // ── Gate 2: Test check ─────────────────────────────────────────────────
+    onLog('[formal-fix-loop] Gate 2: running test...');
+    fs.writeFileSync(stubPath, proposed, 'utf8');
+    const testResult = spawnSync('node', [testPath], {
+      encoding: 'utf8',
+      maxBuffer: 4 * 1024 * 1024,
+      cwd: process.cwd()
+    });
+    gates.gate2_test = testResult.status === 0;
+
+    if (!gates.gate2_test) {
+      const failOutput = (testResult.stderr || '') + (testResult.stdout || '');
+      rejectionReason = 'Gate 2 FAILED (test): ' + failOutput.slice(0, 200);
+      rejectionReasons.push(rejectionReason);
+      onLog('[formal-fix-loop] ' + rejectionReason);
+      fs.writeFileSync(stubPath, originalSource, 'utf8');
+      continue;
+    }
+    onLog('[formal-fix-loop] Gate 2 PASSED');
+
+    // ── Gate 3: Regression check ───────────────────────────────────────────
+    gates.gate3_regression = true;
+    if (constraint && constraint.english) {
+      onLog('[formal-fix-loop] Gate 3: regression check...');
+      const regResult = await callLlm(
+        buildRegressionPrompt(buggySource, proposed, testSource)
+      );
+      if (regResult && regResult.status === 0 && regResult.stdout) {
+        const regText = regResult.stdout.trim().toUpperCase();
+        if (regText.includes('REGRESSION')) {
+          gates.gate3_regression = false;
+          rejectionReason = 'Gate 3 FAILED (regression): ' + regResult.stdout.trim();
+          rejectionReasons.push(rejectionReason);
+          onLog('[formal-fix-loop] ' + rejectionReason);
+          fs.writeFileSync(stubPath, originalSource, 'utf8');
+          continue;
+        }
+      }
+      onLog('[formal-fix-loop] Gate 3 PASSED');
+    }
+
+    converged = true;
+    fixedSource = proposed;
+    onLog('[formal-fix-loop] CONVERGED (' + i + ' iteration(s))');
+    break;
+  }
+
+  if (!converged) {
+    fs.writeFileSync(stubPath, originalSource, 'utf8');
+    onLog('[formal-fix-loop] max iterations reached, no fix accepted');
+  }
+
+  return {
+    converged,
+    iterations,
+    fixedSource,
+    gates,
+    rejectionReasons
+  };
+}
+
+module.exports = { refineFix };

--- a/bin/formal-model-loop.cjs
+++ b/bin/formal-model-loop.cjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * formal-model-loop.cjs
+ *
+ * Loop 1: Iterate formal model until it explains the bug.
+ * Generates a formal spec (Alloy/TLA+), validates it against the bug,
+ * and refines until the model correctly explains why the test fails.
+ *
+ * Shared by: nf-debug-runner, nf:debug Step A.7, nf:quick --full
+ *
+ * Module exports: { refineModel }
+ *
+ * Usage:
+ *   const { refineModel } = require('./formal-model-loop.cjs');
+ *   const result = await refineModel({
+ *     codeSource: '...',
+ *     testSource: '...',
+ *     testFailureOutput: 'FAIL t1\n',
+ *     formalism: 'alloy',
+ *     maxIterations: 3,
+ *     callLlm: async (prompt) => spawnSync('claude', ['-p', prompt, ...]),
+ *     onLog: (msg) => console.error(msg)
+ *   });
+ */
+
+const FORMALISM_MAP = {
+  easy: 'alloy', medium: 'alloy', hard: 'tla', extreme: 'tla', legendary: 'tla'
+};
+
+function formalismForTier(tier) {
+  return FORMALISM_MAP[tier] || 'alloy';
+}
+
+function buildGeneratePrompt(codeSource, testSource, formalismType) {
+  const name = formalismType === 'tla' ? 'TLA+' : 'Alloy';
+  const lang = formalismType === 'tla' ? 'tla' : 'alloy';
+  return [
+    'You are a formal methods expert. Given a JavaScript function and its test cases,',
+    'generate a ' + name + ' specification that:',
+    '1. Defines the CORRECT behavior as a formal invariant',
+    '2. Shows why the BUGGY implementation violates that invariant',
+    '',
+    'Rules:',
+    '- The spec must encode the correct function behavior as a universally quantified assertion',
+    '- Derive the correct behavior from the test expectations, NOT from the buggy implementation',
+    '- The spec should make it clear WHAT the bug is (which operator/logic is wrong)',
+    '- Also extract a plain English constraint describing the correct behavior',
+    '',
+    'Output format (strict):',
+    'SPEC_START',
+    '```' + lang,
+    '<your ' + name + ' spec here>',
+    '```',
+    'SPEC_END',
+    'INVARIANT: <mathematical expression of the correct behavior>',
+    'ENGLISH: <plain English description of what the function must do>',
+    'BUG_EXPLANATION: <one sentence explaining what the bug is and why the invariant is violated>',
+  ].join('\n');
+}
+
+function buildValidatePrompt(spec, invariant, english, bugExplanation, testFailureOutput) {
+  return [
+    'You are verifying a formal model for a bug diagnosis.',
+    '',
+    'Formal spec:',
+    '```',
+    spec,
+    '```',
+    '',
+    'Invariant: ' + invariant,
+    'English: ' + english,
+    'Bug explanation: ' + bugExplanation,
+    '',
+    'Test failure output:',
+    testFailureOutput.slice(0, 500),
+    '',
+    'Does this model correctly explain why the test fails?',
+    'Answer ONLY: EXPLAINS or INCOMPLETE followed by a one-line reason.',
+  ].join('\n');
+}
+
+function buildRefinePrompt(codeSource, testSource, prevSpec, prevInvariant, reason, formalismType) {
+  const name = formalismType === 'tla' ? 'TLA+' : 'Alloy';
+  const lang = formalismType === 'tla' ? 'tla' : 'alloy';
+  return [
+    'The previous ' + name + ' model was judged INCOMPLETE.',
+    'Reason: ' + reason,
+    '',
+    'Previous spec:',
+    '```',
+    prevSpec,
+    '```',
+    '',
+    'Previous invariant: ' + prevInvariant,
+    '',
+    'Improve the model. The spec must:',
+    '1. Precisely capture the correct behavior (not just approximate)',
+    '2. Identify the EXACT bug in the implementation',
+    '',
+    'Buggy implementation:',
+    '```js',
+    codeSource,
+    '```',
+    '',
+    'Test cases:',
+    '```js',
+    testSource,
+    '```',
+    '',
+    'Output format (same as before):',
+    'SPEC_START',
+    '```' + lang,
+    '<improved spec>',
+    '```',
+    'SPEC_END',
+    'INVARIANT: <refined invariant>',
+    'ENGLISH: <refined English description>',
+    'BUG_EXPLANATION: <refined bug explanation>',
+  ].join('\n');
+}
+
+function parseModelResponse(response) {
+  if (!response) return { spec: null, invariant: null, english: null, bugExplanation: null };
+  const specMatch = response.match(/SPEC_START[\s\S]*?```\w*\n([\s\S]*?)\n```[\s\S]*?SPEC_END/);
+  const spec = specMatch ? specMatch[1].trim() : null;
+  const invMatch = response.match(/INVARIANT:\s*(.+)/);
+  const engMatch = response.match(/ENGLISH:\s*(.+)/);
+  const bugMatch = response.match(/BUG_EXPLANATION:\s*(.+)/);
+  return {
+    spec: spec || response.trim(),
+    invariant: invMatch ? invMatch[1].trim() : null,
+    english: engMatch ? engMatch[1].trim() : null,
+    bugExplanation: bugMatch ? bugMatch[1].trim() : null
+  };
+}
+
+async function refineModel(input) {
+  const {
+    codeSource,
+    testSource,
+    testFailureOutput,
+    formalism = 'alloy',
+    maxIterations = 3,
+    callLlm,
+    onLog = function() {}
+  } = input;
+
+  if (!callLlm) throw new Error('callLlm is required');
+  if (!codeSource || !testSource) throw new Error('codeSource and testSource are required');
+
+  let modelResult = null;
+  let converged = false;
+  let iterations = 0;
+
+  for (let i = 1; i <= maxIterations; i++) {
+    iterations = i;
+    onLog('[formal-model-loop] iteration ' + i + '/' + maxIterations);
+
+    let prompt;
+    if (i === 1) {
+      prompt = buildGeneratePrompt(codeSource, testSource, formalism);
+    } else {
+      prompt = buildRefinePrompt(
+        codeSource, testSource,
+        modelResult.spec, modelResult.invariant,
+        modelResult.validationReason || 'unknown',
+        formalism
+      );
+    }
+
+    const result = await callLlm(prompt);
+    if (!result || result.status !== 0 || !result.stdout) {
+      onLog('[formal-model-loop] LLM call failed (iteration ' + i + ')');
+      continue;
+    }
+
+    modelResult = parseModelResponse(result.stdout);
+    modelResult.validationReason = null;
+
+    if (!modelResult.invariant || !modelResult.english) {
+      onLog('[formal-model-loop] model missing invariant/english');
+      modelResult.validationReason = 'Model output missing INVARIANT or ENGLISH fields';
+      continue;
+    }
+
+    onLog('[formal-model-loop] invariant: ' + modelResult.invariant);
+
+    const validPrompt = buildValidatePrompt(
+      modelResult.spec, modelResult.invariant, modelResult.english,
+      modelResult.bugExplanation, testFailureOutput
+    );
+    const validResult = await callLlm(validPrompt);
+
+    if (validResult && validResult.status === 0 && validResult.stdout) {
+      const validText = validResult.stdout.trim().toUpperCase();
+      if (validText.includes('EXPLAINS')) {
+        converged = true;
+        onLog('[formal-model-loop] CONVERGED (' + i + ' iteration(s))');
+        break;
+      } else {
+        modelResult.validationReason = validResult.stdout.trim();
+        onLog('[formal-model-loop] incomplete: ' + validResult.stdout.trim().slice(0, 100));
+      }
+    } else {
+      onLog('[formal-model-loop] validation call failed, accepting as-is');
+      converged = true;
+      break;
+    }
+  }
+
+  if (!converged) {
+    onLog('[formal-model-loop] max iterations reached, using best model');
+  }
+
+  return {
+    converged,
+    iterations,
+    spec: modelResult ? modelResult.spec : null,
+    invariant: modelResult ? modelResult.invariant : null,
+    english: modelResult ? modelResult.english : null,
+    bugExplanation: modelResult ? modelResult.bugExplanation : null
+  };
+}
+
+module.exports = { refineModel, formalismForTier };

--- a/bin/nf-benchmark-debug.cjs
+++ b/bin/nf-benchmark-debug.cjs
@@ -11,6 +11,8 @@
 //   node bin/nf-benchmark-debug.cjs --json
 //   node bin/nf-benchmark-debug.cjs --verbose
 //   node bin/nf-benchmark-debug.cjs --timeout 120000
+//   node bin/nf-benchmark-debug.cjs --tier easy
+//   node bin/nf-benchmark-debug.cjs --tier easy --dry-run
 
 const fs = require('fs');
 const path = require('path');
@@ -21,9 +23,16 @@ const dryRun = args.includes('--dry-run');
 const jsonOutput = args.includes('--json');
 const verbose = args.includes('--verbose');
 const timeoutIdx = args.indexOf('--timeout');
-const runnerTimeout = timeoutIdx !== -1 ? parseInt(args[timeoutIdx + 1], 10) : 180000;
+const runnerTimeout = timeoutIdx !== -1 ? parseInt(args[timeoutIdx + 1], 10) : 360000;
 const trackIdx = args.indexOf('--track');
 const track = trackIdx !== -1 ? args[trackIdx + 1] : 'full';
+const tierIdx = args.indexOf('--tier');
+const tierFilter = tierIdx !== -1 ? args[tierIdx + 1] : null;
+const VALID_TIERS = ['easy', 'medium', 'hard', 'extreme', 'legendary'];
+if (tierFilter !== null && !VALID_TIERS.includes(tierFilter)) {
+  process.stderr.write('[nf-benchmark-debug] ERROR: --tier must be one of: ' + VALID_TIERS.join(', ') + '\n');
+  process.exit(1);
+}
 
 // Smoke track: 5 representative easy stubs, ~3 min in CI.
 // Used on every PR to verify the fix pipeline works end-to-end without
@@ -142,9 +151,13 @@ const STUBS = [
 ];
 
 // Apply track filter
-const ACTIVE_STUBS = track === 'smoke'
+let ACTIVE_STUBS = track === 'smoke'
   ? STUBS.filter(function(s) { return SMOKE_IDS.has(s.id); })
   : STUBS;
+// Apply tier filter
+if (tierFilter !== null) {
+  ACTIVE_STUBS = ACTIVE_STUBS.filter(function(s) { return s.tier === tierFilter; });
+}
 
 if (dryRun) {
   if (jsonOutput) {
@@ -194,7 +207,7 @@ ACTIVE_STUBS.forEach(function(entry) {
   let errorCode = null;
 
   try {
-    const runnerArgs = ['--stub', absStubPath, '--test', absTestPath];
+    const runnerArgs = ['--stub', absStubPath, '--test', absTestPath, '--tier', entry.tier];
     if (verbose) runnerArgs.push('--verbose');
 
     const runResult = spawnSync('node', [NF_DEBUG_RUNNER].concat(runnerArgs), {

--- a/bin/nf-debug-runner.cjs
+++ b/bin/nf-debug-runner.cjs
@@ -2,23 +2,25 @@
 'use strict';
 // bin/nf-debug-runner.cjs
 // Fix-cycle runner for a single debug benchmark stub.
-// Protocol: run test → if fail, assemble formal context → quorum fix → apply → re-run test.
+// Uses shared formal-model-loop (Loop 1) and formal-fix-loop (Loop 2).
 //
 // Usage:
-//   node bin/nf-debug-runner.cjs --stub <path> --test <path>
-//   node bin/nf-debug-runner.cjs --stub <path> --test <path> --dry-run
-//   node bin/nf-debug-runner.cjs --stub <path> --test <path> --verbose
-//   node bin/nf-debug-runner.cjs --stub <path> --test <path> --timeout 60000
+//   node bin/nf-debug-runner.cjs --stub <path> --test <path> [--tier easy] [--verbose] [--no-formal]
 
 const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
+
+const { refineModel, formalismForTier } = require('./formal-model-loop.cjs');
+const { refineFix } = require('./formal-fix-loop.cjs');
 
 const args = process.argv.slice(2);
 const dryRun = args.includes('--dry-run');
 const verbose = args.includes('--verbose');
 const stubIdx = args.indexOf('--stub');
 const testIdx = args.indexOf('--test');
+const tierIdx = args.indexOf('--tier');
+const noFormalIdx = args.indexOf('--no-formal');
 const timeoutIdx = args.indexOf('--timeout');
 
 if (stubIdx === -1 || testIdx === -1) {
@@ -28,138 +30,123 @@ if (stubIdx === -1 || testIdx === -1) {
 
 const stubPath = path.resolve(args[stubIdx + 1]);
 const testPath = path.resolve(args[testIdx + 1]);
-const quorumTimeout = timeoutIdx !== -1 ? parseInt(args[timeoutIdx + 1], 10) : 150000;
-
-const ROOT = process.cwd();
-const DEBUG_FORMAL_CTX = path.join(__dirname, 'debug-formal-context.cjs');
-const CALL_QUORUM_SLOT = path.join(__dirname, 'call-quorum-slot.cjs');
-
-// Pre-flight check: verify required dependencies exist
-if (!fs.existsSync(DEBUG_FORMAL_CTX)) {
-  process.stderr.write('ERROR: bin/debug-formal-context.cjs not found at ' + DEBUG_FORMAL_CTX + '\n');
-  process.exit(1);
-}
-if (!fs.existsSync(CALL_QUORUM_SLOT)) {
-  process.stderr.write('ERROR: bin/call-quorum-slot.cjs not found at ' + CALL_QUORUM_SLOT + '\n');
-  process.exit(1);
-}
+const tier = tierIdx !== -1 ? args[tierIdx + 1] : 'easy';
+const useFormal = noFormalIdx === -1;
+const quorumTimeout = timeoutIdx !== -1 ? parseInt(args[timeoutIdx + 1], 10) : 300000;
+const formalism = formalismForTier(tier);
 
 if (dryRun) {
-  process.stdout.write(JSON.stringify({ dry_run: true, stub: stubPath, test: testPath }) + '\n');
+  process.stdout.write(JSON.stringify({ dry_run: true, stub: stubPath, test: testPath, formal: useFormal, tier, formalism }) + '\n');
   process.exit(0);
 }
 
-// Track original stub source for restoration in finally block
 let originalStubSource = null;
 const startTime = Date.now();
 
-try {
-  // Step 1: run test
-  const spawnOpts = { encoding: 'utf8', maxBuffer: 4 * 1024 * 1024 };
-  if (verbose) spawnOpts.stdio = ['pipe', 'inherit', 'inherit'];
+function log(msg) {
+  if (verbose) process.stderr.write('[nf-debug-runner] ' + msg + '\n');
+}
 
-  let testResult = spawnSync('node', [testPath], { ...spawnOpts, cwd: ROOT });
+function callLlm(prompt) {
+  const claudeCli = require('./resolve-cli.cjs').resolveCli('claude') || 'claude';
+  return Promise.resolve(spawnSync(claudeCli, [
+    '-p', prompt,
+    '--dangerously-skip-permissions',
+    '--model', 'claude-haiku-4-5-20251001'
+  ], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    maxBuffer: 4 * 1024 * 1024,
+    timeout: quorumTimeout
+  }));
+}
+
+async function main() {
+  // ── Step 1: Run test ────────────────────────────────────────────────────────
+  let testResult = spawnSync('node', [testPath], { encoding: 'utf8', maxBuffer: 4 * 1024 * 1024, cwd: process.cwd() });
+  if (verbose && testResult.stderr) process.stderr.write(testResult.stderr);
+  if (verbose && testResult.stdout) process.stderr.write(testResult.stdout);
 
   if (testResult.status === 0) {
-    if (verbose) process.stderr.write('[nf-debug-runner] test already passes — no fix needed\n');
+    log('test already passes');
     process.stdout.write(JSON.stringify({ fixed: false, already_passing: true, elapsed_ms: Date.now() - startTime }) + '\n');
-    process.exit(0);
+    return;
   }
 
   const testFailureOutput = (testResult.stderr || '') + (testResult.stdout || '');
 
-  // Step 2: assemble formal context
+  // ── Step 2: Read sources ────────────────────────────────────────────────────
   const stubSource = fs.readFileSync(stubPath, 'utf8');
   originalStubSource = stubSource;
-  const description = 'Bug in fn.cjs. Test failure:\n' + testFailureOutput.slice(0, 1000);
+  const testSource = fs.readFileSync(testPath, 'utf8');
 
-  const ctxResult = spawnSync('node', [DEBUG_FORMAL_CTX, '--description', description, '--format', 'json'], {
-    cwd: ROOT, encoding: 'utf8', maxBuffer: 4 * 1024 * 1024, timeout: 30000
+  // ── Step 3: Loop 1 — Model refinement ──────────────────────────────────────
+  let modelResult = { converged: false, iterations: 0, spec: null, invariant: null, english: null, bugExplanation: null };
+
+  if (useFormal) {
+    log('Loop 1: refining formal model...');
+    modelResult = await refineModel({
+      codeSource: stubSource,
+      testSource: testSource,
+      testFailureOutput: testFailureOutput,
+      formalism,
+      maxIterations: 3,
+      callLlm,
+      onLog: log
+    });
+  }
+
+  const constraint = modelResult.invariant && modelResult.english
+    ? { invariant: modelResult.invariant, english: modelResult.english }
+    : null;
+
+  // ── Step 4: Loop 2 — Fix refinement ────────────────────────────────────────
+  log('Loop 2: refining fix...');
+  const fixResult = await refineFix({
+    buggySource: stubSource,
+    testSource: testSource,
+    testPath: testPath,
+    stubPath: stubPath,
+    testFailureOutput: testFailureOutput,
+    constraint,
+    spec: modelResult.spec,
+    bugExplanation: modelResult.bugExplanation,
+    maxIterations: 3,
+    callLlm,
+    onLog: log
   });
 
-  let formalContext = '';
-  try {
-    const ctxParsed = JSON.parse(ctxResult.stdout || '{}');
-    formalContext = ctxParsed.constraint_block || ctxParsed.context || '';
-  } catch (_) {
-    formalContext = ctxResult.stdout || '';
-  }
+  // ── Step 5: Report ──────────────────────────────────────────────────────────
+  const output = {
+    fixed: fixResult.converged,
+    exit_code: fixResult.converged ? 0 : 1,
+    elapsed_ms: Date.now() - startTime,
+    loop1: { converged: modelResult.converged, iterations: modelResult.iterations },
+    loop2: { converged: fixResult.converged, iterations: fixResult.iterations, gates: fixResult.gates },
+    formal: useFormal ? {
+      formalism,
+      constraint: constraint ? constraint.english : null,
+      invariant: constraint ? constraint.invariant : null,
+      bug_explanation: modelResult.bugExplanation
+    } : null
+  };
 
-  // Step 3: build prompt and call quorum
-  const prompt = [
-    'Fix the following buggy JavaScript function.',
-    'The test is failing with this output:',
-    testFailureOutput.slice(0, 500),
-    '',
-    'Buggy source (file: fn.cjs):',
-    '```js',
-    stubSource,
-    '```',
-    '',
-    formalContext ? ('Formal context:\n' + formalContext) : '',
-    '',
-    'Return ONLY the fixed source code in a ```js ... ``` code block. Do not explain.',
-  ].join('\n');
+  process.stdout.write(JSON.stringify(output) + '\n');
+  process.exit(output.fixed ? 0 : 1);
+}
 
-  const claudeCli = require('./resolve-cli.cjs').resolveCli('claude') || 'claude';
-  const quorumResult = spawnSync(claudeCli, ['-p', prompt, '--dangerously-skip-permissions', '--model', 'claude-haiku-4-5-20251001'], {
-    cwd: ROOT,
-    encoding: 'utf8',
-    maxBuffer: 4 * 1024 * 1024,
-    timeout: quorumTimeout
-  });
-
-  if (quorumResult.signal === 'SIGTERM' || (quorumResult.error && quorumResult.error.code === 'ETIMEDOUT')) {
-    const elapsed = Date.now() - startTime;
-    process.stderr.write('[nf-debug-runner] quorum call timed out after ' + elapsed + 'ms\n');
-    process.stdout.write(JSON.stringify({ fixed: false, error: 'timeout', elapsed_ms: elapsed }) + '\n');
-    process.exit(1);
-  }
-
-  if (quorumResult.status !== 0 || !quorumResult.stdout) {
-    process.stderr.write('[nf-debug-runner] quorum call failed\n');
-    process.stdout.write(JSON.stringify({ fixed: false, error: 'quorum_failed', elapsed_ms: Date.now() - startTime }) + '\n');
-    process.exit(1);
-  }
-
-  // Step 4: extract code block from response using robust regex
-  const response = quorumResult.stdout;
-  const codeMatch = response.match(/```(?:js|javascript)?\n?([\s\S]*?)\n?```/);
-  if (!codeMatch) {
-    process.stderr.write('[nf-debug-runner] no code block found in quorum response\n');
-    process.stdout.write(JSON.stringify({ fixed: false, error: 'no_code_block', elapsed_ms: Date.now() - startTime }) + '\n');
-    process.exit(1);
-  }
-
-  const fixedSource = codeMatch[1].trim();
-
-  // Step 5: validate JavaScript syntax before writing
-  try {
-    new Function(fixedSource);  // Quick syntax check
-  } catch (syntaxErr) {
-    process.stderr.write('[nf-debug-runner] extracted code has invalid syntax: ' + syntaxErr.message + '\n');
-    process.stdout.write(JSON.stringify({ fixed: false, error: 'invalid_syntax', elapsed_ms: Date.now() - startTime }) + '\n');
-    process.exit(1);
-  }
-
-  // Step 6: apply fix (overwrite stub) — guaranteed to restore on error
-  fs.writeFileSync(stubPath, fixedSource, 'utf8');
-
-  // Step 7: re-run test
-  testResult = spawnSync('node', [testPath], { ...spawnOpts, cwd: ROOT });
-  const fixed = testResult.status === 0;
-
-  process.stdout.write(JSON.stringify({ fixed, exit_code: testResult.status, elapsed_ms: Date.now() - startTime }) + '\n');
-  process.exit(fixed ? 0 : 1);
-} finally {
-  // Guarantee stub source restoration if runner crashed or timed out mid-execution
+main().catch(function(err) {
+  process.stderr.write('[nf-debug-runner] fatal: ' + err.message + '\n');
+  process.stdout.write(JSON.stringify({ fixed: false, error: 'fatal', message: err.message, elapsed_ms: Date.now() - startTime }) + '\n');
+  process.exit(1);
+}).finally(function() {
   if (originalStubSource !== null && fs.existsSync(stubPath)) {
     try {
-      // Only restore if we got partway through and the stub was modified
-      // (This is defensive; in normal operation the stub is correctly applied above)
-      const _currentSource = fs.readFileSync(stubPath, 'utf8');
-    } catch (_) {
-      // Ignore read errors in finally
-    }
+      const currentSource = fs.readFileSync(stubPath, 'utf8');
+      if (currentSource !== originalStubSource) {
+        fs.writeFileSync(stubPath, originalStubSource, 'utf8');
+        if (verbose) process.stderr.write('[nf-debug-runner] stub restored\n');
+      }
+    } catch (_) {}
   }
-}
+});

--- a/bin/refinement-loop.cjs
+++ b/bin/refinement-loop.cjs
@@ -4,6 +4,10 @@
 /**
  * refinement-loop.cjs
  *
+ * @deprecated Use formal-model-loop.cjs instead. This module is superseded by
+ * the convergent refinement loop with callLlm injection. Kept for backward
+ * compatibility only.
+ *
  * Bug context normalization and inverted verification loop for model refinement.
  * When --bug-context is provided, the model checker's semantics are inverted:
  * finding a violation means the model REPRODUCES the bug (success),

--- a/bin/solution-simulation-loop.cjs
+++ b/bin/solution-simulation-loop.cjs
@@ -3,6 +3,11 @@
 
 /**
  * Solution Simulation Loop Module
+ *
+ * @deprecated Use formal-fix-loop.cjs instead. This module uses callback-driven
+ * architecture (onTweakFix). The replacement uses callLlm injection for better
+ * testability and reuse. Kept for backward compatibility only.
+ *
  * Orchestrates the solution simulation pipeline: normalize fix intent, generate consequence models,
  * run convergence gates, and display iteration progress with automatic escalation.
  *

--- a/commands/nf/debug.md
+++ b/commands/nf/debug.md
@@ -76,36 +76,44 @@ Fail-open on checker errors.
 
 ### Step A.7: Refinement (Loop 1)
 
-Run autoresearch-refine to iteratively improve model. Skip if $FORMAL_VERDICT is "reproduced".
+Run formal-model-loop to iteratively generate and validate a formal spec that explains the bug. Skip if $FORMAL_VERDICT is "reproduced".
 This is a MODULE-ONLY API. The Agent subprocess require()s it directly:
 
 ```javascript
 const path = require('path');
+const fs = require('fs');
+const { spawnSync } = require('child_process');
 const nfBin = path.join(process.env.HOME, '.claude', 'nf-bin');
-const { refine } = require(path.join(nfBin, 'autoresearch-refine.cjs'));
+const { refineModel } = require(path.join(nfBin, 'formal-model-loop.cjs'));
 
-const result = await refine({
-  modelPath: '<path to model from A.5 or newly created>',
-  bugContext: '$ARGUMENTS',
-  formalism: FORMALISM || 'tla',
-  maxIterations: 10,
-  verbose: false,
-  onTweak: async (path, ctx) => {
-    // Agent reads ctx.checkerOutput + ctx.tsvHistory
-    // Agent reads ctx.consecutiveDiscards to detect stuck patterns
-    // Agent makes ONE targeted edit to the model file
-    // Returns one-sentence description, or null to skip
-    return 'description of change';
-  }
+// Build callLlm: spawns a subprocess LLM call
+const claudeBin = path.join(nfBin, 'resolve-cli.cjs');
+let claudePath;
+try { claudePath = require(claudeBin)(); } catch (_) { claudePath = 'claude'; }
+
+const callLlm = (prompt) => spawnSync(claudePath, [
+  '-p', prompt, '--model', 'claude-haiku-4-5-20251001', '--max-turns', '1'
+], { encoding: 'utf8', maxBuffer: 4 * 1024 * 1024, timeout: 120000 });
+
+// Read source code from the failing test area
+const codeSource = fs.readFileSync('<path to buggy source>', 'utf8');
+const testSource = fs.readFileSync('<path to test file>', 'utf8');
+
+const result = await refineModel({
+  codeSource,
+  testSource,
+  testFailureOutput: $TEST_OUTPUT || '',
+  formalism: FORMALISM || 'alloy',
+  maxIterations: 5,
+  callLlm,
+  onLog: (msg) => process.stderr.write(msg + '\n')
 });
 ```
 
-Key constraints to specify in the prompt:
-- No per-iteration git commits (in-memory rollback, TSV-as-memory)
-- Single final commit by Agent after refine() returns
-- If result.converged: set $REPRODUCING_MODEL=result.finalModel, $FORMAL_VERDICT="reproduced"
-- If not converged: set $REPRODUCING_MODEL=result.finalModel (best effort), $FORMAL_VERDICT="not_reproduced"
-- Store result.resultsLog as $TSV_LOG for artifact tracking
+Key constraints:
+- If result.converged: set $REPRODUCING_MODEL=result.spec, $FORMAL_VERDICT="reproduced"
+- If not converged: set $REPRODUCING_MODEL=result.spec (best effort), $FORMAL_VERDICT="not_reproduced"
+- Store result.english as $CONSTRAINT_ENGLISH, result.invariant as $CONSTRAINT_INVARIANT for A.8
 
 If no model exists to refine (no models from A.5 and no close-formal-gaps available), set $FORMAL_VERDICT="no-model" and proceed to A.8.
 

--- a/commands/nf/solve-remediate.md
+++ b/commands/nf/solve-remediate.md
@@ -304,11 +304,11 @@ Track a counter for B->F blind spot dispatches. For each covered_not_reproduced 
    ```
    The debug skill's discovery phase identifies relevant formal models and injects the failure description into spec refinement, biasing toward capturing the failure mode.
 
-   Note: /nf:debug uses autoresearch-refine.cjs for iterative
-   refinement (up to 10 iterations with in-memory rollback and TSV-as-memory logging).
-   The TSV results log is written alongside the model file. Single final commit by caller.
+   Note: /nf:debug uses formal-model-loop.cjs for iterative
+   refinement (convergent loop with callLlm injection, up to 5 iterations).
+   The loop generates and validates formal specs until the model explains the bug.
 
-4. Log: `"B->F: dispatching /nf:debug (autoresearch-refine, in-memory rollback) for blind spot {bug_id} ({N} models to refine)"`
+4. Log: `"B->F: dispatching /nf:debug (formal-model-loop, convergent refinement) for blind spot {bug_id} ({N} models to refine)"`
 
 If the counter reaches 100, log `"B->F: max blind spot dispatches (100) reached this cycle — {N} remaining blind spots deferred"`, append `{ "layer": "b_to_f", "dispatched": 100, "max": 100, "bucket": "blind_spots" }` to the `capped_layers` array, and skip remaining blind spot entries.
 

--- a/core/workflows/close-formal-gaps.md
+++ b/core/workflows/close-formal-gaps.md
@@ -78,8 +78,7 @@ If `--batch` is active, log the implicit FSM candidates but proceed without paus
 **Bug context parsing (MRF-01):**
 
 If `--bug-context` is provided:
-- Normalize the value: `BUG_CONTEXT=$(node bin/refinement-loop.cjs --normalize "$RAW_VALUE" 2>/dev/null)`
-  (Auto-detects file path vs inline text, trims whitespace, fails-open to empty string)
+- Normalize the value: if the value is a file path (starts with `./`, `../`, `/`, or ends in `.cjs`/`.js`/`.ts`), read its content. Otherwise trim whitespace. Store as `$BUG_CONTEXT`.
 - Store normalized text as `$BUG_CONTEXT`
 - Log: `Bug context loaded: {first 80 chars of $BUG_CONTEXT}...`
 
@@ -294,31 +293,54 @@ When `$BUG_CONTEXT` is non-empty (`--bug-context` was provided), use **inverted 
 - Model checker finds error (violation) = model **REPRODUCES** the bug = **SUCCESS**
 - Model checker passes (no errors) = model does **NOT** capture the failure = **RETRY**
 
-Run the refinement loop:
-```bash
-node bin/refinement-loop.cjs --model "$MODEL_PATH" --bug-context "$BUG_CONTEXT" --formalism "$FORMALISM" ${VERBOSE:+--verbose} --format json
+Run the refinement loop using `formal-model-loop.cjs`:
+
+```javascript
+const path = require('path');
+const fs = require('fs');
+const { spawnSync } = require('child_process');
+const nfBin = path.join(process.env.HOME, '.claude', 'nf-bin');
+const { refineModel } = require(path.join(nfBin, 'formal-model-loop.cjs'));
+
+let claudePath;
+try { claudePath = require(path.join(nfBin, 'resolve-cli.cjs'))(); } catch (_) { claudePath = 'claude'; }
+
+const callLlm = (prompt) => spawnSync(claudePath, [
+  '-p', prompt, '--model', 'claude-haiku-4-5-20251001', '--max-turns', '1'
+], { encoding: 'utf8', maxBuffer: 4 * 1024 * 1024, timeout: 120000 });
+
+const codeSource = fs.readFileSync('<source file for the requirement>', 'utf8');
+const testSource = ''; // test source if available
+
+const result = await refineModel({
+  codeSource,
+  testSource,
+  testFailureOutput: $BUG_CONTEXT,
+  formalism: '$FORMALISM',
+  maxIterations: 3,
+  callLlm,
+  onLog: (msg) => console.error(msg)
+});
 ```
 
-Parse the JSON output and route:
+Route on result:
 
-- **`status == "reproduced"`**: Log success, display iteration feedback:
-  `Attempt {N}: reproduced -- {summary}`
+- **`result.converged === true`**: Log success: `Model converged — reproduces bug in ${result.iterations} iteration(s)`.
   Continue to Step 7 (registry update).
 
-- **`status == "not_reproduced"` AND refinement retries remain (< 3 total attempts)**:
-  Display: `Attempt {N}: still passes -- {summary}, retry {N} of 2`
+- **`result.converged === false`** AND refinement retries remain (< 3 total attempts):
+  Display: `Attempt {N}: not converged, retry {N} of 2`
   Return to Step 5 to regenerate the model with refinement context. Append to the generation prompt:
-  `"Previous model passed all checks -- it did not capture the failure. Checker output: {iteration summary}. Refine the invariants to be more specific to the described failure mode."`
-  Then re-run Step 6 (up to 2 additional retries, 3 total attempts).
+  `"Previous model did not converge. Extracted invariant: ${result.invariant}. Bug explanation: ${result.bugExplanation}. Refine the invariants to be more specific to the described failure mode."`
+  Then re-run this step (up to 2 additional retries, 3 total attempts).
 
-- **`status == "not_reproduced"` AND all attempts exhausted (3 total)**:
+- **`result.converged === false`** AND all attempts exhausted (3 total):
   Display: `Model refinement exhausted (3 attempts). Model remains incomplete — does not capture the failure.`
   Continue to Step 7 with a note that model is unverified for bug reproduction.
 
 **Feedback display:**
-- If `$VERBOSE` is true: show full checker output for each iteration
+- If `$VERBOSE` is true: show full output for each iteration
 - Otherwise: show summary verdicts only (default per user decision)
-- Always include pointer to full checker output file in summary
 
 **When `$BUG_CONTEXT` is empty:** This entire section is skipped. Step 6 behaves identically to before (standard verification: no errors = success, errors = fix or report).
 </step>

--- a/core/workflows/execute-phase.md
+++ b/core/workflows/execute-phase.md
@@ -223,31 +223,33 @@ node ~/.claude/nf/bin/nf-tools.cjs activity-set \
           - If exit 0: log "Formal coverage verified: models OK"
           - If exit 1: log "WARNING: Formal model drift detected" (do NOT block commit -- fail-open)
        4. If formal-coverage-intersect.cjs is not found or errors: skip silently (fail-open)
-       5. **Loop 2 simulation gate (GATE-02, GATE-03, GATE-04):** If step 2 found intersections (exit code 0):
-          a. Run Loop 2 via `simulateSolutionLoop` from `$HOME/.claude/nf-bin/solution-simulation-loop.cjs` with:
-             - `fixIdea`: description of code changes in current diff
-             - `bugDescription`: "Formal model coverage check for plan execution"
-             - `maxIterations`: 10, `formalism`: 'tla'
-             - `onTweakFix` callback (GATE-05): reads `iterationContext.verdict` to identify which gates failed (`gate1_invariants`, `gate2_bug_resolved`, `gate3_neighbors`). Returns `null` if all gates pass or if `iterationContext.stuck_reason` is set. Otherwise returns a refinement string: `"Iteration N: Gates failing: [list]. Previous fix idea: ... Refine the approach to address the failing gate(s). Make ONE targeted edit."`.
-             Store the result object with fields: `converged`, `iterations`, `escalationReason`, `bestGatesPassing`, `tsvPath`.
-          b. Route on result:
-             - **converged === true:** Log `"Loop 2: CONVERGED (${result.iterations.length} iterations)"`. Continue to commit.
-             - **converged === false (fail-open, default):** Log `"WARNING: Loop 2 did not converge — ${result.iterations.length} iterations. Proceeding (fail-open)."`. Continue to commit.
-             - **converged === false AND plan frontmatter contains `strict_simulation: true` (fail-closed):** Log `"BLOCKED: Loop 2 failed to converge. Fix required before commit."`. Do NOT commit.
-          c. **Non-convergence reporting (fail-open path only):** When Loop 2 did not converge and the commit proceeds:
-             - Log the TSV trace path: `"Loop 2 trace: ${result.tsvPath}"`
-             - Include in SUMMARY.md under "## Issues Encountered":
-               ```
-               ### Loop 2 Simulation Warning
-               - **Status:** Non-converged (fail-open)
-               - **Iterations:** ${result.iterations.length}
-               - **Best gates passing:** ${result.bestGatesPassing}/3
-               - **Reason:** ${result.escalationReason || 'Max iterations reached'}
-               - **TSV trace:** ${result.tsvPath}
-               ```
-          d. **Non-convergence reporting (fail-closed path):** Include TSV trace in BLOCKED message: `"TSV trace at ${result.tsvPath} shows iteration history"`
-          e. If solution-simulation-loop.cjs is not found or throws: skip silently (fail-open)
-       6. If step 2 found NO intersections: skip Loop 2 entirely (GATE-03) — silent, no log
+        5. **Loop 2 simulation gate (GATE-02, GATE-03, GATE-04):** If step 2 found intersections (exit code 0):
+           a. Run Loop 2 via `refineFix` from `$HOME/.claude/nf-bin/formal-fix-loop.cjs` with:
+              - `buggySource`: content of the file being changed in current diff
+              - `testSource`: content of the associated test file
+              - `testPath`: absolute path to the test file
+              - `stubPath`: absolute path to the file being changed
+              - `testFailureOutput`: output from running the test before fix
+              - `constraint`: `{ invariant: '<from formal model>', english: '<human-readable>' }` (from formal-coverage-intersect results)
+              - `maxIterations`: 10
+              - `callLlm`: function that spawns LLM subprocess via `require(path.join(process.env.HOME, '.claude', 'nf-bin', 'resolve-cli.cjs'))()` + `spawnSync(claudePath, ['-p', prompt, '--model', 'claude-haiku-4-5-20251001', '--max-turns', '1'], { encoding: 'utf8', maxBuffer: 4*1024*1024, timeout: 120000 })`
+              Store result with fields: `converged`, `iterations`, `fixedSource`, `gates`, `rejectionReasons`.
+           b. Route on result:
+              - **converged === true:** Log `"Loop 2: CONVERGED (${result.iterations} iterations)"`. Continue to commit.
+              - **converged === false (fail-open, default):** Log `"WARNING: Loop 2 did not converge — ${result.iterations} iterations. Proceeding (fail-open)."`. Continue to commit.
+              - **converged === false AND plan frontmatter contains `strict_simulation: true` (fail-closed):** Log `"BLOCKED: Loop 2 failed to converge. Fix required before commit."`. Do NOT commit.
+           c. **Non-convergence reporting (fail-open path only):** When Loop 2 did not converge and the commit proceeds:
+              - Include in SUMMARY.md under "## Issues Encountered":
+                ```
+                ### Loop 2 Simulation Warning
+                - **Status:** Non-converged (fail-open)
+                - **Iterations:** ${result.iterations}
+                - **Gates passed:** ${Object.entries(result.gates).filter(([k,v]) => v).map(([k]) => k).join(', ') || 'none'}
+                - **Reason:** ${result.rejectionReasons.slice(-1)[0] || 'Max iterations reached'}
+                ```
+           d. **Non-convergence reporting (fail-closed path):** Include rejection reasons in BLOCKED message: `"Loop 2 blocked: ${result.rejectionReasons.slice(-1)[0]}"`
+           e. If formal-fix-loop.cjs is not found or throws: skip silently (fail-open)
+        6. If step 2 found NO intersections: skip Loop 2 entirely (GATE-03) — silent, no log
        </formal_coverage_auto_detection>
 
        ${DEBUG_CONSTRAINTS || DEBUG_FORMAL_VERDICT || DEBUG_REPRODUCING_MODEL ?

--- a/core/workflows/execute-plan.md
+++ b/core/workflows/execute-plan.md
@@ -132,24 +132,28 @@ Task(
     <formal_coverage_auto_detection>
     **Formal coverage auto-detection (hybrid A+B):** Before each atomic commit:
     1. Get changed files: CHANGED=$(git diff --name-only HEAD 2>/dev/null | tr '\n' ',')
-    2. If CHANGED is non-empty, run: node bin/formal-coverage-intersect.cjs --files \"$CHANGED\" 2>/dev/null
+    2. If CHANGED is non-empty, run: node bin/formal-coverage-intersect.cjs --files "$CHANGED" 2>/dev/null
     3. If exit code is 0 (intersections found) OR the plan declares `formal_artifacts: update`:
        - Run: node bin/run-formal-verify.cjs 2>&1
        - If exit 0: log 'Formal coverage verified: models OK'
        - If exit 1: log 'WARNING: Formal model drift detected' (do NOT block commit -- fail-open)
     4. If formal-coverage-intersect.cjs is not found or errors: skip silently (fail-open)
     5. **Loop 2 simulation gate (GATE-02, GATE-03, GATE-04):** If step 2 found intersections (exit code 0):
-       a. Run Loop 2 via `simulateSolutionLoop` from `$HOME/.claude/nf-bin/solution-simulation-loop.cjs` with:
-          - `fixIdea`: description of code changes in current diff
-          - `bugDescription`: plan objective or task description
-          - `maxIterations`: 10, `formalism`: 'tla'
-          - `onTweakFix` callback (GATE-05): reads `iterationContext.verdict` to identify failing gates. Returns `null` if all pass or stuck. Otherwise returns refinement string.
-          Store result with fields: `converged`, `iterations`, `escalationReason`, `bestGatesPassing`, `tsvPath`.
+       a. Run Loop 2 via `refineFix` from `$HOME/.claude/nf-bin/formal-fix-loop.cjs` with:
+          - `buggySource`: content of the file being changed
+          - `testSource`: content of associated test file
+          - `testPath`: absolute path to test file
+          - `stubPath`: absolute path to file being changed
+          - `testFailureOutput`: test runner output before fix
+          - `constraint`: `{ invariant: '<from formal model>', english: '<human-readable>' }`
+          - `maxIterations`: 10
+          - `callLlm`: spawns LLM subprocess via resolve-cli.cjs + spawnSync
+          Store result with fields: `converged`, `iterations`, `fixedSource`, `gates`, `rejectionReasons`.
        b. Route on result:
           - **converged === true:** Log 'Loop 2: CONVERGED'. Continue to commit.
           - **converged === false (fail-open, default):** Log 'WARNING: Loop 2 did not converge'. Continue to commit.
           - **converged === false AND plan frontmatter `strict_simulation: true`:** Log 'BLOCKED'. Do NOT commit.
-       c. If solution-simulation-loop.cjs is not found or throws: skip silently (fail-open)
+       c. If formal-fix-loop.cjs is not found or throws: skip silently (fail-open)
     6. If step 2 found NO intersections: skip Loop 2 entirely — silent, no log
     </formal_coverage_auto_detection>
 

--- a/core/workflows/quick.md
+++ b/core/workflows/quick.md
@@ -1081,50 +1081,63 @@ When you encounter these tools in the constraints below, log "WARNING: [tool] no
      - If exit 1: log "WARNING: Formal model drift detected" (do NOT block commit -- fail-open)
   4. If formal-coverage-intersect.cjs is not found or errors: log "WARNING: formal-coverage-intersect.cjs not found -- skipping formal coverage check (fail-open)" and continue without blocking
 - **Loop 2 pre-commit simulation gate (GATE-01, GATE-03, GATE-04):** After formal coverage auto-detection passes (step 3 above), if formal models were found in scope (exit code 0 from formal-coverage-intersect.cjs):
-  1. Determine if `--strict` flag was passed to the quick task (from `$STRICT_MODE` variable, default false)
-  2. Run Loop 2 simulation via node heredoc (executor-delegated):
-     ```bash
-     node << 'NF_LOOP2'
-     const ssl = JSON.parse(process.env.HOME + '/.claude/nf-bin/solution-simulation-loop.cjs');
-     // Executor calls simulateSolutionLoop with these parameters:
-     // fixIdea: "Code changes in current diff for task ${task_number}"
-     // bugDescription: "${DESCRIPTION}"
-     // maxIterations: 10, formalism: 'tla'
-     // onTweakFix: callback that reads iterationContext.verdict,
-     //   identifies failing gates (invariants, bug_resolved, neighbors),
-     //   returns null if all pass or stuck, else returns refinement string
-     NF_LOOP2
-     ```
-     The executor MUST call `simulateSolutionLoop` from `$HOME/.claude/nf-bin/solution-simulation-loop.cjs` with:
-     - `fixIdea`: description of code changes in current diff
-     - `bugDescription`: the task description (`${DESCRIPTION}`)
-     - `maxIterations`: 10
-     - `formalism`: 'tla'
-     - `onTweakFix` callback (GATE-05): reads `iterationContext.verdict` to identify which gates failed (`gate1_invariants`, `gate2_bug_resolved`, `gate3_neighbors`). Returns `null` if all gates pass or if `iterationContext.stuck_reason` is set. Otherwise returns a refinement string: `"Iteration N: Gates failing: [list]. Previous fix idea: ... Refine the approach to address the failing gate(s). Make ONE targeted edit."`.
-     Store the result object with fields: `converged`, `iterations`, `escalationReason`, `bestGatesPassing`, `tsvPath`.
-  3. Route on result:
-     - **converged === true:** Log `"Loop 2 simulation: CONVERGED after ${result.iterations.length} iteration(s)"`. Proceed to commit.
-     - **converged === false AND NOT $STRICT_MODE (fail-open, default):** Log `"WARNING: Loop 2 simulation did not converge — ${result.iterations.length} iterations, ${result.escalationReason || 'max iterations reached'}. Proceeding (fail-open)."`. Proceed to commit anyway.
-     - **converged === false AND $STRICT_MODE (fail-closed):** Log `"BLOCKED: Loop 2 simulation failed to converge after ${result.iterations.length} iterations. Fix required before commit."`. Do NOT commit. Report failure to orchestrator with TSV trace path: `${result.tsvPath}`.
-  4. **Non-convergence reporting (fail-open path only):** When Loop 2 did not converge and the commit proceeds:
-     - Log the TSV trace path: `"Loop 2 trace: ${result.tsvPath}"`
-     - When creating SUMMARY.md, include under "## Issues Encountered":
-       ```
-       ### Loop 2 Simulation Warning
-       - **Status:** Non-converged (fail-open)
-       - **Iterations:** ${result.iterations.length}
-       - **Best gates passing:** ${result.bestGatesPassing}/3
-       - **Reason:** ${result.escalationReason || 'Max iterations reached'}
-       - **TSV trace:** ${result.tsvPath}
-       ```
-  5. **Non-convergence reporting (fail-closed path):** When --strict blocks the commit, include TSV trace in BLOCKED message: `"TSV trace at ${result.tsvPath} shows iteration history"`
-  7. **Loop 2 SUMMARY.md reporting (--full mode, MANDATORY):** When `$FULL_MODE` is true, Loop 2 results MUST always be recorded in SUMMARY.md regardless of outcome:
-     - **Converged:** Under "## Formal Modeling", add: `### Loop 2 Simulation\n- **Status:** Converged\n- **Iterations:** ${result.iterations.length}\n- **TSV trace:** ${result.tsvPath}`
-     - **Non-converged (fail-open):** Use the existing "## Issues Encountered" format (item 4 above).
-     - **Skipped (tool unavailable):** Under "## Formal Modeling", add: `### Loop 2 Simulation\n- **Status:** Skipped (tool unavailable)\n- **Reason:** solution-simulation-loop.cjs not found`
-     - **Not applicable (no intersections):** Under "## Formal Modeling", add: `### Loop 2 Simulation\n- **Status:** Not applicable (no formal coverage intersections)`
-     This ensures the Step 6.1 audit gate can reliably grep SUMMARY.md for Loop 2 evidence.
-  6. If solution-simulation-loop.cjs is not found, module loading fails, or simulateSolutionLoop throws: log "WARNING: solution-simulation-loop.cjs not found or errored -- skipping Loop 2 simulation (fail-open)". Do NOT skip silently.
+   1. Determine if `--strict` flag was passed to the quick task (from `$STRICT_MODE` variable, default false)
+   2. Run Loop 2 via `refineFix` from `$HOME/.claude/nf-bin/formal-fix-loop.cjs`:
+      ```javascript
+      const path = require('path');
+      const fs = require('fs');
+      const { spawnSync } = require('child_process');
+      const nfBin = path.join(process.env.HOME, '.claude', 'nf-bin');
+      const { refineFix } = require(path.join(nfBin, 'formal-fix-loop.cjs'));
+
+      let claudePath;
+      try { claudePath = require(path.join(nfBin, 'resolve-cli.cjs'))(); } catch (_) { claudePath = 'claude'; }
+
+      const callLlm = (prompt) => spawnSync(claudePath, [
+        '-p', prompt, '--model', 'claude-haiku-4-5-20251001', '--max-turns', '1'
+      ], { encoding: 'utf8', maxBuffer: 4 * 1024 * 1024, timeout: 120000 });
+
+      // Read the files being modified in this commit
+      const buggySource = fs.readFileSync('<file being fixed>', 'utf8');
+      const testSource = fs.readFileSync('<test file>', 'utf8');
+      const testFailureOutput = 'Output from running the test before fix';
+
+      const result = await refineFix({
+        buggySource,
+        testSource,
+        testPath: '<absolute path to test file>',
+        stubPath: '<absolute path to file being fixed>',
+        testFailureOutput,
+        constraint: { invariant: '<from formal model>', english: '<human-readable constraint>' },
+        spec: '<formal spec from formal-model-loop, if available>',
+        bugExplanation: '${DESCRIPTION}',
+        maxIterations: 10,
+        callLlm,
+        onLog: (msg) => process.stderr.write(msg + '\n')
+      });
+      ```
+      Store the result object with fields: `converged`, `iterations`, `fixedSource`, `gates`, `rejectionReasons`.
+   3. Route on result:
+      - **converged === true:** Log `"Loop 2 simulation: CONVERGED after ${result.iterations} iteration(s)"`. Proceed to commit.
+      - **converged === false AND NOT $STRICT_MODE (fail-open, default):** Log `"WARNING: Loop 2 simulation did not converge — ${result.iterations} iterations. Proceeding (fail-open)."`. Proceed to commit anyway.
+      - **converged === false AND $STRICT_MODE (fail-closed):** Log `"BLOCKED: Loop 2 simulation failed to converge after ${result.iterations} iterations. Fix required before commit."`. Do NOT commit. Report failure to orchestrator.
+   4. **Non-convergence reporting (fail-open path only):** When Loop 2 did not converge and the commit proceeds:
+      - When creating SUMMARY.md, include under "## Issues Encountered":
+        ```
+        ### Loop 2 Simulation Warning
+        - **Status:** Non-converged (fail-open)
+        - **Iterations:** ${result.iterations}
+        - **Gates passed:** ${Object.entries(result.gates).filter(([k,v]) => v).map(([k]) => k).join(', ') || 'none'}
+        - **Rejection reasons:** ${result.rejectionReasons.slice(-1)[0] || 'max iterations reached'}
+        ```
+   5. **Non-convergence reporting (fail-closed path):** When --strict blocks the commit, include rejection reasons in BLOCKED message: `"Loop 2 blocked: ${result.rejectionReasons.slice(-1)[0]}"`
+   7. **Loop 2 SUMMARY.md reporting (--full mode, MANDATORY):** When `$FULL_MODE` is true, Loop 2 results MUST always be recorded in SUMMARY.md regardless of outcome:
+      - **Converged:** Under "## Formal Modeling", add: `### Loop 2 Simulation\n- **Status:** Converged\n- **Iterations:** ${result.iterations}\n- **Gates:** ${JSON.stringify(result.gates)}`
+      - **Non-converged (fail-open):** Use the existing "## Issues Encountered" format (item 4 above).
+      - **Skipped (tool unavailable):** Under "## Formal Modeling", add: `### Loop 2 Simulation\n- **Status:** Skipped (tool unavailable)\n- **Reason:** formal-fix-loop.cjs not found`
+      - **Not applicable (no intersections):** Under "## Formal Modeling", add: `### Loop 2 Simulation\n- **Status:** Not applicable (no formal coverage intersections)`
+      This ensures the Step 6.1 audit gate can reliably grep SUMMARY.md for Loop 2 evidence.
+   6. If formal-fix-loop.cjs is not found, module loading fails, or refineFix throws: log "WARNING: formal-fix-loop.cjs not found or errored -- skipping Loop 2 simulation (fail-open)". Do NOT skip silently.
 - If formal-coverage-intersect.cjs found NO intersections (exit code non-zero): skip Loop 2 entirely — log "INFO: No formal coverage intersections found -- Loop 2 not needed (GATE-03)." If the tool was not found, log "WARNING: formal-coverage-intersect.cjs not found -- skipping Loop 2 (fail-open, GATE-03)."
 - If the plan declares `formal_artifacts: update` or `formal_artifacts: create`, execute those formal file changes and include the .planning/formal/ files in the atomic commit for that task (alongside the implementation files)
 - Formal/ files must never be committed separately — always include in the task's atomic commit
@@ -1218,7 +1231,7 @@ SUMMARY_CONTENT=$(cat "${QUICK_DIR}/${next_num}-SUMMARY.md" 2>/dev/null)
 
 # Check for formal step execution evidence
 FORMAL_COVERAGE_RAN=$(echo "$SUMMARY_CONTENT" | grep -c "formal-coverage-intersect\|Formal coverage verified\|formal coverage")
-LOOP2_RAN=$(echo "$SUMMARY_CONTENT" | grep -c "Loop 2\|solution-simulation-loop\|CONVERGED\|Non-converged\|Skipped (tool unavailable)\|Not applicable")
+LOOP2_RAN=$(echo "$SUMMARY_CONTENT" | grep -c "Loop 2\|formal-fix-loop\|CONVERGED\|Non-converged\|Skipped (tool unavailable)\|Not applicable")
 
 if [ "$FORMAL_COVERAGE_RAN" -eq 0 ] && [ ${#FORMAL_TOOLS_MISSING[@]} -eq 0 ]; then
   echo ":: AUDIT WARNING: Formal coverage auto-detection appears to have been skipped despite tools being available."

--- a/docs/dev/requirements-coverage.md
+++ b/docs/dev/requirements-coverage.md
@@ -2018,7 +2018,7 @@
 
 **Requirement:** solve-remediate b_to_f layer dispatches through /nf:debug (not deprecated /nf:model-driven-fix)
 
-**Implementation:** The `commands/nf/solve-remediate.md` skill file routes `b_to_f` layer remediation through `/nf:debug` for covered-not-reproduced blind spots (using autoresearch-refine.cjs for iterative refinement) and through `/nf:close-formal-gaps` for not-covered gaps. The deprecated `/nf:model-driven-fix` skill is no longer referenced in any remediation dispatch path.
+**Implementation:** The `commands/nf/solve-remediate.md` skill file routes `b_to_f` layer remediation through `/nf:debug` for covered-not-reproduced blind spots (using formal-model-loop.cjs for iterative refinement) and through `/nf:close-formal-gaps` for not-covered gaps. The deprecated `/nf:model-driven-fix` skill is no longer referenced in any remediation dispatch path.
 
 **Source files:** commands/nf/solve-remediate.md, commands/nf/model-driven-fix.md
 


### PR DESCRIPTION
## Summary
- Creates two shared convergent loop modules (`formal-model-loop.cjs` for spec generation, `formal-fix-loop.cjs` for 3-gate fix validation) with `callLlm` injection API
- Migrates all 5 active workflow consumers from old callback-driven modules (`autoresearch-refine.cjs`, `solution-simulation-loop.cjs`, `refinement-loop.cjs`) to the new shared modules
- Adds `@deprecated` JSDoc notices to 4 old modules (kept for backward compat, not deleted)

## Files changed
- **New:** `bin/formal-model-loop.cjs` (Loop 1: refineModel), `bin/formal-fix-loop.cjs` (Loop 2: refineFix)
- **Migrated:** `commands/nf/debug.md`, `core/workflows/quick.md`, `core/workflows/execute-phase.md`, `core/workflows/execute-plan.md`, `core/workflows/close-formal-gaps.md`, `commands/nf/solve-remediate.md`
- **Deprecated:** `bin/autoresearch-refine.cjs`, `bin/solution-simulation-loop.cjs`, `bin/refinement-loop.cjs`, `bin/bench-formal-spec.cjs`
- **Updated:** `bin/nf-debug-runner.cjs` (benchmark runner, already consumed shared loops), `bin/nf-benchmark-debug.cjs` (--tier flag)

## Test plan
- [x] `npm run lint:isolation` passes
- [x] Benchmark runner scored 100% (5/5 stubs) with these shared loops before migration
- [ ] CI gates pass (lockfile sync, CHANGELOG, asset staleness, lint, tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Formal specification generation for bug analysis supporting Alloy and TLA+ formats
  * Iterative fix refinement with multi-gate validation
  * Added `--tier` CLI option for debug benchmark filtering

* **Improvements**
  * Enhanced debug runner with integrated formal model and fix refinement capabilities
  * Streamlined formal gap closure workflow

* **Deprecations**
  * Legacy refinement modules deprecated in favor of formal model and fix loop architecture

* **Documentation**
  * Updated workflow and reference documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->