### PR TITLE
fix(debug): improve Loop 2 fix generation prompt and iteration budget

### DIFF
--- a/bin/formal-fix-loop.cjs
+++ b/bin/formal-fix-loop.cjs
@@ -74,7 +74,7 @@ function buildFixPrompt(buggySource, testFailureOutput, constraint, spec, bugExp
     '```',
     '',
     '## TEST FAILURE OUTPUT',
-    testFailureOutput.slice(0, 500)
+    String(testFailureOutput || '').slice(0, 500)
   );
 
   // Spec last — reference material, not the primary signal

--- a/bin/formal-fix-loop.cjs
+++ b/bin/formal-fix-loop.cjs
@@ -33,55 +33,65 @@ const { spawnSync } = require('child_process');
 const fs = require('fs');
 
 function buildFixPrompt(buggySource, testFailureOutput, constraint, spec, bugExplanation, rejectionReason) {
-  const constraintBlock = constraint && constraint.english ? [
-    '',
-    '[FORMAL CONSTRAINT — HARD REQUIREMENT]',
-    'The following invariant was derived from formal analysis:',
-    constraint.english,
-    constraint.invariant ? ('Formal: ' + constraint.invariant) : '',
-    '',
-    'Your fix MUST satisfy this constraint. Fixes that violate it will be REJECTED.',
-    '[END FORMAL CONSTRAINT]',
-  ].join('\n') : '';
+  const parts = ['Fix the following buggy JavaScript function.'];
 
-  const specBlock = spec ? [
-    '',
-    '[FORMAL SPECIFICATION]',
-    spec,
-    '[END SPECIFICATION]',
-  ].join('\n') : '';
+  // Bug explanation front-and-center so the LLM understands the root cause first
+  if (bugExplanation) {
+    parts.push(
+      '',
+      '## ROOT CAUSE',
+      bugExplanation
+    );
+  }
 
-  const bugBlock = bugExplanation ? [
-    '',
-    '[BUG ANALYSIS]',
-    bugExplanation,
-    '[END BUG ANALYSIS]',
-  ].join('\n') : '';
+  // Formal constraint immediately after root cause — hard requirement
+  if (constraint && constraint.english) {
+    parts.push(
+      '',
+      '## FORMAL CONSTRAINT (HARD REQUIREMENT)',
+      'Your code MUST satisfy: ' + constraint.english,
+      constraint.invariant ? ('Formal expression: ' + constraint.invariant) : '',
+      'The buggy code violates this constraint. Any fix that violates it will be REJECTED.'
+    );
+  }
 
-  const rejectionBlock = rejectionReason ? [
-    '',
-    '[PREVIOUS FIX REJECTED]',
-    rejectionReason,
-    'Address this rejection in your new fix. Do NOT repeat the same mistake.',
-    '[END REJECTION]',
-  ].join('\n') : '';
+  // Rejection feedback from previous iteration
+  if (rejectionReason) {
+    parts.push(
+      '',
+      '## PREVIOUS FIX REJECTED',
+      rejectionReason,
+      'Address this rejection in your new fix. Do NOT repeat the same mistake.'
+    );
+  }
 
-  return [
-    'Fix the following buggy JavaScript function.',
-    'The test is failing with this output:',
-    testFailureOutput.slice(0, 500),
+  // Buggy source and test failure
+  parts.push(
     '',
-    'Buggy source (file: fn.cjs):',
+    '## BUGGY SOURCE (file: fn.cjs)',
     '```js',
     buggySource,
     '```',
-    constraintBlock,
-    specBlock,
-    bugBlock,
-    rejectionBlock,
     '',
-    'Return ONLY the fixed source code in a ```js ... ``` code block. Do not explain.',
-  ].join('\n');
+    '## TEST FAILURE OUTPUT',
+    testFailureOutput.slice(0, 500)
+  );
+
+  // Spec last — reference material, not the primary signal
+  if (spec) {
+    parts.push(
+      '',
+      '## FORMAL SPECIFICATION',
+      spec
+    );
+  }
+
+  parts.push(
+    '',
+    'Return ONLY the fixed source code in a ```js ... ``` code block. Do not explain.'
+  );
+
+  return parts.join('\n');
 }
 
 function buildInvariantValidationPrompt(fixedSource, constraint) {

--- a/bin/nf-debug-runner.cjs
+++ b/bin/nf-debug-runner.cjs
@@ -101,7 +101,9 @@ async function main() {
     : null;
 
   // ── Step 4: Loop 2 — Fix refinement ────────────────────────────────────────
-  log('Loop 2: refining fix...');
+  // Grant extra iterations when L1 converged with high confidence (1 iteration)
+  const l2MaxIterations = (modelResult.converged && modelResult.iterations === 1) ? 5 : 3;
+  log('Loop 2: refining fix (maxIterations=' + l2MaxIterations + ')...');
   const fixResult = await refineFix({
     buggySource: stubSource,
     testSource: testSource,
@@ -111,7 +113,7 @@ async function main() {
     constraint,
     spec: modelResult.spec,
     bugExplanation: modelResult.bugExplanation,
-    maxIterations: 3,
+    maxIterations: l2MaxIterations,
     callLlm,
     onLog: log
   });


### PR DESCRIPTION
## Summary
- Restructure `buildFixPrompt()` to place root cause analysis and formal constraint front-and-center in the fix prompt, demoting spec to reference material
- Increase Loop 2 `maxIterations` from 3 to 5 when L1 converged with high confidence (1 iteration)
- Stronger constraint wording: "Your code MUST satisfy: {invariant}. The buggy code violates this constraint."

Closes #124

## Test plan
- [x] Module loads without errors
- [x] Full test suite passes (1541/1541)
- [ ] Re-run nf:debug benchmark on 100 stubs to measure L2 convergence improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Reorganized automated fix prompt to present root cause, constraints, prior rejection feedback, buggy source, and test output more clearly for more consistent fix suggestions.
  * Smarter debug run behavior: loop refinement now adapts its iteration budget based on previous convergence results, improving debugging efficiency and success rates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->