### PR TITLE
fix(link-daintree): correct family-gate fallback in fan-out import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.43.0] - 2026-05-02
+
+### Changed
+- refactor(install): manifest-driven CLI detection — `providers.json` now shipped empty and populated at install time from `~/.claude.json` MCP servers and PATH auto-detection
+
+### Fixed
+- fix(formal): resolve merge conflict markers in `.planning/formal/` JSON files that caused `extract-annotations.cjs` to fail with JSON parse errors
+- fix(formal): give `max_retries` a safe default value in `oauth-rotation.pm` — PRISM requires all constants to be defined
+
 ## [0.43.0-rc.1] - 2026-04-23 — next prerelease
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.43.1] - 2026-05-03
+
+### Fixed
+- fix(link-daintree): fan-out fallback logic no longer silently drops presets when no vanilla provider has a matching `provider` field — the family gate is now correctly bypassed when the inferred family doesn't match any vanilla slot, falling back to all candidates sorted by daintree_preset_id then numeric suffix
+
 ## [0.43.0] - 2026-05-02
 
 ### Changed

--- a/commands/nf/link-daintree.md
+++ b/commands/nf/link-daintree.md
@@ -482,7 +482,7 @@ function inferFamily(envObj) {
 function findVanilla(agentName, family) {
   const candidates = providersData.providers.filter(p => p.mainTool === agentName);
   const familyMatch = family ? candidates.filter(p => p.provider === family) : candidates;
-  const pool = familyMatch.length ? familyMatch : (family ? [] : candidates);
+  const pool = familyMatch.length ? familyMatch : candidates;
   // Prefer provider without daintree_preset_id, then lowest numeric suffix
   pool.sort((a, b) => {
     const aIsClone = !!a.daintree_preset_id;

--- a/docs/assets/terminal.svg
+++ b/docs/assets/terminal.svg
@@ -80,7 +80,7 @@
     <path d="M100.8,143.0 H96.6 V132.0" stroke="#7dcfff" stroke-width="1.5" stroke-linecap="square" fill="none"/>
     <line x1="100.8" y1="143.0" x2="109.2" y2="143.0" stroke="#7dcfff" stroke-width="1.5" stroke-linecap="square" fill="none"/>
     <path d="M109.2,143.0 H113.4 V132.0" stroke="#7dcfff" stroke-width="1.5" stroke-linecap="square" fill="none"/>
-    <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="198" xml:space="preserve"><tspan fill="#c0caf5">  nForma </tspan><tspan fill="#c0caf5">— Consensus before code. Proof before production. </tspan><tspan fill="#565f89">v0.43.0-rc.1</tspan></text>
+    <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="198" xml:space="preserve"><tspan fill="#c0caf5">  nForma </tspan><tspan fill="#c0caf5">— Consensus before code. Proof before production. </tspan><tspan fill="#565f89">v0.43.0</tspan></text>
     <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="220" xml:space="preserve"><tspan fill="#565f89">  Built on GSD-CC by TÂCHES.</tspan></text>
     <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="264" xml:space="preserve"><tspan fill="#7dcfff">  The task of leadership is to create an alignment of strengths</tspan></text>
     <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="286" xml:space="preserve"><tspan fill="#7dcfff">   so strong that it makes the system’s weaknesses irrelevant.</tspan></text>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nforma.ai/nforma",
-  "version": "0.43.0-rc.1",
+  "version": "0.43.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nforma.ai/nforma",
-      "version": "0.43.0-rc.1",
+      "version": "0.43.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nforma.ai/nforma",
-  "version": "0.43.0-rc.1",
+  "version": "0.43.0",
   "description": "nForma — Multi-agent coding orchestrator with quorum consensus and formal verification (TLA+, Alloy, PRISM). Consensus before code, proof before production.",
   "bin": {
     "nforma": "bin/nforma-cli.js",


### PR DESCRIPTION
## Summary
- Fix fan-out import logic in `/nf:link-daintree` where presets were silently skipped because `findVanilla()` returned `[]` when the inferred family didn't match any vanilla slot's `provider` field
- When family match exists → use it; when it doesn't → fall back to all candidates (not an empty array)

## Test plan
- [ ] Run `/nf:link-daintree` with a Daintree config that has presets for an agent whose vanilla slots have `provider=claude` (not `anthropic`) — confirm presets are imported, not skipped
- [ ] Re-run `/nf:link-daintree` — confirm idempotency (existing preset-linked slots updated in place, no duplicates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI installer now uses manifest-driven detection for improved setup reliability.

* **Bug Fixes**
  * Fixed preset fan-out fallback behavior to properly handle provider selection.
  * Fixed JSON conflict-marker parsing issue.
  * Fixed default retry settings configuration.

* **Chores**
  * Version 0.43.0 released as stable (previously pre-release).
  * Version 0.43.1 released with fallback behavior refinement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->