### PR TITLE
fix(install): preserve user-customized providers.json across installs

### DIFF
--- a/bin/install-helpers.cjs
+++ b/bin/install-helpers.cjs
@@ -1,0 +1,88 @@
+'use strict';
+
+/**
+ * install-helpers.cjs — pure helpers extracted from install.js for unit testability.
+ *
+ * The main install.js is a long imperative CLI; functions in here are isolated so they
+ * can be exercised by node --test without spawning a real install.
+ */
+
+const fs = require('fs');
+
+/**
+ * Merge the repo's providers.json into the user's installed copy, preserving user-added
+ * entries. The repo source (`bin/providers.json`) ships the canonical default fleet; users
+ * extend it via /nf:link-canopy fan-out (Daintree presets), /nf:mcp-setup (manual ccr-* etc.),
+ * or hand-editing.
+ *
+ * Merge rules:
+ *   - Provider entries present in the repo source: REPLACED with the repo version (so metadata
+ *     bumps in description/mainTool/model defaults propagate on update).
+ *   - Provider entries present ONLY in the user's copy (no name match in repo): PRESERVED
+ *     verbatim, appended after the repo entries. This covers fan-out preset slots
+ *     (those carrying `daintree_preset_id`), user-added ccr-* slots (Together.xyz routing
+ *     was retired from the default fleet), and any hand-rolled custom slots.
+ *   - Top-level providers.json fields other than `providers` are merged shallowly with repo
+ *     winning. Today the file is `{providers: [...]}` only, so this is effectively a no-op.
+ *
+ * Fail-open: any read/parse error on either side falls back to the original copy semantics
+ * (overwrite the user's file with the repo version) so installs never wedge on a corrupt file.
+ *
+ * @param {string} repoPath - absolute path to bin/providers.json in the repo source
+ * @param {string} userPath - absolute path to the user's installed copy
+ * @param {object} [opts]
+ * @param {(msg: string) => void} [opts.log] - optional log sink (defaults to no-op)
+ * @returns {{ status: 'merged' | 'fresh-copy' | 'fallback-copy' | 'error', preservedCount: number, preservedNames: string[] }}
+ */
+function mergeProvidersJson(repoPath, userPath, opts = {}) {
+  const log = typeof opts.log === 'function' ? opts.log : () => {};
+
+  let repoData;
+  try {
+    repoData = JSON.parse(fs.readFileSync(repoPath, 'utf8'));
+  } catch (e) {
+    log(`providers.json: could not read repo source (${e.message}); skipping copy`);
+    return { status: 'error', preservedCount: 0, preservedNames: [] };
+  }
+
+  // First-time install or user file missing → straight copy
+  if (!fs.existsSync(userPath)) {
+    fs.copyFileSync(repoPath, userPath);
+    return { status: 'fresh-copy', preservedCount: 0, preservedNames: [] };
+  }
+
+  let userData;
+  try {
+    userData = JSON.parse(fs.readFileSync(userPath, 'utf8'));
+  } catch (e) {
+    log(`providers.json: user copy unreadable (${e.message}); replacing with repo source`);
+    fs.copyFileSync(repoPath, userPath);
+    return { status: 'fallback-copy', preservedCount: 0, preservedNames: [] };
+  }
+
+  const repoProviders = Array.isArray(repoData.providers) ? repoData.providers : [];
+  const userProviders = Array.isArray(userData.providers) ? userData.providers : [];
+  const repoNames = new Set(repoProviders.map(p => p && p.name).filter(Boolean));
+
+  // Preserved: user entries whose name doesn't appear in the repo source.
+  const userExtras = userProviders.filter(p => p && p.name && !repoNames.has(p.name));
+
+  const merged = {
+    ...userData,    // start with user's top-level fields
+    ...repoData,    // repo wins on top-level (e.g. schema_version) — same shape today
+    providers: [...repoProviders, ...userExtras],
+  };
+
+  // Atomic write (avoid leaving a half-written file if power-cuts mid-merge)
+  const tmpPath = userPath + '.merge.tmp';
+  fs.writeFileSync(tmpPath, JSON.stringify(merged, null, 2) + '\n', 'utf8');
+  fs.renameSync(tmpPath, userPath);
+
+  const preservedNames = userExtras.map(p => p.name);
+  if (preservedNames.length > 0) {
+    log(`providers.json: merged repo defaults; preserved ${preservedNames.length} user-added slot(s): ${preservedNames.join(', ')}`);
+  }
+  return { status: 'merged', preservedCount: preservedNames.length, preservedNames };
+}
+
+module.exports = { mergeProvidersJson };

