### PR TITLE
fix(security): add gitleaks guard to pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,13 @@
-gitleaks protect --staged --config .gitleaks.toml --redact --verbose
+#!/bin/sh
+
+if ! command -v gitleaks >/dev/null 2>&1; then
+  echo "gitleaks is not installed. Install it before committing."
+  echo "  macOS:  brew install gitleaks"
+  echo "  Linux:  https://github.com/gitleaks/gitleaks#install"
+  exit 1
+fi
+
+if ! gitleaks protect --staged --config .gitleaks.toml --redact --verbose; then
+  echo "Secrets detected! Commit blocked."
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Adds a `command -v gitleaks` guard to `.husky/pre-commit` so developers get a clear install hint instead of a cryptic error when gitleaks isn't installed
- Adds a "Secrets detected! Commit blocked." message on scan failure

Inspired by [Digital-Frontier-LDA/standard-CI](https://github.com/Digital-Frontier-LDA/standard-CI) template.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved pre-commit hook with enhanced validation for required tools and more reliable secret detection during commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->