### PR TITLE
feat(statusline): show quorum-slot responsiveness

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -63,6 +63,7 @@ try {
     'nf-statusline': 10,
     'nf-token-collector': 10,
     'nf-slot-correlator': 10,
+    'nf-slot-health-probe': 10,
   };
 }
 
@@ -1544,9 +1545,7 @@ function uninstall(isGlobal, runtime = 'claude') {
               h.command.includes('nf-check-update') ||
               h.command.includes('nf-statusline') ||
               h.command.includes('nf-session-start') ||
-              h.command.includes('nf-check-update') ||
-              h.command.includes('nf-statusline') ||
-              h.command.includes('nf-session-start')
+              h.command.includes('nf-slot-health-probe')
             )
           );
           return !hasNfHook;
@@ -2772,6 +2771,25 @@ function install(isGlobal, runtime = 'claude') {
         ]
       });
       log(`  ${green}✓${reset} Configured nForma secret sync hook (SessionStart)`);
+    }
+
+    // Register nForma slot-health probe (populates ~/.claude/nf/slot-health.json
+    // for the statusline's quorum slots line). Probe runs in parallel and finishes
+    // in ~400ms for a typical 5-7 slot setup; capped at 15s.
+    const hasSlotHealthProbeHook = settings.hooks.SessionStart.some(entry =>
+      entry.hooks && entry.hooks.some(h => h.command && h.command.includes('nf-slot-health-probe'))
+    );
+    if (!hasSlotHealthProbeHook) {
+      settings.hooks.SessionStart.push({
+        hooks: [
+          {
+            type: 'command',
+            command: buildHookCommand(targetDir, 'nf-slot-health-probe.js'),
+            timeout: 15
+          }
+        ]
+      });
+      log(`  ${green}✓${reset} Configured nForma slot-health probe (SessionStart)`);
     }
 
     // INST-05: Warn (yellow) if quorum MCP servers are absent — runs every install