--- a/bin/install-helpers.test.cjs
+++ b/bin/install-helpers.test.cjs
@@ -1,0 +1,212 @@
+'use strict';
+
+// Unit tests for bin/install-helpers.cjs — specifically mergeProvidersJson.
+// Run: node --test bin/install-helpers.test.cjs
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { mergeProvidersJson } = require('./install-helpers.cjs');
+
+function tmpDir(suffix) {
+  const d = path.join(os.tmpdir(), `nf-merge-${process.pid}-${Date.now()}-${suffix}`);
+  fs.mkdirSync(d, { recursive: true });
+  return d;
+}
+
+function writeJson(p, obj) { fs.writeFileSync(p, JSON.stringify(obj, null, 2)); }
+function readJson(p) { return JSON.parse(fs.readFileSync(p, 'utf8')); }
+
+// MERGE-01: Fresh install (no user file) → straight copy from repo
+test('MERGE-01: fresh install copies repo source to user path', () => {
+  const dir = tmpDir('m01');
+  try {
+    const repoPath = path.join(dir, 'repo.json');
+    const userPath = path.join(dir, 'user.json'); // does NOT exist yet
+    writeJson(repoPath, { providers: [{ name: 'codex-1' }, { name: 'claude-1' }] });
+
+    const result = mergeProvidersJson(repoPath, userPath);
+
+    assert.equal(result.status, 'fresh-copy');
+    assert.equal(result.preservedCount, 0);
+    assert.ok(fs.existsSync(userPath), 'user file must be created');
+    assert.deepEqual(readJson(userPath).providers.map(p => p.name), ['codex-1', 'claude-1']);
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
+// MERGE-02: User has a fan-out preset slot → preserved on re-install
+test('MERGE-02: user-added preset slot (daintree_preset_id) preserved across install', () => {
+  const dir = tmpDir('m02');
+  try {
+    const repoPath = path.join(dir, 'repo.json');
+    const userPath = path.join(dir, 'user.json');
+    writeJson(repoPath, { providers: [{ name: 'codex-1', model: 'gpt-5' }, { name: 'claude-1', model: 'opus' }] });
+    writeJson(userPath, {
+      providers: [
+        { name: 'codex-1', model: 'gpt-5' },
+        { name: 'claude-1', model: 'opus' },
+        // Fan-out preset slot — user-added, not in repo
+        {
+          name: 'claude-z-ai',
+          model: 'glm-5.1',
+          provider: 'anthropic',
+          mainTool: 'claude',
+          env: { ANTHROPIC_BASE_URL: 'https://api.z.ai/api/anthropic' },
+          daintree_preset_id: 'user-47d3419a-275e-4d73-8ef2-6be27181ce33',
+          daintree_preset_name: 'Z.AI',
+        },
+      ],
+    });
+
+    const result = mergeProvidersJson(repoPath, userPath);
+
+    assert.equal(result.status, 'merged');
+    assert.equal(result.preservedCount, 1);
+    assert.deepEqual(result.preservedNames, ['claude-z-ai']);
+    const merged = readJson(userPath).providers;
+    assert.deepEqual(merged.map(p => p.name), ['codex-1', 'claude-1', 'claude-z-ai']);
+    // Preserved slot's metadata is intact
+    const zai = merged.find(p => p.name === 'claude-z-ai');
+    assert.equal(zai.daintree_preset_id, 'user-47d3419a-275e-4d73-8ef2-6be27181ce33');
+    assert.equal(zai.env.ANTHROPIC_BASE_URL, 'https://api.z.ai/api/anthropic');
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
+// MERGE-03: Repo updates an existing slot's metadata → repo version wins
+test('MERGE-03: repo-shipped slot is refreshed from repo (metadata bumps propagate)', () => {
+  const dir = tmpDir('m03');
+  try {
+    const repoPath = path.join(dir, 'repo.json');
+    const userPath = path.join(dir, 'user.json');
+    // Repo bumped claude-1's model from "opus" to "opus-4-7"
+    writeJson(repoPath, { providers: [{ name: 'claude-1', model: 'opus-4-7', description: 'updated' }] });
+    writeJson(userPath, { providers: [{ name: 'claude-1', model: 'opus', description: 'old' }] });
+
+    mergeProvidersJson(repoPath, userPath);
+
+    const merged = readJson(userPath).providers;
+    assert.equal(merged.length, 1);
+    // Repo version wins for repo-shipped slots
+    assert.equal(merged[0].model, 'opus-4-7');
+    assert.equal(merged[0].description, 'updated');
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
+// MERGE-04: User has multiple custom slots (e.g. ccr-* added after repo retired them) → all preserved
+test('MERGE-04: multiple user-added slots preserved', () => {
+  const dir = tmpDir('m04');
+  try {
+    const repoPath = path.join(dir, 'repo.json');
+    const userPath = path.join(dir, 'user.json');
+    writeJson(repoPath, { providers: [{ name: 'claude-1' }] });
+    writeJson(userPath, {
+      providers: [
+        { name: 'claude-1' },
+        { name: 'ccr-1', provider: 'together' }, // user re-added after repo retired
+        { name: 'ccr-2', provider: 'together' },
+        { name: 'claude-z-ai', daintree_preset_id: 'abc' },
+        { name: 'my-custom-slot' }, // hand-rolled
+      ],
+    });
+
+    const result = mergeProvidersJson(repoPath, userPath);
+
+    assert.equal(result.preservedCount, 4);
+    assert.deepEqual(result.preservedNames.sort(), ['ccr-1', 'ccr-2', 'claude-z-ai', 'my-custom-slot']);
+    const merged = readJson(userPath).providers;
+    assert.equal(merged.length, 5);
+    assert.equal(merged[0].name, 'claude-1', 'repo entries come first');
+    assert.deepEqual(merged.slice(1).map(p => p.name), ['ccr-1', 'ccr-2', 'claude-z-ai', 'my-custom-slot']);
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
+// MERGE-05: Corrupt user file → fall back to repo overwrite (install never wedges)
+test('MERGE-05: corrupt user JSON falls back to repo overwrite (fail-open)', () => {
+  const dir = tmpDir('m05');
+  try {
+    const repoPath = path.join(dir, 'repo.json');
+    const userPath = path.join(dir, 'user.json');
+    writeJson(repoPath, { providers: [{ name: 'claude-1' }] });
+    fs.writeFileSync(userPath, 'not valid json {{{');
+
+    const logs = [];
+    const result = mergeProvidersJson(repoPath, userPath, { log: msg => logs.push(msg) });
+
+    assert.equal(result.status, 'fallback-copy');
+    assert.equal(result.preservedCount, 0);
+    assert.deepEqual(readJson(userPath).providers.map(p => p.name), ['claude-1']);
+    assert.ok(logs.some(m => /unreadable/.test(m)), 'must log the corruption fallback');
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
+// MERGE-06: Corrupt repo source → bail without touching user file
+test('MERGE-06: corrupt repo source bails without touching user file', () => {
+  const dir = tmpDir('m06');
+  try {
+    const repoPath = path.join(dir, 'repo.json');
+    const userPath = path.join(dir, 'user.json');
+    fs.writeFileSync(repoPath, 'not valid json {{{');
+    writeJson(userPath, { providers: [{ name: 'user-only-slot' }] });
+
+    const result = mergeProvidersJson(repoPath, userPath);
+
+    assert.equal(result.status, 'error');
+    // User file should still be intact and unchanged
+    assert.deepEqual(readJson(userPath).providers.map(p => p.name), ['user-only-slot']);
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
+// MERGE-07: Atomic write — no .merge.tmp file lingers after success
+test('MERGE-07: atomic write leaves no .merge.tmp lingering', () => {
+  const dir = tmpDir('m07');
+  try {
+    const repoPath = path.join(dir, 'repo.json');
+    const userPath = path.join(dir, 'user.json');
+    writeJson(repoPath, { providers: [{ name: 'claude-1' }] });
+    writeJson(userPath, { providers: [{ name: 'claude-1' }, { name: 'extra' }] });
+
+    mergeProvidersJson(repoPath, userPath);
+    assert.ok(!fs.existsSync(userPath + '.merge.tmp'), '.merge.tmp must be cleaned up');
+    assert.ok(fs.existsSync(userPath), 'user file must exist');
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
+// MERGE-08: User file has providers as non-array (or missing) → treat as empty, repo wins
+test('MERGE-08: malformed user.providers treated as empty', () => {
+  const dir = tmpDir('m08');
+  try {
+    const repoPath = path.join(dir, 'repo.json');
+    const userPath = path.join(dir, 'user.json');
+    writeJson(repoPath, { providers: [{ name: 'claude-1' }] });
+    writeJson(userPath, { providers: 'not-an-array' });
+
+    const result = mergeProvidersJson(repoPath, userPath);
+
+    assert.equal(result.status, 'merged');
+    assert.equal(result.preservedCount, 0);
+    assert.deepEqual(readJson(userPath).providers.map(p => p.name), ['claude-1']);
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
+// MERGE-09: Order — repo entries always come before preserved user extras
+test('MERGE-09: repo entries always precede user extras in merged output', () => {
+  const dir = tmpDir('m09');
+  try {
+    const repoPath = path.join(dir, 'repo.json');
+    const userPath = path.join(dir, 'user.json');
+    writeJson(repoPath, { providers: [{ name: 'a' }, { name: 'b' }, { name: 'c' }] });
+    writeJson(userPath, {
+      // user has them in a different order, plus extras interleaved
+      providers: [{ name: 'extra-1' }, { name: 'b' }, { name: 'extra-2' }, { name: 'a' }, { name: 'c' }],
+    });
+
+    mergeProvidersJson(repoPath, userPath);
+
+    const names = readJson(userPath).providers.map(p => p.name);
+    assert.deepEqual(names, ['a', 'b', 'c', 'extra-1', 'extra-2'],
+      'repo order preserved first, user extras appended in their declared order');
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});

--- a/bin/install.js
+++ b/bin/install.js
@@ -469,6 +469,26 @@ function detectCcrCli() {
   return { found, resolvedPath: found ? result : null };
 }
 
+// providers.json merge: see bin/install-helpers.cjs for the implementation. The wrapper here
+// adapts the colored install.js logger and forwards the result so the install path keeps a
+// single call site.
+const { mergeProvidersJson: _mergeProvidersJson } = require('./install-helpers.cjs');
+function mergeProvidersJson(repoPath, userPath) {
+  const result = _mergeProvidersJson(repoPath, userPath, {
+    log: (msg) => {
+      // Re-color based on result kind. The helper just emits plain text so it's easy to test.
+      if (msg.startsWith('providers.json: could not read repo source')) {
+        log(`  ${yellow}⚠${reset} ${msg}`);
+      } else if (msg.startsWith('providers.json: user copy unreadable')) {
+        log(`  ${yellow}⚠${reset} ${msg}`);
+      } else {
+        log(`  ${green}✓${reset} ${msg}`);
+      }
+    },
+  });
+  return result;
+}
+
 // Ensures all provider slots from providers.json have corresponding MCP entries in ~/.claude.json.
 // Only adds missing entries (never modifies existing ones).
 // Fail-open: errors are logged but do not abort install.
@@ -2475,14 +2495,21 @@ function install(isGlobal, runtime = 'claude') {
     }
   }
 
-  // Copy bin/*.cjs scripts to nf-bin/ (used by commands with absolute paths)
+  // Copy bin/*.cjs scripts to nf-bin/ (used by commands with absolute paths).
+  // providers.json gets MERGE semantics rather than overwrite: user-added entries
+  // (slots created by /nf:link-canopy fan-out, /nf:mcp-setup, hand-edited customizations,
+  // anything carrying daintree_preset_id or simply not present in the repo source) are
+  // preserved across re-installs. Repo-shipped slot entries are always refreshed from
+  // the repo so metadata bumps (description, mainTool, model defaults) propagate.
   const binSrc = path.join(src, 'bin');
   if (fs.existsSync(binSrc)) {
     const binDest = path.join(targetDir, 'nf-bin');
     fs.mkdirSync(binDest, { recursive: true });
     const binEntries = fs.readdirSync(binSrc);
     for (const entry of binEntries) {
-      if (entry.endsWith('.cjs') || entry === 'providers.json') {
+      if (entry === 'providers.json') {
+        mergeProvidersJson(path.join(binSrc, entry), path.join(binDest, entry));
+      } else if (entry.endsWith('.cjs')) {
         fs.copyFileSync(path.join(binSrc, entry), path.join(binDest, entry));
       }
     }


### PR DESCRIPTION
Closes the install.js clobber bug observed during PR #142 testing — running \`node bin/install.js --claude --global\` would silently destroy user-added provider entries (fan-out preset slots from \`/nf:link-canopy\`, manually-added ccr-* slots, hand-rolled customizations).

In the most recent occurrence, \`claude-z-ai\` and \`claude-minimax\` slots created from Daintree presets were wiped on a routine install run. Their MCP server entries in \`~/.claude.json\` and quorum_active entries in \`~/.claude/nf.json\` survived, but they pointed at provider entries that no longer existed in \`providers.json\`.

## Before
\`bin/install.js:2485\` did:
\`\`\`js
if (entry.endsWith('.cjs') || entry === 'providers.json') {
  fs.copyFileSync(path.join(binSrc, entry), path.join(binDest, entry));
}
\`\`\`

Every install ran an unconditional overwrite. No merge, no preservation.

## After
A new \`bin/install-helpers.cjs\` exports \`mergeProvidersJson()\` with name-keyed merge semantics:

| Scenario | Outcome |
|---|---|
| Fresh install (no user file) | Straight copy from repo |
| Repo-shipped slot (name in both) | **Refreshed** from repo — metadata bumps (description, mainTool, model defaults) propagate |
| User-only slot (no name match in repo) | **Preserved** verbatim, appended after repo entries |
| Corrupt user JSON | Fall back to repo overwrite (install never wedges) |
| Corrupt repo JSON | Bail without touching user file |
| Atomic write | \`.merge.tmp\` + rename — no half-written file on power-cut |

\`install.js\` wraps the helper with its color-coded logger so the output reads the same for repo-only updates, plus a \`✓ providers.json: merged repo defaults; preserved N user-added slot(s): <names>\` line when there are extras.

## Test plan

- [x] 9 unit tests in \`bin/install-helpers.test.cjs\` cover: fresh install, single preserved fan-out slot, metadata bump on shared slot, multiple user extras, corrupt user JSON, corrupt repo JSON, atomic write cleanup, malformed \`user.providers\`, ordering invariants — all pass locally.
- [x] Full suite: 1540/1541 pass (1 unrelated pre-existing flake in \`bin/repowise/resolve-hotspot-risk.test.cjs\`, fails on \`main\` too — confirmed by stash test).
- [x] \`node --check\` clean on \`bin/install.js\` and \`bin/install-helpers.cjs\`.

## Manual repro of the original bug + verification of the fix

1. Add a preset slot via \`/nf:link-canopy\` (or just hand-edit \`~/.claude/nf/bin/providers.json\` to add a \`{ name: "claude-z-ai", daintree_preset_id: "abc", ... }\` entry).
2. Run \`node bin/install.js --claude --global\`.
3. **Before this PR**: the entry vanishes from \`providers.json\`.
4. **After this PR**: the entry is preserved, with a log line showing \`preserved 1 user-added slot(s): claude-z-ai\`.

## Related

- PR #142 (already merged) — bidirectional fleet sync; whose user-added slots needed protecting.
- PR #147 — retired ccr-1..ccr-6 from the default fleet; users who manually re-add them benefit from this same merge behavior.
- PR #144, #146 — sibling follow-ups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User-added and custom provider entries are now preserved during installation and updates, preventing loss of personalized configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->