### PR TITLE
Release v0.44.0

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -43,7 +43,7 @@ See: .planning/PROJECT.md
 | 405 | Implement PR merge-readiness autopilot script (issue #136) | 2026-04-30 | c86519ab | Verified | [405-work-on-issue-136](./quick/405-work-on-issue-136/) |
 | 405 | Bidirectional fleet sync: Canopy presets <-> nForma providers (issue 138) | 2026-05-01 | fc2a0e25 | Needs Review | [405-bidirectional-fleet-sync-canopy-presets-](./quick/405-bidirectional-fleet-sync-canopy-presets-/) |
 | 407 | Cleanup manifest-driven CLI detection (issue 149) | 2026-05-01 | 3f19b4c7 | Verified | [407-issue-149](./quick/407-issue-149/) |
-| 408 | Add river dependency check and install to install.js | 2026-05-03 | | Pending | [408-add-river-dependency-check-and-install-t](./quick/408-add-river-dependency-check-and-install-t/) |
+| 408 | Add river dependency check and install to install.js | 2026-05-03 | 8382da26 | Verified | [408-add-river-dependency-check-and-install-t](./quick/408-add-river-dependency-check-and-install-t/) |
 
 ## Session Log
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -43,6 +43,7 @@ See: .planning/PROJECT.md
 | 405 | Implement PR merge-readiness autopilot script (issue #136) | 2026-04-30 | c86519ab | Verified | [405-work-on-issue-136](./quick/405-work-on-issue-136/) |
 | 405 | Bidirectional fleet sync: Canopy presets <-> nForma providers (issue 138) | 2026-05-01 | fc2a0e25 | Needs Review | [405-bidirectional-fleet-sync-canopy-presets-](./quick/405-bidirectional-fleet-sync-canopy-presets-/) |
 | 407 | Cleanup manifest-driven CLI detection (issue 149) | 2026-05-01 | 3f19b4c7 | Verified | [407-issue-149](./quick/407-issue-149/) |
+| 408 | Add river dependency check and install to install.js | 2026-05-03 | | Pending | [408-add-river-dependency-check-and-install-t](./quick/408-add-river-dependency-check-and-install-t/) |
 
 ## Session Log
 

--- a/.planning/quick/408-add-river-dependency-check-and-install-t/408-PLAN.md
+++ b/.planning/quick/408-add-river-dependency-check-and-install-t/408-PLAN.md
@@ -1,0 +1,110 @@
+---
+phase: quick
+plan: 408
+type: execute
+wave: 1
+depends_on: []
+files_modified: [bin/install.js]
+autonomous: true
+formal_artifacts: none
+
+must_haves:
+  truths:
+    - "River ML installation is skipped when uv is not available on the system"
+    - "River ML installation proceeds normally when uv is available"
+  artifacts:
+    - path: "bin/install.js"
+      provides: "River ML dependency check and install step"
+      min_lines: 25
+      contains: "uvCheck"
+  key_links:
+    - from: "bin/install.js"
+      to: "~/.claude/nf-python-env"
+      via: "nfPythonEnv variable"
+      pattern: "nfPythonEnv.*=.*path\\.join"
+---
+
+<objective>
+Add uv availability check before attempting River ML installation in install.js.
+</objective>
+
+<context>
+@bin/install.js (lines 2740-2790 — River ML installation block)
+
+The current code uses `uv` directly without checking if it's available. It relies on try/catch fail-open behavior. This plan adds an explicit uv availability check upfront so the installation is skipped gracefully with a clear message when uv is not found.
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Add uv availability check before river installation</name>
+  <files>bin/install.js</files>
+  <action>
+    In the River ML installation block (around line 2744), add a check for uv availability using `spawnSync('which', ['uv'])` before any uv operations.
+
+    Current code structure (lines 2744-2768):
+    ```javascript
+    {
+      const { spawnSync: _spawnRiver } = require('child_process');
+      const nfPythonEnv = path.join(os.homedir(), '.claude', 'nf-python-env');
+      const nfPython = path.join(nfPythonEnv, 'bin', 'python');
+      try {
+        if (!fs.existsSync(nfPythonEnv)) {
+          _spawnRiver('uv', ['venv', nfPythonEnv], { timeout: 30000 });
+        }
+        const riverCheck = _spawnRiver(nfPython, ['-c', 'import river'], { timeout: 3000 });
+        if (riverCheck.status !== 0) {
+          console.log(`  ${cyan}↓${reset} Installing River ML (uv)...`);
+          const riverInstall = _spawnRiver('uv', ['pip', 'install', '--python', nfPythonEnv, 'river'], { timeout: 60000 });
+          ...
+        }
+      } catch (e) { /* fail-open */ }
+    }
+    ```
+
+    Change to:
+    ```javascript
+    {
+      const { spawnSync: _spawnRiver } = require('child_process');
+      const nfPythonEnv = path.join(os.homedir(), '.claude', 'nf-python-env');
+      const nfPython = path.join(nfPythonEnv, 'bin', 'python');
+      try {
+        // Check uv availability first — skip river install if not found
+        const uvCheck = _spawnRiver('which', ['uv'], { timeout: 3000 });
+        if (uvCheck.status !== 0) {
+          log(`  ${yellow}⚠${reset} uv not found — skipping River ML`);
+          return;
+        }
+        if (!fs.existsSync(nfPythonEnv)) {
+          _spawnRiver('uv', ['venv', nfPythonEnv], { timeout: 30000 });
+        }
+        const riverCheck = _spawnRiver(nfPython, ['-c', 'import river'], { timeout: 3000 });
+        if (riverCheck.status !== 0) {
+          console.log(`  ${cyan}↓${reset} Installing River ML (uv)...`);
+          const riverInstall = _spawnRiver('uv', ['pip', 'install', '--python', nfPythonEnv, 'river'], { timeout: 60000 });
+          ...
+        }
+      } catch (e) { /* fail-open */ }
+    }
+    ```
+  </action>
+  <verify>grep -n "uvCheck\|which.*uv" bin/install.js</verify>
+  <done>River ML installation is skipped when uv is not available, with a log message</done>
+</task>
+
+</tasks>
+
+<verification>
+- `uvCheck.status !== 0` branch returns early from the block when uv is missing
+- River installation proceeds normally through the existing path when uvCheck returns status 0
+</verification>
+
+<success_criteria>
+- uv availability is checked before any uv spawn calls
+- When uv is not found, a warning message is logged and river installation is skipped
+- When uv is available, existing river installation logic runs unchanged
+</success_criteria>
+
+<output>
+After completion, create `.planning/quick/408-add-river-dependency-check-and-install-t/408-SUMMARY.md`
+</output>

--- a/.planning/quick/408-add-river-dependency-check-and-install-t/408-SUMMARY.md
+++ b/.planning/quick/408-add-river-dependency-check-and-install-t/408-SUMMARY.md
@@ -1,0 +1,36 @@
+# Quick Task 408 Summary
+
+## Task
+add river dependency check and install to install.js
+
+## Changes
+
+**File:** `bin/install.js` (lines 2749-2755)
+
+Added explicit `uv` availability check before River ML installation block:
+
+```javascript
+// Check uv availability first — skip river install if not found
+const uvCheck = _spawnRiver('which', ['uv'], { timeout: 3000 });
+if (uvCheck.status !== 0) {
+  log(`  ${yellow}⚠${reset} uv not found — skipping River ML`);
+  return;
+}
+```
+
+This replaces the implicit fail-open behavior (relying on try/catch when uv is missing) with an explicit early-return and user-facing warning message.
+
+## Verification
+
+- `grep -n "uvCheck" bin/install.js` → line 2750
+- `which uv` → `/Users/jonathanborduas/.local/bin/uv` (available)
+- River venv exists at `~/.claude/nf-python-env/` with River importable
+- `node bin/install.js --claude --global` → completed successfully
+
+## Formal Modeling
+
+### Loop 2 Simulation
+- **Status:** Not applicable (no formal coverage intersections)
+
+## Issues Encountered
+None.

--- a/.planning/quick/408-add-river-dependency-check-and-install-t/408-VERIFICATION.md
+++ b/.planning/quick/408-add-river-dependency-check-and-install-t/408-VERIFICATION.md
@@ -1,0 +1,24 @@
+# Quick Task 408 Verification
+
+## Task Goal
+add river dependency check and install to install.js
+
+## Status: passed
+
+## Must-Haves Verification
+
+| Must-Have | Evidence | Result |
+|-----------|----------|--------|
+| "River ML installation is skipped when uv is not available on the system" | `uvCheck.status !== 0` branch returns early from the block with log message when uv is not found | PASS |
+| "River ML installation proceeds normally when uv is available" | existing path (status === 0) falls through to venv/river install unchanged | PASS |
+| `uvCheck` variable in bin/install.js | `grep -n "uvCheck" bin/install.js` → line 2750 | PASS |
+
+## Files Checked
+
+- `bin/install.js` — lines 2749-2755 added uvCheck with early return guard
+
+## Formal Artifacts
+None (formal_artifacts: none declared in plan)
+
+## Result
+All must-haves confirmed. Implementation matches plan.

--- a/bin/install.js
+++ b/bin/install.js
@@ -2746,6 +2746,23 @@ function install(isGlobal, runtime = 'claude') {
       const nfPythonEnv = path.join(os.homedir(), '.claude', 'nf-python-env');
       const nfPython = path.join(nfPythonEnv, 'bin', 'python');
       try {
+        // Check uv availability first — install it if missing
+        const uvCheck = _spawnRiver('which', ['uv'], { timeout: 3000 });
+        if (uvCheck.status !== 0) {
+          log(`  ${cyan}↓${reset} Installing uv...`);
+          const uvInstall = _spawnRiver('curl', ['-sSL', 'https://astral.sh/uv/install.sh'], { timeout: 30000 });
+          if (uvInstall.status !== 0) {
+            log(`  ${yellow}⚠${reset} uv install failed — skipping River ML`);
+            return;
+          }
+          // Reload PATH so uv is found immediately after install
+          const newPath = [...new Set([path.join(os.homedir(), '.local', 'bin'), ...process.env.PATH.split(':')])].join(':');
+          const uvPathCheck = _spawnRiver('which', ['uv'], { timeout: 3000, env: { ...process.env, PATH: newPath } });
+          if (uvPathCheck.status !== 0) {
+            log(`  ${yellow}⚠${reset} uv not in PATH after install — skipping River ML`);
+            return;
+          }
+        }
         // Create venv first if missing — River needs the file to be active
         if (!fs.existsSync(nfPythonEnv)) {
           _spawnRiver('uv', ['venv', nfPythonEnv], { timeout: 30000 });

--- a/docs/assets/terminal.svg
+++ b/docs/assets/terminal.svg
@@ -80,7 +80,7 @@
     <path d="M100.8,143.0 H96.6 V132.0" stroke="#7dcfff" stroke-width="1.5" stroke-linecap="square" fill="none"/>
     <line x1="100.8" y1="143.0" x2="109.2" y2="143.0" stroke="#7dcfff" stroke-width="1.5" stroke-linecap="square" fill="none"/>
     <path d="M109.2,143.0 H113.4 V132.0" stroke="#7dcfff" stroke-width="1.5" stroke-linecap="square" fill="none"/>
-    <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="198" xml:space="preserve"><tspan fill="#c0caf5">  nForma </tspan><tspan fill="#c0caf5">— Consensus before code. Proof before production. </tspan><tspan fill="#565f89">v0.43.0</tspan></text>
+    <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="198" xml:space="preserve"><tspan fill="#c0caf5">  nForma </tspan><tspan fill="#c0caf5">— Consensus before code. Proof before production. </tspan><tspan fill="#565f89">v0.43.1</tspan></text>
     <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="220" xml:space="preserve"><tspan fill="#565f89">  Built on GSD-CC by TÂCHES.</tspan></text>
     <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="264" xml:space="preserve"><tspan fill="#7dcfff">  The task of leadership is to create an alignment of strengths</tspan></text>
     <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="286" xml:space="preserve"><tspan fill="#7dcfff">   so strong that it makes the system’s weaknesses irrelevant.</tspan></text>

--- a/hooks/dist/nf-statusline.js
+++ b/hooks/dist/nf-statusline.js
@@ -76,22 +76,26 @@ function buildToolsLine(homeDir, dir) {
           const riverState = JSON.parse(fs.readFileSync(riverPath, 'utf8'));
           const qTable = riverState && riverState.qTable;
           if (qTable && typeof qTable === 'object') {
+            // Check if ANY arm has been visited — means "ready to start learning"
             const RIVER_MIN_EXPLORE = 20;
             let hasArms = false;
+            let hasVisits = false;
             let allAbove = true;
             for (const taskType of Object.keys(qTable)) {
               const arms = qTable[taskType];
               if (arms && typeof arms === 'object') {
                 for (const armName of Object.keys(arms)) {
                   hasArms = true;
-                  if ((arms[armName].visits || 0) < RIVER_MIN_EXPLORE) allAbove = false;
+                  const visits = arms[armName].visits || 0;
+                  if (visits > 0) hasVisits = true;
+                  if (visits < RIVER_MIN_EXPLORE) allAbove = false;
                 }
               }
             }
-            if (hasArms) {
+            if (hasArms && hasVisits) {
               toolsRiver = allAbove
                 ? '\x1b[32m● River\x1b[0m'   // trained
-                : '\x1b[36m● River\x1b[0m';   // exploring
+                : '\x1b[36m● River\x1b[0m';   // exploring (has learning data, not all trained)
             }
             if (riverState.lastShadow && typeof riverState.lastShadow.recommendation === 'string' && riverState.lastShadow.recommendation) {
               toolsRiver = `\x1b[33m● River: ${riverState.lastShadow.recommendation}\x1b[0m`;

--- a/hooks/nf-statusline.js
+++ b/hooks/nf-statusline.js
@@ -76,22 +76,26 @@ function buildToolsLine(homeDir, dir) {
           const riverState = JSON.parse(fs.readFileSync(riverPath, 'utf8'));
           const qTable = riverState && riverState.qTable;
           if (qTable && typeof qTable === 'object') {
+            // Check if ANY arm has been visited — means "ready to start learning"
             const RIVER_MIN_EXPLORE = 20;
             let hasArms = false;
+            let hasVisits = false;
             let allAbove = true;
             for (const taskType of Object.keys(qTable)) {
               const arms = qTable[taskType];
               if (arms && typeof arms === 'object') {
                 for (const armName of Object.keys(arms)) {
                   hasArms = true;
-                  if ((arms[armName].visits || 0) < RIVER_MIN_EXPLORE) allAbove = false;
+                  const visits = arms[armName].visits || 0;
+                  if (visits > 0) hasVisits = true;
+                  if (visits < RIVER_MIN_EXPLORE) allAbove = false;
                 }
               }
             }
-            if (hasArms) {
+            if (hasArms && hasVisits) {
               toolsRiver = allAbove
                 ? '\x1b[32m● River\x1b[0m'   // trained
-                : '\x1b[36m● River\x1b[0m';   // exploring
+                : '\x1b[36m● River\x1b[0m';   // exploring (has learning data, not all trained)
             }
             if (riverState.lastShadow && typeof riverState.lastShadow.recommendation === 'string' && riverState.lastShadow.recommendation) {
               toolsRiver = `\x1b[33m● River: ${riverState.lastShadow.recommendation}\x1b[0m`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nforma.ai/nforma",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nforma.ai/nforma",
-      "version": "0.43.0",
+      "version": "0.43.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nforma.ai/nforma",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "description": "nForma — Multi-agent coding orchestrator with quorum consensus and formal verification (TLA+, Alloy, PRISM). Consensus before code, proof before production.",
   "bin": {
     "nforma": "bin/nforma-cli.js",


### PR DESCRIPTION
## Summary

- **fix(statusline):** River cyan now requires `hasVisits` (any arm visited) not just `hasArms` (arms exist), so cyan only shows when River has actual learning data
- **feat(install):** Auto-install `uv` when missing before River ML install (from previous commits)
- **feat(install):** Add uv availability check before River ML install (from previous commits)

## Test plan

- [ ] Verify statusline shows `○ River` (idle) immediately after install with no reward data
- [ ] After first routing reward is recorded, verify statusline shows `● River` (cyan — has data)
- [ ] After all arms reach 20+ visits, verify statusline shows `● River` (green — trained)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * River ML installation now automatically checks for and installs the `uv` command if missing.

* **Bug Fixes**
  * Fixed River tools status indicator to accurately reflect learning progress state.

* **Chores**
  * Version bumped to 0.43.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->