--- a/hooks/config-loader.js
+++ b/hooks/config-loader.js
@@ -54,6 +54,7 @@ const HOOK_PROFILE_MAP = {
     'nf-token-collector',
     'nf-slot-correlator',
     'nf-session-start',
+    'nf-slot-health-probe',
     'nf-statusline',
     'nf-post-edit-format',
     'nf-console-guard',
@@ -73,6 +74,7 @@ const HOOK_PROFILE_MAP = {
     'nf-token-collector',
     'nf-slot-correlator',
     'nf-session-start',
+    'nf-slot-health-probe',
     'nf-statusline',
     'nf-post-edit-format',
     'nf-console-guard',
@@ -103,6 +105,7 @@ const DEFAULT_HOOK_PRIORITIES = {
   'nf-statusline':        10,  // Low — status display
   'nf-token-collector':   10,  // Low — token tracking
   'nf-slot-correlator':   10,  // Low — slot correlation
+  'nf-slot-health-probe': 10,  // Low — quorum slot responsiveness probe (SessionStart)
   'nf-destructive-git-guard': 50,  // Normal — destructive ops advisory
   'nf-scope-guard': 50,             // Normal — scope advisory (warn-only)
   'nf-mcp-dispatch-guard': 50,    // Normal — MCP dispatch advisory

--- a/hooks/config-loader.test.js
+++ b/hooks/config-loader.test.js
@@ -631,14 +631,14 @@ test('HPM-TC2: minimal profile has exactly 4 hooks', async (t) => {
   assert.equal(HOOK_PROFILE_MAP.minimal.size, 4, 'minimal must have 4 hooks');
 });
 
-// HPM-TC3: standard has 17 entries
-test('HPM-TC3: standard profile has 17 hooks', async (t) => {
-  assert.equal(HOOK_PROFILE_MAP.standard.size, 17, 'standard must have 17 hooks');
+// HPM-TC3: standard has 18 entries (added nf-slot-health-probe for quorum slot statusline)
+test('HPM-TC3: standard profile has 18 hooks', async (t) => {
+  assert.equal(HOOK_PROFILE_MAP.standard.size, 18, 'standard must have 18 hooks');
 });
 
-// HPM-TC4: strict has 17 entries (same as standard)
-test('HPM-TC4: strict profile has 17 hooks (same as standard)', async (t) => {
-  assert.equal(HOOK_PROFILE_MAP.strict.size, 17, 'strict must have 17 hooks');
+// HPM-TC4: strict has 18 entries (same as standard)
+test('HPM-TC4: strict profile has 18 hooks (same as standard)', async (t) => {
+  assert.equal(HOOK_PROFILE_MAP.strict.size, 18, 'strict must have 18 hooks');
 });
 
 // HPM-TC5: circuit-breaker in ALL profiles (MonitoringReachable invariant)

--- a/hooks/dist/config-loader.js
+++ b/hooks/dist/config-loader.js
@@ -54,6 +54,7 @@ const HOOK_PROFILE_MAP = {
     'nf-token-collector',
     'nf-slot-correlator',
     'nf-session-start',
+    'nf-slot-health-probe',
     'nf-statusline',
     'nf-post-edit-format',
     'nf-console-guard',
@@ -73,6 +74,7 @@ const HOOK_PROFILE_MAP = {
     'nf-token-collector',
     'nf-slot-correlator',
     'nf-session-start',
+    'nf-slot-health-probe',
     'nf-statusline',
     'nf-post-edit-format',
     'nf-console-guard',
@@ -103,6 +105,7 @@ const DEFAULT_HOOK_PRIORITIES = {
   'nf-statusline':        10,  // Low — status display
   'nf-token-collector':   10,  // Low — token tracking
   'nf-slot-correlator':   10,  // Low — slot correlation
+  'nf-slot-health-probe': 10,  // Low — quorum slot responsiveness probe (SessionStart)
   'nf-destructive-git-guard': 50,  // Normal — destructive ops advisory
   'nf-scope-guard': 50,             // Normal — scope advisory (warn-only)
   'nf-mcp-dispatch-guard': 50,    // Normal — MCP dispatch advisory

--- a/hooks/dist/nf-slot-health-probe.js
+++ b/hooks/dist/nf-slot-health-probe.js
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+// nf-slot-health-probe.js — probe each nForma quorum slot (MCP server) for responsiveness.
+//
+// For each slot present in BOTH ~/.claude.json mcpServers AND ~/.claude/nf/bin/providers.json,
+// spawn the MCP server with the slot's env and send a JSON-RPC `initialize` over stdio.
+// Success = a well-formed response within the timeout. Writes the cache atomically to
+// ~/.claude/nf/slot-health.json. Statusline reads that cache and renders ●/⊘/○/·.
+//
+// Designed to run as a SessionStart hook fire-and-forget. Total budget ~10s.
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { spawn } = require('child_process');
+
+// Profile gate — opt-out on `minimal`, on by default on `standard`/`strict`.
+try {
+  const { loadConfig, shouldRunHook } = require('./config-loader');
+  const cfg = loadConfig(process.cwd());
+  const profile = cfg.hook_profile || 'standard';
+  if (!shouldRunHook('nf-slot-health-probe', profile)) process.exit(0);
+} catch (_) { /* config-loader missing on first install; fail-open */ }
+
+const HOME = os.homedir();
+const CACHE = path.join(HOME, '.claude', 'nf', 'slot-health.json');
+const PER_SLOT_TIMEOUT_MS = 5000;
+const TOTAL_BUDGET_MS = 10000;
+
+function readJson(p) { try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch (_) { return null; } }
+
+function probeSlot(name, mcpEntry, deadlineMs) {
+  return new Promise((resolve) => {
+    const start = Date.now();
+    let child;
+    try {
+      child = spawn(mcpEntry.command, mcpEntry.args || [], {
+        env: { ...process.env, ...(mcpEntry.env || {}) },
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+    } catch (e) {
+      return resolve({ ok: false, latency_ms: 0, error: 'spawn:' + e.message });
+    }
+
+    let out = '';
+    let done = false;
+    let stderrTail = '';
+
+    const finish = (result) => {
+      if (done) return;
+      done = true;
+      try { child.kill('SIGKILL'); } catch (_) {}
+      resolve(result);
+    };
+
+    child.stdout.on('data', (d) => {
+      out += d.toString();
+      // Look for the response to our init call: jsonrpc + id:1 + result
+      // Any line containing "id":1 with a "result" key counts as a successful handshake.
+      const lines = out.split('\n');
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        try {
+          const msg = JSON.parse(trimmed);
+          if (msg && msg.id === 1 && msg.result) {
+            return finish({ ok: true, latency_ms: Date.now() - start });
+          }
+          if (msg && msg.id === 1 && msg.error) {
+            return finish({ ok: false, latency_ms: Date.now() - start, error: 'init_error:' + (msg.error.message || JSON.stringify(msg.error)).slice(0, 120) });
+          }
+        } catch (_) { /* not a complete JSON message yet */ }
+      }
+    });
+    child.stderr.on('data', (d) => { stderrTail = (stderrTail + d.toString()).slice(-500); });
+    child.on('error', (e) => finish({ ok: false, latency_ms: Date.now() - start, error: 'spawn_err:' + e.message }));
+    child.on('exit', (code, sig) => {
+      if (!done) finish({ ok: false, latency_ms: Date.now() - start, error: 'exited:' + (code != null ? 'code=' + code : 'sig=' + sig) + (stderrTail ? ' stderr=' + stderrTail.slice(0, 80) : '') });
+    });
+
+    const init = JSON.stringify({
+      jsonrpc: '2.0', id: 1, method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05', capabilities: {},
+        clientInfo: { name: 'nf-slot-health-probe', version: '0.1' },
+      },
+    });
+    try { child.stdin.write(init + '\n'); } catch (_) { /* will be caught by error/exit */ }
+
+    const slotDeadline = Math.min(start + PER_SLOT_TIMEOUT_MS, deadlineMs);
+    setTimeout(() => finish({ ok: false, latency_ms: Date.now() - start, error: 'timeout' }), Math.max(0, slotDeadline - Date.now()));
+  });
+}
+
+async function main() {
+  const claudeJson = readJson(path.join(HOME, '.claude.json')) || { mcpServers: {} };
+  const providersData = readJson(path.join(HOME, '.claude', 'nf', 'bin', 'providers.json')) || { providers: [] };
+
+  const providerNames = new Set(providersData.providers.map(p => p.name));
+  const mcpServers = claudeJson.mcpServers || {};
+
+  // Only probe slots that are in BOTH providers.json (claimed as nForma slots) AND mcpServers (registered).
+  const targets = Object.entries(mcpServers)
+    .filter(([name]) => providerNames.has(name))
+    .map(([name, entry]) => ({ name, entry }));
+
+  const deadline = Date.now() + TOTAL_BUDGET_MS;
+  const results = await Promise.all(targets.map(async ({ name, entry }) => {
+    const r = await probeSlot(name, entry, deadline);
+    return [name, r];
+  }));
+
+  const slots = {};
+  for (const [name, r] of results) slots[name] = r;
+
+  // Atomic write
+  const cacheDir = path.dirname(CACHE);
+  try { fs.mkdirSync(cacheDir, { recursive: true }); } catch (_) {}
+  const tmp = CACHE + '.tmp.' + process.pid;
+  fs.writeFileSync(tmp, JSON.stringify({ checked_at: new Date().toISOString(), slots }, null, 2) + '\n');
+  fs.renameSync(tmp, CACHE);
+
+  if (process.argv.includes('--print')) {
+    for (const [name, r] of results) console.log(`${r.ok ? '●' : '⊘'} ${name.padEnd(18)} ${r.latency_ms}ms${r.error ? '  err=' + r.error : ''}`);
+  }
+}
+
+main().catch(e => { process.stderr.write('[nf-slot-health-probe] ' + (e?.stack || e) + '\n'); process.exit(1); });

--- a/hooks/dist/nf-slot-health-probe.js
+++ b/hooks/dist/nf-slot-health-probe.js
@@ -13,10 +13,25 @@ const path = require('path');
 const os = require('os');
 const { spawn } = require('child_process');
 
+// SessionStart hooks receive a JSON payload on stdin that includes a workspace cwd.
+// Read it so the profile gate can pick up project-level `hook_profile: minimal` from the
+// right .planning/ — falling back to process.cwd() when:
+//   - stdin is a TTY (manual invocation with --print, would block on read)
+//   - the payload is empty or not JSON
+function readStdinSync() {
+  if (process.stdin.isTTY) return null; // never block on the terminal
+  try {
+    const buf = fs.readFileSync(0, 'utf8'); // fd 0 = stdin
+    return buf ? JSON.parse(buf) : null;
+  } catch (_) { return null; }
+}
+const stdinPayload = readStdinSync();
+const stdinCwd = (stdinPayload && (stdinPayload.workspace?.current_dir || stdinPayload.cwd)) || null;
+
 // Profile gate — opt-out on `minimal`, on by default on `standard`/`strict`.
 try {
   const { loadConfig, shouldRunHook } = require('./config-loader');
-  const cfg = loadConfig(process.cwd());
+  const cfg = loadConfig(stdinCwd || process.cwd());
   const profile = cfg.hook_profile || 'standard';
   if (!shouldRunHook('nf-slot-health-probe', profile)) process.exit(0);
 } catch (_) { /* config-loader missing on first install; fail-open */ }
@@ -25,6 +40,7 @@ const HOME = os.homedir();
 const CACHE = path.join(HOME, '.claude', 'nf', 'slot-health.json');
 const PER_SLOT_TIMEOUT_MS = 5000;
 const TOTAL_BUDGET_MS = 10000;
+const STDOUT_BUFFER_CAP = 64 * 1024; // bound to 64 KiB — beyond that, drop oldest data
 
 function readJson(p) { try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch (_) { return null; } }
 
@@ -41,9 +57,12 @@ function probeSlot(name, mcpEntry, deadlineMs) {
       return resolve({ ok: false, latency_ms: 0, error: 'spawn:' + e.message });
     }
 
-    let out = '';
+    // Incremental line buffer: carry over the last partial line and parse complete lines only.
+    // Bounded to STDOUT_BUFFER_CAP so a noisy server can't blow out memory; we only need to find
+    // a single line containing the JSON-RPC response to id:1.
+    let pending = '';
+    let stderrSawData = false;
     let done = false;
-    let stderrTail = '';
 
     const finish = (result) => {
       if (done) return;
@@ -53,11 +72,13 @@ function probeSlot(name, mcpEntry, deadlineMs) {
     };
 
     child.stdout.on('data', (d) => {
-      out += d.toString();
-      // Look for the response to our init call: jsonrpc + id:1 + result
-      // Any line containing "id":1 with a "result" key counts as a successful handshake.
-      const lines = out.split('\n');
-      for (const line of lines) {
+      pending += d.toString();
+      if (pending.length > STDOUT_BUFFER_CAP) pending = pending.slice(-STDOUT_BUFFER_CAP);
+      const lastNl = pending.lastIndexOf('\n');
+      if (lastNl < 0) return; // no complete line yet
+      const complete = pending.slice(0, lastNl);
+      pending = pending.slice(lastNl + 1);
+      for (const line of complete.split('\n')) {
         const trimmed = line.trim();
         if (!trimmed) continue;
         try {
@@ -66,15 +87,23 @@ function probeSlot(name, mcpEntry, deadlineMs) {
             return finish({ ok: true, latency_ms: Date.now() - start });
           }
           if (msg && msg.id === 1 && msg.error) {
-            return finish({ ok: false, latency_ms: Date.now() - start, error: 'init_error:' + (msg.error.message || JSON.stringify(msg.error)).slice(0, 120) });
+            // Truncate error message to a fixed length so we can't accidentally persist secrets
+            // bundled into a verbose JSON-RPC error payload.
+            return finish({ ok: false, latency_ms: Date.now() - start, error: 'init_error:' + (msg.error.message || 'unspecified').slice(0, 120) });
           }
-        } catch (_) { /* not a complete JSON message yet */ }
+        } catch (_) { /* not valid JSON, skip */ }
       }
     });
-    child.stderr.on('data', (d) => { stderrTail = (stderrTail + d.toString()).slice(-500); });
-    child.on('error', (e) => finish({ ok: false, latency_ms: Date.now() - start, error: 'spawn_err:' + e.message }));
+    // Note: we observe stderr only as a "saw any" signal, NOT to persist its content.
+    // MCP server stderr can include tokens, prompts, or endpoints — never write to disk cache.
+    child.stderr.on('data', () => { stderrSawData = true; });
+    child.on('error', (e) => finish({ ok: false, latency_ms: Date.now() - start, error: 'spawn_err:' + e.message.slice(0, 120) }));
     child.on('exit', (code, sig) => {
-      if (!done) finish({ ok: false, latency_ms: Date.now() - start, error: 'exited:' + (code != null ? 'code=' + code : 'sig=' + sig) + (stderrTail ? ' stderr=' + stderrTail.slice(0, 80) : '') });
+      if (!done) finish({
+        ok: false,
+        latency_ms: Date.now() - start,
+        error: 'exited:' + (code != null ? 'code=' + code : 'sig=' + sig) + (stderrSawData ? ' (stderr emitted)' : ''),
+      });
     });
 
     const init = JSON.stringify({
@@ -95,7 +124,10 @@ async function main() {
   const claudeJson = readJson(path.join(HOME, '.claude.json')) || { mcpServers: {} };
   const providersData = readJson(path.join(HOME, '.claude', 'nf', 'bin', 'providers.json')) || { providers: [] };
 
-  const providerNames = new Set(providersData.providers.map(p => p.name));
+  // Guard against malformed providers.json (missing/non-array `providers`). Default to []
+  // so a malformed file is treated as "nothing to probe" rather than crashing the hook.
+  const providersList = Array.isArray(providersData.providers) ? providersData.providers : [];
+  const providerNames = new Set(providersList.map(p => p && p.name).filter(Boolean));
   const mcpServers = claudeJson.mcpServers || {};
 
   // Only probe slots that are in BOTH providers.json (claimed as nForma slots) AND mcpServers (registered).

--- a/hooks/dist/nf-statusline.js
+++ b/hooks/dist/nf-statusline.js
@@ -119,6 +119,44 @@ function buildToolsLine(homeDir, dir) {
   return parts.join(' \x1b[2m│\x1b[0m ');
 }
 
+// Build the quorum-slots line. Reads providers.json (the configured slot inventory),
+// ~/.claude.json mcpServers (which slots are MCP-registered), and the slot-health
+// cache written by nf-slot-health-probe.js. Statusline rendering must stay fast,
+// so this is purely cache-read — the probe runs out-of-band (e.g. SessionStart).
+function buildSlotsLine(homeDir) {
+  const providersPath = path.join(homeDir, '.claude', 'nf', 'bin', 'providers.json');
+  const claudeJsonPath = path.join(homeDir, '.claude.json');
+  const cachePath = path.join(homeDir, '.claude', 'nf', 'slot-health.json');
+
+  let providers, mcpServers, cache;
+  try { providers = JSON.parse(fs.readFileSync(providersPath, 'utf8')).providers; } catch (_) { return null; }
+  if (!Array.isArray(providers) || providers.length === 0) return null;
+  try { mcpServers = JSON.parse(fs.readFileSync(claudeJsonPath, 'utf8')).mcpServers || {}; } catch (_) { mcpServers = {}; }
+  try { cache = JSON.parse(fs.readFileSync(cachePath, 'utf8')); } catch (_) { cache = null; }
+
+  const FRESH_MS = 5 * 60 * 1000;
+  const checkedAt = cache && cache.checked_at ? Date.parse(cache.checked_at) : 0;
+  const fresh = checkedAt && (Date.now() - checkedAt) < FRESH_MS;
+
+  const parts = [];
+  for (const p of providers) {
+    const inMcp = !!mcpServers[p.name];
+    const entry = cache && cache.slots && cache.slots[p.name];
+    let glyph, color;
+    if (!inMcp) {
+      glyph = '·'; color = '\x1b[2m'; // dim — listed but not MCP-registered
+    } else if (fresh && entry && entry.ok) {
+      glyph = '●'; color = '\x1b[32m'; // green — recent OK
+    } else if (fresh && entry && !entry.ok) {
+      glyph = '⊘'; color = '\x1b[31m'; // red — recent failure
+    } else {
+      glyph = '○'; color = ''; // configured, no fresh data
+    }
+    parts.push(`${color}${glyph} ${p.name}\x1b[0m`);
+  }
+  return parts.join(' \x1b[2m│\x1b[0m ');
+}
+
 // Read JSON from stdin
 let input = '';
 process.stdin.setEncoding('utf8');
@@ -270,6 +308,14 @@ process.stdin.on('end', () => {
     } else {
       process.stdout.write(`${nfUpdate}\x1b[2m${model}\x1b[0m │ \x1b[2m${dirname}\x1b[0m${ctx}`);
     }
+
+    // Quorum slots line (above the tools line)
+    try {
+      const slotsLine = buildSlotsLine(homeDir);
+      if (slotsLine) {
+        process.stdout.write('\n' + slotsLine);
+      }
+    } catch (_e) {}
 
     // Tools status second line
     try {

--- a/hooks/nf-slot-health-probe.js
+++ b/hooks/nf-slot-health-probe.js
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+// nf-slot-health-probe.js — probe each nForma quorum slot (MCP server) for responsiveness.
+//
+// For each slot present in BOTH ~/.claude.json mcpServers AND ~/.claude/nf/bin/providers.json,
+// spawn the MCP server with the slot's env and send a JSON-RPC `initialize` over stdio.
+// Success = a well-formed response within the timeout. Writes the cache atomically to
+// ~/.claude/nf/slot-health.json. Statusline reads that cache and renders ●/⊘/○/·.
+//
+// Designed to run as a SessionStart hook fire-and-forget. Total budget ~10s.
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { spawn } = require('child_process');
+
+// Profile gate — opt-out on `minimal`, on by default on `standard`/`strict`.
+try {
+  const { loadConfig, shouldRunHook } = require('./config-loader');
+  const cfg = loadConfig(process.cwd());
+  const profile = cfg.hook_profile || 'standard';
+  if (!shouldRunHook('nf-slot-health-probe', profile)) process.exit(0);
+} catch (_) { /* config-loader missing on first install; fail-open */ }
+
+const HOME = os.homedir();
+const CACHE = path.join(HOME, '.claude', 'nf', 'slot-health.json');
+const PER_SLOT_TIMEOUT_MS = 5000;
+const TOTAL_BUDGET_MS = 10000;
+
+function readJson(p) { try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch (_) { return null; } }
+
+function probeSlot(name, mcpEntry, deadlineMs) {
+  return new Promise((resolve) => {
+    const start = Date.now();
+    let child;
+    try {
+      child = spawn(mcpEntry.command, mcpEntry.args || [], {
+        env: { ...process.env, ...(mcpEntry.env || {}) },
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+    } catch (e) {
+      return resolve({ ok: false, latency_ms: 0, error: 'spawn:' + e.message });
+    }
+
+    let out = '';
+    let done = false;
+    let stderrTail = '';
+
+    const finish = (result) => {
+      if (done) return;
+      done = true;
+      try { child.kill('SIGKILL'); } catch (_) {}
+      resolve(result);
+    };
+
+    child.stdout.on('data', (d) => {
+      out += d.toString();
+      // Look for the response to our init call: jsonrpc + id:1 + result
+      // Any line containing "id":1 with a "result" key counts as a successful handshake.
+      const lines = out.split('\n');
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        try {
+          const msg = JSON.parse(trimmed);
+          if (msg && msg.id === 1 && msg.result) {
+            return finish({ ok: true, latency_ms: Date.now() - start });
+          }
+          if (msg && msg.id === 1 && msg.error) {
+            return finish({ ok: false, latency_ms: Date.now() - start, error: 'init_error:' + (msg.error.message || JSON.stringify(msg.error)).slice(0, 120) });
+          }
+        } catch (_) { /* not a complete JSON message yet */ }
+      }
+    });
+    child.stderr.on('data', (d) => { stderrTail = (stderrTail + d.toString()).slice(-500); });
+    child.on('error', (e) => finish({ ok: false, latency_ms: Date.now() - start, error: 'spawn_err:' + e.message }));
+    child.on('exit', (code, sig) => {
+      if (!done) finish({ ok: false, latency_ms: Date.now() - start, error: 'exited:' + (code != null ? 'code=' + code : 'sig=' + sig) + (stderrTail ? ' stderr=' + stderrTail.slice(0, 80) : '') });
+    });
+
+    const init = JSON.stringify({
+      jsonrpc: '2.0', id: 1, method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05', capabilities: {},
+        clientInfo: { name: 'nf-slot-health-probe', version: '0.1' },
+      },
+    });
+    try { child.stdin.write(init + '\n'); } catch (_) { /* will be caught by error/exit */ }
+
+    const slotDeadline = Math.min(start + PER_SLOT_TIMEOUT_MS, deadlineMs);
+    setTimeout(() => finish({ ok: false, latency_ms: Date.now() - start, error: 'timeout' }), Math.max(0, slotDeadline - Date.now()));
+  });
+}
+
+async function main() {
+  const claudeJson = readJson(path.join(HOME, '.claude.json')) || { mcpServers: {} };
+  const providersData = readJson(path.join(HOME, '.claude', 'nf', 'bin', 'providers.json')) || { providers: [] };
+
+  const providerNames = new Set(providersData.providers.map(p => p.name));
+  const mcpServers = claudeJson.mcpServers || {};
+
+  // Only probe slots that are in BOTH providers.json (claimed as nForma slots) AND mcpServers (registered).
+  const targets = Object.entries(mcpServers)
+    .filter(([name]) => providerNames.has(name))
+    .map(([name, entry]) => ({ name, entry }));
+
+  const deadline = Date.now() + TOTAL_BUDGET_MS;
+  const results = await Promise.all(targets.map(async ({ name, entry }) => {
+    const r = await probeSlot(name, entry, deadline);
+    return [name, r];
+  }));
+
+  const slots = {};
+  for (const [name, r] of results) slots[name] = r;
+
+  // Atomic write
+  const cacheDir = path.dirname(CACHE);
+  try { fs.mkdirSync(cacheDir, { recursive: true }); } catch (_) {}
+  const tmp = CACHE + '.tmp.' + process.pid;
+  fs.writeFileSync(tmp, JSON.stringify({ checked_at: new Date().toISOString(), slots }, null, 2) + '\n');
+  fs.renameSync(tmp, CACHE);
+
+  if (process.argv.includes('--print')) {
+    for (const [name, r] of results) console.log(`${r.ok ? '●' : '⊘'} ${name.padEnd(18)} ${r.latency_ms}ms${r.error ? '  err=' + r.error : ''}`);
+  }
+}
+
+main().catch(e => { process.stderr.write('[nf-slot-health-probe] ' + (e?.stack || e) + '\n'); process.exit(1); });

--- a/hooks/nf-slot-health-probe.js
+++ b/hooks/nf-slot-health-probe.js
@@ -13,10 +13,25 @@ const path = require('path');
 const os = require('os');
 const { spawn } = require('child_process');
 
+// SessionStart hooks receive a JSON payload on stdin that includes a workspace cwd.
+// Read it so the profile gate can pick up project-level `hook_profile: minimal` from the
+// right .planning/ — falling back to process.cwd() when:
+//   - stdin is a TTY (manual invocation with --print, would block on read)
+//   - the payload is empty or not JSON
+function readStdinSync() {
+  if (process.stdin.isTTY) return null; // never block on the terminal
+  try {
+    const buf = fs.readFileSync(0, 'utf8'); // fd 0 = stdin
+    return buf ? JSON.parse(buf) : null;
+  } catch (_) { return null; }
+}
+const stdinPayload = readStdinSync();
+const stdinCwd = (stdinPayload && (stdinPayload.workspace?.current_dir || stdinPayload.cwd)) || null;
+
 // Profile gate — opt-out on `minimal`, on by default on `standard`/`strict`.
 try {
   const { loadConfig, shouldRunHook } = require('./config-loader');
-  const cfg = loadConfig(process.cwd());
+  const cfg = loadConfig(stdinCwd || process.cwd());
   const profile = cfg.hook_profile || 'standard';
   if (!shouldRunHook('nf-slot-health-probe', profile)) process.exit(0);
 } catch (_) { /* config-loader missing on first install; fail-open */ }
@@ -25,6 +40,7 @@ const HOME = os.homedir();
 const CACHE = path.join(HOME, '.claude', 'nf', 'slot-health.json');
 const PER_SLOT_TIMEOUT_MS = 5000;
 const TOTAL_BUDGET_MS = 10000;
+const STDOUT_BUFFER_CAP = 64 * 1024; // bound to 64 KiB — beyond that, drop oldest data
 
 function readJson(p) { try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch (_) { return null; } }
 
@@ -41,9 +57,12 @@ function probeSlot(name, mcpEntry, deadlineMs) {
       return resolve({ ok: false, latency_ms: 0, error: 'spawn:' + e.message });
     }
 
-    let out = '';
+    // Incremental line buffer: carry over the last partial line and parse complete lines only.
+    // Bounded to STDOUT_BUFFER_CAP so a noisy server can't blow out memory; we only need to find
+    // a single line containing the JSON-RPC response to id:1.
+    let pending = '';
+    let stderrSawData = false;
     let done = false;
-    let stderrTail = '';
 
     const finish = (result) => {
       if (done) return;
@@ -53,11 +72,13 @@ function probeSlot(name, mcpEntry, deadlineMs) {
     };
 
     child.stdout.on('data', (d) => {
-      out += d.toString();
-      // Look for the response to our init call: jsonrpc + id:1 + result
-      // Any line containing "id":1 with a "result" key counts as a successful handshake.
-      const lines = out.split('\n');
-      for (const line of lines) {
+      pending += d.toString();
+      if (pending.length > STDOUT_BUFFER_CAP) pending = pending.slice(-STDOUT_BUFFER_CAP);
+      const lastNl = pending.lastIndexOf('\n');
+      if (lastNl < 0) return; // no complete line yet
+      const complete = pending.slice(0, lastNl);
+      pending = pending.slice(lastNl + 1);
+      for (const line of complete.split('\n')) {
         const trimmed = line.trim();
         if (!trimmed) continue;
         try {
@@ -66,15 +87,23 @@ function probeSlot(name, mcpEntry, deadlineMs) {
             return finish({ ok: true, latency_ms: Date.now() - start });
           }
           if (msg && msg.id === 1 && msg.error) {
-            return finish({ ok: false, latency_ms: Date.now() - start, error: 'init_error:' + (msg.error.message || JSON.stringify(msg.error)).slice(0, 120) });
+            // Truncate error message to a fixed length so we can't accidentally persist secrets
+            // bundled into a verbose JSON-RPC error payload.
+            return finish({ ok: false, latency_ms: Date.now() - start, error: 'init_error:' + (msg.error.message || 'unspecified').slice(0, 120) });
           }
-        } catch (_) { /* not a complete JSON message yet */ }
+        } catch (_) { /* not valid JSON, skip */ }
       }
     });
-    child.stderr.on('data', (d) => { stderrTail = (stderrTail + d.toString()).slice(-500); });
-    child.on('error', (e) => finish({ ok: false, latency_ms: Date.now() - start, error: 'spawn_err:' + e.message }));
+    // Note: we observe stderr only as a "saw any" signal, NOT to persist its content.
+    // MCP server stderr can include tokens, prompts, or endpoints — never write to disk cache.
+    child.stderr.on('data', () => { stderrSawData = true; });
+    child.on('error', (e) => finish({ ok: false, latency_ms: Date.now() - start, error: 'spawn_err:' + e.message.slice(0, 120) }));
     child.on('exit', (code, sig) => {
-      if (!done) finish({ ok: false, latency_ms: Date.now() - start, error: 'exited:' + (code != null ? 'code=' + code : 'sig=' + sig) + (stderrTail ? ' stderr=' + stderrTail.slice(0, 80) : '') });
+      if (!done) finish({
+        ok: false,
+        latency_ms: Date.now() - start,
+        error: 'exited:' + (code != null ? 'code=' + code : 'sig=' + sig) + (stderrSawData ? ' (stderr emitted)' : ''),
+      });
     });
 
     const init = JSON.stringify({
@@ -95,7 +124,10 @@ async function main() {
   const claudeJson = readJson(path.join(HOME, '.claude.json')) || { mcpServers: {} };
   const providersData = readJson(path.join(HOME, '.claude', 'nf', 'bin', 'providers.json')) || { providers: [] };
 
-  const providerNames = new Set(providersData.providers.map(p => p.name));
+  // Guard against malformed providers.json (missing/non-array `providers`). Default to []
+  // so a malformed file is treated as "nothing to probe" rather than crashing the hook.
+  const providersList = Array.isArray(providersData.providers) ? providersData.providers : [];
+  const providerNames = new Set(providersList.map(p => p && p.name).filter(Boolean));
   const mcpServers = claudeJson.mcpServers || {};
 
   // Only probe slots that are in BOTH providers.json (claimed as nForma slots) AND mcpServers (registered).

--- a/hooks/nf-statusline.js
+++ b/hooks/nf-statusline.js
@@ -119,6 +119,44 @@ function buildToolsLine(homeDir, dir) {
   return parts.join(' \x1b[2m│\x1b[0m ');
 }
 
+// Build the quorum-slots line. Reads providers.json (the configured slot inventory),
+// ~/.claude.json mcpServers (which slots are MCP-registered), and the slot-health
+// cache written by nf-slot-health-probe.js. Statusline rendering must stay fast,
+// so this is purely cache-read — the probe runs out-of-band (e.g. SessionStart).
+function buildSlotsLine(homeDir) {
+  const providersPath = path.join(homeDir, '.claude', 'nf', 'bin', 'providers.json');
+  const claudeJsonPath = path.join(homeDir, '.claude.json');
+  const cachePath = path.join(homeDir, '.claude', 'nf', 'slot-health.json');
+
+  let providers, mcpServers, cache;
+  try { providers = JSON.parse(fs.readFileSync(providersPath, 'utf8')).providers; } catch (_) { return null; }
+  if (!Array.isArray(providers) || providers.length === 0) return null;
+  try { mcpServers = JSON.parse(fs.readFileSync(claudeJsonPath, 'utf8')).mcpServers || {}; } catch (_) { mcpServers = {}; }
+  try { cache = JSON.parse(fs.readFileSync(cachePath, 'utf8')); } catch (_) { cache = null; }
+
+  const FRESH_MS = 5 * 60 * 1000;
+  const checkedAt = cache && cache.checked_at ? Date.parse(cache.checked_at) : 0;
+  const fresh = checkedAt && (Date.now() - checkedAt) < FRESH_MS;
+
+  const parts = [];
+  for (const p of providers) {
+    const inMcp = !!mcpServers[p.name];
+    const entry = cache && cache.slots && cache.slots[p.name];
+    let glyph, color;
+    if (!inMcp) {
+      glyph = '·'; color = '\x1b[2m'; // dim — listed but not MCP-registered
+    } else if (fresh && entry && entry.ok) {
+      glyph = '●'; color = '\x1b[32m'; // green — recent OK
+    } else if (fresh && entry && !entry.ok) {
+      glyph = '⊘'; color = '\x1b[31m'; // red — recent failure
+    } else {
+      glyph = '○'; color = ''; // configured, no fresh data
+    }
+    parts.push(`${color}${glyph} ${p.name}\x1b[0m`);
+  }
+  return parts.join(' \x1b[2m│\x1b[0m ');
+}
+
 // Read JSON from stdin
 let input = '';
 process.stdin.setEncoding('utf8');
@@ -270,6 +308,14 @@ process.stdin.on('end', () => {
     } else {
       process.stdout.write(`${nfUpdate}\x1b[2m${model}\x1b[0m │ \x1b[2m${dirname}\x1b[0m${ctx}`);
     }
+
+    // Quorum slots line (above the tools line)
+    try {
+      const slotsLine = buildSlotsLine(homeDir);
+      if (slotsLine) {
+        process.stdout.write('\n' + slotsLine);
+      }
+    } catch (_e) {}
 
     // Tools status second line
     try {

--- a/scripts/build-hooks.js
+++ b/scripts/build-hooks.js
@@ -21,6 +21,7 @@ const HOOKS_TO_COPY = [
   'nf-spec-regen.js',      // nForma: PostToolUse spec regeneration
   'nf-token-collector.js', // nForma: SubagentStop token collection
   'nf-slot-correlator.js', // nForma: SubagentStart slot correlation
+  'nf-slot-health-probe.js', // nForma: SessionStart quorum slot responsiveness probe
   'nf-context-monitor.js', // nForma: PostToolUse context monitoring
   'nf-post-edit-format.js',  // nForma: PostToolUse edit formatting
   'nf-console-guard.js',     // nForma: Stop console guard


### PR DESCRIPTION
## Summary

Adds a quorum-slot status row to the Claude Code statusline showing responsiveness of every configured nForma slot, rendered above the existing tools row (`coderlm | River | embed`).

```
● claude-1 │ ⊘ codex-1 │ ○ gemini-1 │ · opencode-1
● coderlm │ ○ River │ ● embed
```

Glyphs:
- `· dim` — listed in providers.json but not registered as MCP server
- `○ normal` — registered, no fresh probe data (or > 5min stale)
- `● green` — recent probe OK
- `⊘ red` — recent probe FAILED

## How it works

- New `hooks/nf-slot-health-probe.js` runs at SessionStart. It probes every slot present in BOTH `providers.json` AND `~/.claude.json` mcpServers by spawning the MCP server with the slot's env and sending a JSON-RPC `initialize` over stdio. Parallel — ~225ms for 7 slots, 10s total budget. Writes `~/.claude/nf/slot-health.json` atomically.
- `hooks/nf-statusline.js` adds `buildSlotsLine()` which is a pure cache read — keeps the statusline fast.
- `bin/install.js` registers the probe as a SessionStart hook (timeout 15s) and includes it in the orphan-cleanup filter for uninstall paths.
- `hooks/config-loader.js` adds `nf-slot-health-probe` to standard + strict profiles (opt-out on minimal). Hook priority 10 (low).

## Test plan

- [x] Run `node ~/.claude/hooks/nf-slot-health-probe.js --print` against a live install with 7 slots — all probe ●, ~220ms
- [x] Probe correctly reports ⊘ for misconfigured slots (caught a real bug during dev: cloned MCP entries needed `UNIFIED_PROVIDERS_CONFIG`)
- [x] Statusline renders correctly with the slots row above the existing tools row
- [x] Profile gate: `shouldRunHook('nf-slot-health-probe', 'minimal')` returns false; standard + strict return true
- [x] `node bin/install.js --claude --global` registers the SessionStart hook idempotently
- [x] All Node files syntax-check clean

## Notes

- `~/.claude/nf/slot-health.json` is the cache (gitignored, per-machine state).
- The probe uses the MCP `initialize` handshake — minimal payload, no tool invocations, no LLM calls. Cost is just the cold-start of `unified-mcp-server.mjs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic health checks for MCP slots with per-slot latency/error tracking, local cache persistence, optional console output, and freshness-based gating in the UI statusline.
  * Statusline now shows per-slot health indicators (green/red/dim glyphs) reflecting cached results.

* **Chores**
  * Installer and configuration updated to register and manage the new slot-health probe hook.
  * Build process updated to include the probe in packaged hooks.

* **Tests**
  * Test expectations updated to account for the added hook in relevant profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->