### PR TITLE
fix(link-daintree): correct family-gate fallback in fan-out import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.43.1] - 2026-05-03
+
+### Fixed
+- fix(link-daintree): fan-out fallback logic no longer silently drops presets when no vanilla provider has a matching `provider` field — the family gate is now correctly bypassed when the inferred family doesn't match any vanilla slot, falling back to all candidates sorted by daintree_preset_id then numeric suffix
+
 ## [0.43.0] - 2026-05-02
 
 ### Changed

--- a/commands/nf/link-daintree.md
+++ b/commands/nf/link-daintree.md
@@ -482,7 +482,7 @@ function inferFamily(envObj) {
 function findVanilla(agentName, family) {
   const candidates = providersData.providers.filter(p => p.mainTool === agentName);
   const familyMatch = family ? candidates.filter(p => p.provider === family) : candidates;
-  const pool = familyMatch.length ? familyMatch : (family ? [] : candidates);
+  const pool = familyMatch.length ? familyMatch : candidates;
   // Prefer provider without daintree_preset_id, then lowest numeric suffix
   pool.sort((a, b) => {
     const aIsClone = !!a.daintree_preset_id;


### PR DESCRIPTION
## Summary
- Fix fan-out import logic in `/nf:link-daintree` where presets were silently skipped because `findVanilla()` returned `[]` when the inferred family didn't match any vanilla slot's `provider` field
- When family match exists → use it; when it doesn't → fall back to all candidates (not an empty array)

## Test plan
- [ ] Run `/nf:link-daintree` with a Daintree config that has presets for an agent whose vanilla slots have `provider=claude` (not `anthropic`) — confirm presets are imported, not skipped
- [ ] Re-run `/nf:link-daintree` — confirm idempotency (existing preset-linked slots updated in place, no duplicates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 0.43.1

* **Bug Fixes**
  * Fixed fallback logic that could silently drop presets when certain provider matching conditions weren't met. Presets are now properly retained and processed using an improved fallback mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->