### PR TITLE
ci: add Socket.dev supply-chain security and harden .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,15 @@ node_modules/
 .vscode/
 TO-DOS.md
 
+*.pem
+*.key
+*.p12
+*.pfx
+*.jks
+certs/
+secrets/
+.sentryclirc
+
 /research.claude/
 commands.html
 

--- a/socket.yml
+++ b/socket.yml
@@ -1,0 +1,21 @@
+version: 2
+
+projectIgnorePaths:
+  - "node_modules/**"
+  - ".next/**"
+  - "dist/**"
+  - "build/**"
+  - ".planning/**"
+
+issueRules:
+  malware: true
+  typosquat: true
+  native-code: true
+  telemetry: true
+  install-scripts: false
+
+githubApp:
+  enabled: true
+  pullRequestAlertsEnabled: true
+  dependencyOverviewEnabled: true
+  projectReportsEnabled: true


### PR DESCRIPTION
## Summary
- Add `socket.yml` config for Socket.dev supply-chain protection (malware, typosquat, native-code, telemetry detection on PRs)
- Add secret-related exclusions to `.gitignore` (`*.pem`, `*.key`, `*.p12`, `*.pfx`, `*.jks`, `certs/`, `secrets/`, `.sentryclirc`)

Inspired by [standard-CI](https://github.com/Digital-Frontier-LDA/standard-CI) best practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security by updating configuration to exclude credential and certificate files from being committed.
  * Added Socket dependency scanning configuration to enable automated security checks and GitHub pull request alerts for dependency issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->