### PR TITLE
fix(link-daintree): always register health_check + smoke-probe new slots

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -43,7 +43,7 @@ See: .planning/PROJECT.md
 | 405 | Implement PR merge-readiness autopilot script (issue #136) | 2026-04-30 | c86519ab | Verified | [405-work-on-issue-136](./quick/405-work-on-issue-136/) |
 | 405 | Bidirectional fleet sync: Canopy presets <-> nForma providers (issue 138) | 2026-05-01 | fc2a0e25 | Needs Review | [405-bidirectional-fleet-sync-canopy-presets-](./quick/405-bidirectional-fleet-sync-canopy-presets-/) |
 | 407 | Cleanup manifest-driven CLI detection (issue 149) | 2026-05-01 | 3f19b4c7 | Verified | [407-issue-149](./quick/407-issue-149/) |
-| 408 | Add river dependency check and install to install.js | 2026-05-03 | | Pending | [408-add-river-dependency-check-and-install-t](./quick/408-add-river-dependency-check-and-install-t/) |
+| 408 | Add river dependency check and install to install.js | 2026-05-03 | 8382da26 | Verified | [408-add-river-dependency-check-and-install-t](./quick/408-add-river-dependency-check-and-install-t/) |
 
 ## Session Log
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -43,6 +43,7 @@ See: .planning/PROJECT.md
 | 405 | Implement PR merge-readiness autopilot script (issue #136) | 2026-04-30 | c86519ab | Verified | [405-work-on-issue-136](./quick/405-work-on-issue-136/) |
 | 405 | Bidirectional fleet sync: Canopy presets <-> nForma providers (issue 138) | 2026-05-01 | fc2a0e25 | Needs Review | [405-bidirectional-fleet-sync-canopy-presets-](./quick/405-bidirectional-fleet-sync-canopy-presets-/) |
 | 407 | Cleanup manifest-driven CLI detection (issue 149) | 2026-05-01 | 3f19b4c7 | Verified | [407-issue-149](./quick/407-issue-149/) |
+| 408 | Add river dependency check and install to install.js | 2026-05-03 | | Pending | [408-add-river-dependency-check-and-install-t](./quick/408-add-river-dependency-check-and-install-t/) |
 
 ## Session Log
 

--- a/.planning/quick/408-add-river-dependency-check-and-install-t/408-PLAN.md
+++ b/.planning/quick/408-add-river-dependency-check-and-install-t/408-PLAN.md
@@ -1,0 +1,110 @@
+---
+phase: quick
+plan: 408
+type: execute
+wave: 1
+depends_on: []
+files_modified: [bin/install.js]
+autonomous: true
+formal_artifacts: none
+
+must_haves:
+  truths:
+    - "River ML installation is skipped when uv is not available on the system"
+    - "River ML installation proceeds normally when uv is available"
+  artifacts:
+    - path: "bin/install.js"
+      provides: "River ML dependency check and install step"
+      min_lines: 25
+      contains: "uvCheck"
+  key_links:
+    - from: "bin/install.js"
+      to: "~/.claude/nf-python-env"
+      via: "nfPythonEnv variable"
+      pattern: "nfPythonEnv.*=.*path\\.join"
+---
+
+<objective>
+Add uv availability check before attempting River ML installation in install.js.
+</objective>
+
+<context>
+@bin/install.js (lines 2740-2790 — River ML installation block)
+
+The current code uses `uv` directly without checking if it's available. It relies on try/catch fail-open behavior. This plan adds an explicit uv availability check upfront so the installation is skipped gracefully with a clear message when uv is not found.
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Add uv availability check before river installation</name>
+  <files>bin/install.js</files>
+  <action>
+    In the River ML installation block (around line 2744), add a check for uv availability using `spawnSync('which', ['uv'])` before any uv operations.
+
+    Current code structure (lines 2744-2768):
+    ```javascript
+    {
+      const { spawnSync: _spawnRiver } = require('child_process');
+      const nfPythonEnv = path.join(os.homedir(), '.claude', 'nf-python-env');
+      const nfPython = path.join(nfPythonEnv, 'bin', 'python');
+      try {
+        if (!fs.existsSync(nfPythonEnv)) {
+          _spawnRiver('uv', ['venv', nfPythonEnv], { timeout: 30000 });
+        }
+        const riverCheck = _spawnRiver(nfPython, ['-c', 'import river'], { timeout: 3000 });
+        if (riverCheck.status !== 0) {
+          console.log(`  ${cyan}↓${reset} Installing River ML (uv)...`);
+          const riverInstall = _spawnRiver('uv', ['pip', 'install', '--python', nfPythonEnv, 'river'], { timeout: 60000 });
+          ...
+        }
+      } catch (e) { /* fail-open */ }
+    }
+    ```
+
+    Change to:
+    ```javascript
+    {
+      const { spawnSync: _spawnRiver } = require('child_process');
+      const nfPythonEnv = path.join(os.homedir(), '.claude', 'nf-python-env');
+      const nfPython = path.join(nfPythonEnv, 'bin', 'python');
+      try {
+        // Check uv availability first — skip river install if not found
+        const uvCheck = _spawnRiver('which', ['uv'], { timeout: 3000 });
+        if (uvCheck.status !== 0) {
+          log(`  ${yellow}⚠${reset} uv not found — skipping River ML`);
+          return;
+        }
+        if (!fs.existsSync(nfPythonEnv)) {
+          _spawnRiver('uv', ['venv', nfPythonEnv], { timeout: 30000 });
+        }
+        const riverCheck = _spawnRiver(nfPython, ['-c', 'import river'], { timeout: 3000 });
+        if (riverCheck.status !== 0) {
+          console.log(`  ${cyan}↓${reset} Installing River ML (uv)...`);
+          const riverInstall = _spawnRiver('uv', ['pip', 'install', '--python', nfPythonEnv, 'river'], { timeout: 60000 });
+          ...
+        }
+      } catch (e) { /* fail-open */ }
+    }
+    ```
+  </action>
+  <verify>grep -n "uvCheck\|which.*uv" bin/install.js</verify>
+  <done>River ML installation is skipped when uv is not available, with a log message</done>
+</task>
+
+</tasks>
+
+<verification>
+- `uvCheck.status !== 0` branch returns early from the block when uv is missing
+- River installation proceeds normally through the existing path when uvCheck returns status 0
+</verification>
+
+<success_criteria>
+- uv availability is checked before any uv spawn calls
+- When uv is not found, a warning message is logged and river installation is skipped
+- When uv is available, existing river installation logic runs unchanged
+</success_criteria>
+
+<output>
+After completion, create `.planning/quick/408-add-river-dependency-check-and-install-t/408-SUMMARY.md`
+</output>

--- a/.planning/quick/408-add-river-dependency-check-and-install-t/408-SUMMARY.md
+++ b/.planning/quick/408-add-river-dependency-check-and-install-t/408-SUMMARY.md
@@ -1,0 +1,36 @@
+# Quick Task 408 Summary
+
+## Task
+add river dependency check and install to install.js
+
+## Changes
+
+**File:** `bin/install.js` (lines 2749-2755)
+
+Added explicit `uv` availability check before River ML installation block:
+
+```javascript
+// Check uv availability first — skip river install if not found
+const uvCheck = _spawnRiver('which', ['uv'], { timeout: 3000 });
+if (uvCheck.status !== 0) {
+  log(`  ${yellow}⚠${reset} uv not found — skipping River ML`);
+  return;
+}
+```
+
+This replaces the implicit fail-open behavior (relying on try/catch when uv is missing) with an explicit early-return and user-facing warning message.
+
+## Verification
+
+- `grep -n "uvCheck" bin/install.js` → line 2750
+- `which uv` → `/Users/jonathanborduas/.local/bin/uv` (available)
+- River venv exists at `~/.claude/nf-python-env/` with River importable
+- `node bin/install.js --claude --global` → completed successfully
+
+## Formal Modeling
+
+### Loop 2 Simulation
+- **Status:** Not applicable (no formal coverage intersections)
+
+## Issues Encountered
+None.

--- a/.planning/quick/408-add-river-dependency-check-and-install-t/408-VERIFICATION.md
+++ b/.planning/quick/408-add-river-dependency-check-and-install-t/408-VERIFICATION.md
@@ -1,0 +1,24 @@
+# Quick Task 408 Verification
+
+## Task Goal
+add river dependency check and install to install.js
+
+## Status: passed
+
+## Must-Haves Verification
+
+| Must-Have | Evidence | Result |
+|-----------|----------|--------|
+| "River ML installation is skipped when uv is not available on the system" | `uvCheck.status !== 0` branch returns early from the block with log message when uv is not found | PASS |
+| "River ML installation proceeds normally when uv is available" | existing path (status === 0) falls through to venv/river install unchanged | PASS |
+| `uvCheck` variable in bin/install.js | `grep -n "uvCheck" bin/install.js` → line 2750 | PASS |
+
+## Files Checked
+
+- `bin/install.js` — lines 2749-2755 added uvCheck with early return guard
+
+## Formal Artifacts
+None (formal_artifacts: none declared in plan)
+
+## Result
+All must-haves confirmed. Implementation matches plan.

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -362,14 +362,14 @@
         "filename": "bin/unified-mcp-server.mjs",
         "hashed_secret": "f8ca0d7266886f4b5be9adddc9b66017b3bf1a4b",
         "is_verified": false,
-        "line_number": 486
+        "line_number": 484
       },
       {
         "type": "Secret Keyword",
         "filename": "bin/unified-mcp-server.mjs",
         "hashed_secret": "138901a352fddde83a010e609f2091c5ebaad7bd",
         "is_verified": false,
-        "line_number": 916
+        "line_number": 914
       }
     ],
     "bin/validate-debt-entry.test.cjs": [
@@ -391,5 +391,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-01T19:11:19Z"
+  "generated_at": "2026-05-12T12:09:20Z"
 }

--- a/bin/install.js
+++ b/bin/install.js
@@ -2746,6 +2746,23 @@ function install(isGlobal, runtime = 'claude') {
       const nfPythonEnv = path.join(os.homedir(), '.claude', 'nf-python-env');
       const nfPython = path.join(nfPythonEnv, 'bin', 'python');
       try {
+        // Check uv availability first — install it if missing
+        const uvCheck = _spawnRiver('which', ['uv'], { timeout: 3000 });
+        if (uvCheck.status !== 0) {
+          log(`  ${cyan}↓${reset} Installing uv...`);
+          const uvInstall = _spawnRiver('curl', ['-sSL', 'https://astral.sh/uv/install.sh'], { timeout: 30000 });
+          if (uvInstall.status !== 0) {
+            log(`  ${yellow}⚠${reset} uv install failed — skipping River ML`);
+            return;
+          }
+          // Reload PATH so uv is found immediately after install
+          const newPath = [...new Set([path.join(os.homedir(), '.local', 'bin'), ...process.env.PATH.split(':')])].join(':');
+          const uvPathCheck = _spawnRiver('which', ['uv'], { timeout: 3000, env: { ...process.env, PATH: newPath } });
+          if (uvPathCheck.status !== 0) {
+            log(`  ${yellow}⚠${reset} uv not in PATH after install — skipping River ML`);
+            return;
+          }
+        }
         // Create venv first if missing — River needs the file to be active
         if (!fs.existsSync(nfPythonEnv)) {
           _spawnRiver('uv', ['venv', nfPythonEnv], { timeout: 30000 });

--- a/bin/providers.json
+++ b/bin/providers.json
@@ -1,3 +1,582 @@
 {
-  "providers": []
+  "providers": [
+    {
+      "name": "codex-1",
+      "provider": "openai",
+      "type": "subprocess",
+      "auth_type": "sub",
+      "has_file_access": true,
+      "description": "Execute Codex CLI agent non-interactively (slot 1)",
+      "mainTool": "codex",
+      "model": "gpt-5.4",
+      "model_detect": {
+        "file": "~/.codex/config.toml",
+        "pattern": "^model = \"([^\"]+)\""
+      },
+      "health_check_args": [
+        "--version"
+      ],
+      "display_provider": "OpenAI",
+      "cli": null,
+      "args_template": [
+        "exec",
+        "{prompt}"
+      ],
+      "helpArgs": [
+        "--help"
+      ],
+      "extraTools": [
+        {
+          "name": "review",
+          "description": "Run a code review against the current repository using Codex CLI",
+          "args_template": [
+            "review",
+            "{prompt}"
+          ]
+        }
+      ],
+      "timeout_ms": 300000,
+      "quorum_timeout_ms": 300000,
+      "idle_timeout_ms": 30000,
+      "hard_timeout_ms": 600000,
+      "latency_budget_ms": null,
+      "env": {},
+      "display_type": "codex-cli",
+      "auth_check": {
+        "args": [
+          "login",
+          "status"
+        ],
+        "success_pattern": "Logged in",
+        "login_args": [
+          "login"
+        ],
+        "login_hint": "Opens browser for OpenAI authentication",
+        "timeout_ms": 5000
+      },
+      "oauth_rotation": {
+        "enabled": true,
+        "creds_dir": "~/.codex/accounts",
+        "active_file": "~/.codex/auth.json",
+        "max_retries": 3,
+        "retry_on_patterns": [
+          "quota",
+          "rate_limit",
+          "unauthorized",
+          "401",
+          "429",
+          "refresh_token_reused",
+          "token_expired"
+        ],
+        "rotate_cmd": [
+          "node",
+          "bin/account-manager.cjs",
+          "switch",
+          "next",
+          "--provider",
+          "codex-1"
+        ]
+      },
+      "deep_probe": {
+        "prompt": "respond with: PROBE_OK",
+        "expect": "PROBE_OK",
+        "timeout_ms": 45000
+      }
+    },
+    {
+      "name": "gemini-1",
+      "provider": "google",
+      "type": "subprocess",
+      "auth_type": "sub",
+      "has_file_access": true,
+      "description": "Query Gemini CLI agent non-interactively (slot 1)",
+      "mainTool": "gemini",
+      "model": "gemini-3-flash-preview",
+      "health_check_args": [
+        "--version"
+      ],
+      "display_provider": "Google",
+      "cli": null,
+      "args_template": [
+        "-m",
+        "gemini-3-flash-preview",
+        "-p",
+        "{prompt}"
+      ],
+      "helpArgs": [
+        "--help"
+      ],
+      "extraTools": [],
+      "timeout_ms": 300000,
+      "quorum_timeout_ms": 300000,
+      "idle_timeout_ms": 45000,
+      "hard_timeout_ms": 600000,
+      "latency_budget_ms": null,
+      "env": {},
+      "display_type": "gemini-cli",
+      "auth_check": {
+        "args": [
+          "auth",
+          "print-access-token"
+        ],
+        "success_pattern": "Loaded cached credentials|ya29\\.",
+        "login_args": [
+          "auth",
+          "login"
+        ],
+        "login_hint": "Opens browser for Google authentication",
+        "timeout_ms": 5000
+      },
+      "oauth_rotation": {
+        "enabled": true,
+        "creds_dir": "~/.gemini/accounts",
+        "active_file": "~/.gemini/oauth_creds.json",
+        "max_retries": 3,
+        "retry_on_patterns": [
+          "quota",
+          "resource_exhausted",
+          "unauthorized",
+          "401",
+          "403",
+          "429"
+        ],
+        "rotate_cmd": [
+          "node",
+          "bin/account-manager.cjs",
+          "switch",
+          "next",
+          "--provider",
+          "gemini-1"
+        ]
+      },
+      "deep_probe": {
+        "prompt": "respond with: PROBE_OK",
+        "expect": "PROBE_OK",
+        "timeout_ms": 45000
+      }
+    },
+    {
+      "name": "opencode-1",
+      "provider": "xai",
+      "type": "subprocess",
+      "auth_type": "sub",
+      "has_file_access": true,
+      "description": "Run OpenCode agent non-interactively with a message",
+      "mainTool": "opencode",
+      "model": "grok-code-fast-1",
+      "model_detect": {
+        "file": "~/.local/state/opencode/model.json",
+        "pattern": "\"recent\":\\[{\"providerID\":\"[^\"]*\",\"modelID\":\"([^\"]+)\""
+      },
+      "health_check_args": [
+        "--version"
+      ],
+      "display_provider": "OpenCode",
+      "cli": null,
+      "args_template": [
+        "run",
+        "--print-logs",
+        "--log-level",
+        "ERROR",
+        "{prompt}"
+      ],
+      "helpArgs": [
+        "--help"
+      ],
+      "extraTools": [
+        {
+          "name": "opencode_check_update",
+          "description": "Check whether a newer version of OpenCode is available on npm. Returns current version, latest version, and whether an update is available.",
+          "checkUpdate": true
+        }
+      ],
+      "timeout_ms": 300000,
+      "quorum_timeout_ms": 300000,
+      "idle_timeout_ms": 20000,
+      "hard_timeout_ms": 600000,
+      "latency_budget_ms": null,
+      "env": {},
+      "display_type": "opencode-cli",
+      "auth_check": {
+        "args": [
+          "auth",
+          "list"
+        ],
+        "success_pattern": "api|oauth",
+        "login_args": [
+          "auth",
+          "login"
+        ],
+        "login_hint": "Configure provider credentials for OpenCode",
+        "timeout_ms": 5000
+      },
+      "deep_probe": {
+        "prompt": "respond with: PROBE_OK",
+        "expect": "PROBE_OK",
+        "timeout_ms": 45000
+      }
+    },
+    {
+      "name": "copilot-1",
+      "provider": "github",
+      "type": "subprocess",
+      "auth_type": "sub",
+      "has_file_access": true,
+      "description": "Execute GitHub Copilot CLI non-interactively",
+      "mainTool": "ask",
+      "model": "gpt-4.1",
+      "health_check_args": [
+        "--version"
+      ],
+      "display_provider": "GitHub",
+      "cli": null,
+      "args_template": [
+        "-p",
+        "{prompt}",
+        "--allow-all-tools",
+        "--no-color",
+        "-s"
+      ],
+      "helpArgs": [
+        "--help"
+      ],
+      "extraTools": [
+        {
+          "name": "suggest",
+          "description": "Ask GitHub Copilot to suggest a shell, git, or gh CLI command for a given task.",
+          "args_template": [
+            "-p",
+            "Suggest a shell command for the following task: {prompt}",
+            "--allow-all-tools",
+            "--no-color",
+            "-s"
+          ]
+        },
+        {
+          "name": "explain",
+          "description": "Ask GitHub Copilot to explain what a shell command does in plain language.",
+          "args_template": [
+            "-p",
+            "Explain what the following shell command does: {prompt}",
+            "--allow-all-tools",
+            "--no-color",
+            "-s"
+          ]
+        }
+      ],
+      "timeout_ms": 300000,
+      "quorum_timeout_ms": 300000,
+      "idle_timeout_ms": 30000,
+      "hard_timeout_ms": 600000,
+      "latency_budget_ms": null,
+      "env": {},
+      "display_type": "copilot-cli",
+      "auth_check": {
+        "args": [
+          "--version"
+        ],
+        "success_pattern": "\\d+\\.\\d+",
+        "login_args": null,
+        "login_hint": "Copilot authenticates via GitHub CLI (gh auth login). No separate login command.",
+        "timeout_ms": 5000
+      },
+      "deep_probe": {
+        "prompt": "respond with: PROBE_OK",
+        "expect": "PROBE_OK",
+        "timeout_ms": 45000
+      }
+    },
+    {
+      "name": "claude-1",
+      "provider": "anthropic",
+      "type": "subprocess",
+      "auth_type": "sub",
+      "has_file_access": true,
+      "description": "Claude Opus via Anthropic — direct Claude CLI (non-interactive print mode)",
+      "mainTool": "claude",
+      "model": "claude-opus-4-6",
+      "display_provider": "Anthropic",
+      "cli": null,
+      "args_template": [
+        "-p",
+        "{prompt}",
+        "--model",
+        "claude-opus-4-6",
+        "--dangerously-skip-permissions"
+      ],
+      "health_check_args": [
+        "--version"
+      ],
+      "helpArgs": [
+        "--help"
+      ],
+      "extraTools": [],
+      "timeout_ms": 300000,
+      "quorum_timeout_ms": 300000,
+      "idle_timeout_ms": 90000,
+      "hard_timeout_ms": 600000,
+      "latency_budget_ms": null,
+      "max_context_tokens": 200000,
+      "max_output_tokens": 32000,
+      "env": {},
+      "display_type": "claude-cli",
+      "deep_probe": {
+        "prompt": "respond with: PROBE_OK",
+        "expect": "PROBE_OK",
+        "timeout_ms": 45000
+      }
+    },
+    {
+      "name": "ccr-1",
+      "provider": "together",
+      "type": "subprocess",
+      "auth_type": "sub",
+      "has_file_access": true,
+      "description": "MiniMax-M2.5 via Together.xyz — Claude Code Router (CCR) preset claude-1",
+      "mainTool": "claude",
+      "model": "MiniMaxAI/MiniMax-M2.5",
+      "display_provider": "Together.xyz",
+      "cli": null,
+      "args_template": [
+        "claude-1",
+        "-p",
+        "{prompt}",
+        "--dangerously-skip-permissions"
+      ],
+      "health_check_args": [
+        "-v"
+      ],
+      "helpArgs": [
+        "--help"
+      ],
+      "extraTools": [],
+      "timeout_ms": 300000,
+      "quorum_timeout_ms": 300000,
+      "idle_timeout_ms": 90000,
+      "hard_timeout_ms": 600000,
+      "latency_budget_ms": null,
+      "max_context_tokens": 131072,
+      "max_output_tokens": 4096,
+      "max_concurrency": 3,
+      "ccr_overhead_tokens": 95000,
+      "ccr_response_budget_tokens": 64000,
+      "env": {},
+      "display_type": "claude-code-router",
+      "deep_probe": {
+        "prompt": "respond with: PROBE_OK",
+        "expect": "PROBE_OK",
+        "timeout_ms": 45000
+      }
+    },
+    {
+      "name": "ccr-2",
+      "provider": "together",
+      "type": "subprocess",
+      "auth_type": "sub",
+      "has_file_access": true,
+      "description": "Qwen3.5-397B via Together.xyz — Claude Code Router (CCR) preset claude-2",
+      "mainTool": "claude",
+      "model": "Qwen/Qwen3.5-397B-A17B",
+      "display_provider": "Together.xyz",
+      "cli": null,
+      "args_template": [
+        "claude-2",
+        "-p",
+        "{prompt}",
+        "--dangerously-skip-permissions"
+      ],
+      "health_check_args": [
+        "-v"
+      ],
+      "helpArgs": [
+        "--help"
+      ],
+      "extraTools": [],
+      "timeout_ms": 300000,
+      "quorum_timeout_ms": 300000,
+      "idle_timeout_ms": 90000,
+      "hard_timeout_ms": 600000,
+      "latency_budget_ms": null,
+      "max_context_tokens": 131072,
+      "max_output_tokens": 4096,
+      "max_concurrency": 3,
+      "ccr_overhead_tokens": 95000,
+      "ccr_response_budget_tokens": 64000,
+      "env": {},
+      "display_type": "claude-code-router",
+      "deep_probe": {
+        "prompt": "respond with: PROBE_OK",
+        "expect": "PROBE_OK",
+        "timeout_ms": 45000
+      }
+    },
+    {
+      "name": "ccr-3",
+      "provider": "together",
+      "type": "subprocess",
+      "auth_type": "sub",
+      "has_file_access": true,
+      "description": "Qwen3-Coder-480B via Together.xyz — Claude Code Router (CCR) preset claude-3",
+      "mainTool": "claude",
+      "model": "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8",
+      "display_provider": "Together.xyz",
+      "cli": null,
+      "args_template": [
+        "claude-3",
+        "-p",
+        "{prompt}",
+        "--dangerously-skip-permissions"
+      ],
+      "health_check_args": [
+        "-v"
+      ],
+      "helpArgs": [
+        "--help"
+      ],
+      "extraTools": [],
+      "timeout_ms": 300000,
+      "quorum_timeout_ms": 300000,
+      "idle_timeout_ms": 90000,
+      "hard_timeout_ms": 600000,
+      "latency_budget_ms": null,
+      "max_context_tokens": 131072,
+      "max_output_tokens": 4096,
+      "max_concurrency": 3,
+      "ccr_overhead_tokens": 95000,
+      "ccr_response_budget_tokens": 64000,
+      "env": {},
+      "display_type": "claude-code-router",
+      "deep_probe": {
+        "prompt": "respond with: PROBE_OK",
+        "expect": "PROBE_OK",
+        "timeout_ms": 45000
+      }
+    },
+    {
+      "name": "ccr-4",
+      "provider": "together",
+      "type": "subprocess",
+      "auth_type": "sub",
+      "has_file_access": true,
+      "description": "Kimi-K2.5 via Together.xyz — Claude Code Router (CCR) preset claude-4",
+      "mainTool": "claude",
+      "model": "moonshotai/Kimi-K2.5",
+      "display_provider": "Together.xyz",
+      "cli": null,
+      "args_template": [
+        "claude-4",
+        "-p",
+        "{prompt}",
+        "--dangerously-skip-permissions"
+      ],
+      "health_check_args": [
+        "-v"
+      ],
+      "helpArgs": [
+        "--help"
+      ],
+      "extraTools": [],
+      "timeout_ms": 300000,
+      "quorum_timeout_ms": 300000,
+      "idle_timeout_ms": 90000,
+      "hard_timeout_ms": 600000,
+      "latency_budget_ms": null,
+      "max_context_tokens": 131072,
+      "max_output_tokens": 4096,
+      "max_concurrency": 3,
+      "ccr_overhead_tokens": 95000,
+      "ccr_response_budget_tokens": 64000,
+      "env": {},
+      "display_type": "claude-code-router",
+      "deep_probe": {
+        "prompt": "respond with: PROBE_OK",
+        "expect": "PROBE_OK",
+        "timeout_ms": 45000
+      }
+    },
+    {
+      "name": "ccr-5",
+      "provider": "together",
+      "type": "subprocess",
+      "auth_type": "sub",
+      "has_file_access": true,
+      "description": "GPT-OSS-120B via Together.xyz — Claude Code Router (CCR) preset claude-5",
+      "mainTool": "claude",
+      "model": "openai/gpt-oss-120b",
+      "display_provider": "Together.xyz",
+      "cli": null,
+      "args_template": [
+        "claude-5",
+        "-p",
+        "{prompt}",
+        "--dangerously-skip-permissions"
+      ],
+      "health_check_args": [
+        "-v"
+      ],
+      "helpArgs": [
+        "--help"
+      ],
+      "extraTools": [],
+      "timeout_ms": 300000,
+      "quorum_timeout_ms": 300000,
+      "idle_timeout_ms": 90000,
+      "hard_timeout_ms": 600000,
+      "latency_budget_ms": null,
+      "max_context_tokens": 131072,
+      "max_output_tokens": 4096,
+      "max_concurrency": 3,
+      "ccr_overhead_tokens": 95000,
+      "ccr_response_budget_tokens": 64000,
+      "env": {},
+      "display_type": "claude-code-router",
+      "deep_probe": {
+        "prompt": "respond with: PROBE_OK",
+        "expect": "PROBE_OK",
+        "timeout_ms": 45000
+      }
+    },
+    {
+      "name": "ccr-6",
+      "provider": "together",
+      "type": "subprocess",
+      "auth_type": "sub",
+      "has_file_access": true,
+      "description": "GLM-5.1 via Together.xyz — Claude Code Router (CCR) preset claude-6",
+      "mainTool": "claude",
+      "model": "zai-org/GLM-5.1",
+      "display_provider": "Together.xyz",
+      "cli": null,
+      "args_template": [
+        "claude-6",
+        "-p",
+        "{prompt}",
+        "--dangerously-skip-permissions"
+      ],
+      "health_check_args": [
+        "-v"
+      ],
+      "helpArgs": [
+        "--help"
+      ],
+      "extraTools": [],
+      "timeout_ms": 300000,
+      "quorum_timeout_ms": 300000,
+      "idle_timeout_ms": 90000,
+      "hard_timeout_ms": 600000,
+      "latency_budget_ms": null,
+      "max_context_tokens": 131072,
+      "max_output_tokens": 4096,
+      "max_concurrency": 3,
+      "ccr_overhead_tokens": 95000,
+      "ccr_response_budget_tokens": 64000,
+      "env": {},
+      "display_type": "claude-code-router",
+      "deep_probe": {
+        "prompt": "respond with: PROBE_OK",
+        "expect": "PROBE_OK",
+        "timeout_ms": 45000
+      }
+    }
+  ]
 }

--- a/bin/unified-mcp-server.mjs
+++ b/bin/unified-mcp-server.mjs
@@ -177,14 +177,13 @@ function buildSlotTools(provider) {
       });
     }
 
-    // health_check tool for subprocess providers
-    if (provider.health_check_args) {
-      tools.push({
-        name: 'health_check',
-        description: 'Test CLI availability by running a lightweight command (e.g. --version). Returns { healthy, latencyMs, type: "subprocess" }.',
-        inputSchema: NO_ARGS_SCHEMA,
-      });
-    }
+    // health_check tool for subprocess providers — always registered;
+    // execution defaults to ['--version'] when health_check_args is missing
+    tools.push({
+      name: 'health_check',
+      description: 'Test CLI availability by running a lightweight command (e.g. --version). Returns { healthy, latencyMs, type: "subprocess" }.',
+      inputSchema: NO_ARGS_SCHEMA,
+    });
 
     // deep_health_check tool for subprocess providers
     tools.push({
@@ -204,13 +203,12 @@ function buildSlotTools(provider) {
       description: 'Display CCR CLI help and available options.',
       inputSchema: NO_ARGS_SCHEMA,
     });
-    if (provider.health_check_args) {
-      tools.push({
-        name: 'health_check',
-        description: 'Test CCR binary availability. Returns { healthy, latencyMs, type: "ccr" }.',
-        inputSchema: NO_ARGS_SCHEMA,
-      });
-    }
+    // Always registered; execution defaults to ['--version'] when health_check_args is missing
+    tools.push({
+      name: 'health_check',
+      description: 'Test CCR binary availability. Returns { healthy, latencyMs, type: "ccr" }.',
+      inputSchema: NO_ARGS_SCHEMA,
+    });
 
     // deep_health_check tool for ccr providers
     tools.push({

--- a/commands/nf/link-daintree.md
+++ b/commands/nf/link-daintree.md
@@ -688,6 +688,74 @@ providers.json:
 ⚠ Restart Claude Code to pick up the new MCP servers and quorum slots.
 ```
 
+Continue to Step 2e.
+
+### Step 2e: Smoke-probe newly-added slots
+
+For each newly-added MCP server entry from Step 2d (`summary.mcpServers.added`), spawn the configured `unified-mcp-server.mjs` out-of-band with the slot's exact env and verify it (a) starts, (b) exposes `identity`, and (c) exposes `health_check`. This catches misconfigured slots **before** the user has to restart Claude Code and discover the failure manually.
+
+Pass IMPORT_RESULT to the probe via env var (never interpolate JSON into the script body):
+
+```bash
+PROBE_RESULT=$(NF_IMPORT_JSON="$IMPORT_RESULT" node << 'NF_EVAL'
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const importResult = JSON.parse(process.env.NF_IMPORT_JSON || '{}');
+const added = (importResult.summary?.mcpServers?.added) || [];
+if (added.length === 0) { process.stdout.write(JSON.stringify({ probed: 0, results: [] }) + '\n'); process.exit(0); }
+
+let claudeJson = {};
+try { claudeJson = JSON.parse(fs.readFileSync(path.join(os.homedir(), '.claude.json'), 'utf8')); } catch (_) {}
+
+const initReq = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }) + '\n';
+const listReq = JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }) + '\n';
+
+const results = [];
+for (const { name } of added) {
+  const entry = (claudeJson.mcpServers || {})[name];
+  if (!entry) { results.push({ slot: name, ok: false, reason: 'mcp entry not found in ~/.claude.json' }); continue; }
+  const res = spawnSync(entry.command, entry.args || [], {
+    input: initReq + listReq,
+    env: { ...process.env, ...(entry.env || {}) },
+    timeout: 8000,
+    encoding: 'utf8',
+  });
+  if (res.error) { results.push({ slot: name, ok: false, reason: 'spawn failed: ' + res.error.message }); continue; }
+  if (res.status !== null && res.status !== 0) {
+    const stderr = (res.stderr || '').trim().split('\n').slice(-3).join(' | ').slice(0, 200);
+    results.push({ slot: name, ok: false, reason: 'exit ' + res.status + ': ' + stderr });
+    continue;
+  }
+  let tools = null;
+  for (const line of (res.stdout || '').split('\n')) {
+    if (!line.trim()) continue;
+    try { const obj = JSON.parse(line); if (obj.id === 2 && obj.result && Array.isArray(obj.result.tools)) tools = obj.result.tools.map(t => t.name); } catch (_) {}
+  }
+  if (!tools) { results.push({ slot: name, ok: false, reason: 'no tools/list response' }); continue; }
+  const missing = ['identity', 'health_check'].filter(t => !tools.includes(t));
+  if (missing.length) { results.push({ slot: name, ok: false, reason: 'missing tools: ' + missing.join(', '), tools }); continue; }
+  results.push({ slot: name, ok: true, toolCount: tools.length });
+}
+process.stdout.write(JSON.stringify({ probed: results.length, results }) + '\n');
+NF_EVAL
+)
+```
+
+Parse PROBE_RESULT and display:
+
+```text
+Slot probe (out-of-band MCP handshake):
+{for each result:}
+  {ok ? "✓" : "✗"} {slot} {ok ? "— " + toolCount + " tools registered" : "— " + reason}
+```
+
+Store the pass/fail counts for the closing summary in Step 4 (`probePassedCount`, `probeFailedCount`).
+
+If any slots failed: tell the user explicitly that those slots will **not** work after a Claude Code restart and link to `/nf:mcp-repair`. If all passed: tell them the slots are wired correctly but still require a Claude Code restart to register tools in this session.
+
 Continue to Step 3.
 
 ---
@@ -1048,8 +1116,13 @@ Display:
   Product detected:        {productName} (Daintree, or canopy-app legacy)
   Import (nf.json):        {imported ? "✓ Canopy config imported to nf.json" : "○ Skipped"}
   Preset env imported:     {presetEnvImported ? "✓ " + providersUpdated + " provider(s) updated in providers.json" : "○ Skipped"}
+  Slot probe:              {probedCount > 0 ? (probeFailedCount === 0 ? "✓ " + probePassedCount + " new slot(s) respond to MCP probe" : "⚠ " + probePassedCount + " ok, " + probeFailedCount + " failed — run /nf:mcp-repair") : "○ No new slots to probe"}
   Register userAgents:     {registered ? "✓ " + userAgentsAddedCount + " added, " + userAgentsSkippedCount + " skipped" : "○ Skipped"}
   Custom presets exported: {customPresetsAddedCount > 0 || customPresetsUnchangedCount > 0 ? "✓ " + customPresetsAddedCount + " added, " + customPresetsUnchangedCount + " unchanged" : "○ Skipped"}
+
+{if probedCount > 0 || imported:}
+⚠ Restart Claude Code now — newly-added MCP slots register their tools only at session start.
+   Quit with CTRL+C (or `/quit`), then run `claude` again.
 
 Re-run /nf:link-canopy any time to refresh the link. Idempotency rules:
   • Vanilla nForma slots (no daintree_preset_id) are never touched.
@@ -1079,4 +1152,6 @@ Re-run /nf:link-canopy any time to refresh the link. Idempotency rules:
 - All values passed via environment variables — never interpolated into script bodies
 - Cross-platform: macOS (~/Library/Application Support), Windows (%APPDATA%), Linux (~/.config)
 - Idempotent: safe to re-run — updates canopy section, skips existing agents and customPresets
+- Post-write smoke probe (Step 2e): each newly-added MCP slot is spawned out-of-band via its exact command+args+env, sent initialize + tools/list, and verified to expose at minimum `identity` and `health_check`. Failures surface per-slot in the probe display and aggregated in Step 4 closing summary.
+- Step 4 closing summary tells the user explicitly to restart Claude Code when any new MCP slot was added or nf.json was imported, since MCP tools register only at session start.
 </success_criteria>

--- a/docs/assets/terminal.svg
+++ b/docs/assets/terminal.svg
@@ -80,7 +80,7 @@
     <path d="M100.8,143.0 H96.6 V132.0" stroke="#7dcfff" stroke-width="1.5" stroke-linecap="square" fill="none"/>
     <line x1="100.8" y1="143.0" x2="109.2" y2="143.0" stroke="#7dcfff" stroke-width="1.5" stroke-linecap="square" fill="none"/>
     <path d="M109.2,143.0 H113.4 V132.0" stroke="#7dcfff" stroke-width="1.5" stroke-linecap="square" fill="none"/>
-    <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="198" xml:space="preserve"><tspan fill="#c0caf5">  nForma </tspan><tspan fill="#c0caf5">— Consensus before code. Proof before production. </tspan><tspan fill="#565f89">v0.43.0</tspan></text>
+    <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="198" xml:space="preserve"><tspan fill="#c0caf5">  nForma </tspan><tspan fill="#c0caf5">— Consensus before code. Proof before production. </tspan><tspan fill="#565f89">v0.43.1</tspan></text>
     <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="220" xml:space="preserve"><tspan fill="#565f89">  Built on GSD-CC by TÂCHES.</tspan></text>
     <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="264" xml:space="preserve"><tspan fill="#7dcfff">  The task of leadership is to create an alignment of strengths</tspan></text>
     <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="286" xml:space="preserve"><tspan fill="#7dcfff">   so strong that it makes the system’s weaknesses irrelevant.</tspan></text>

--- a/hooks/dist/nf-statusline.js
+++ b/hooks/dist/nf-statusline.js
@@ -76,22 +76,26 @@ function buildToolsLine(homeDir, dir) {
           const riverState = JSON.parse(fs.readFileSync(riverPath, 'utf8'));
           const qTable = riverState && riverState.qTable;
           if (qTable && typeof qTable === 'object') {
+            // Check if ANY arm has been visited — means "ready to start learning"
             const RIVER_MIN_EXPLORE = 20;
             let hasArms = false;
+            let hasVisits = false;
             let allAbove = true;
             for (const taskType of Object.keys(qTable)) {
               const arms = qTable[taskType];
               if (arms && typeof arms === 'object') {
                 for (const armName of Object.keys(arms)) {
                   hasArms = true;
-                  if ((arms[armName].visits || 0) < RIVER_MIN_EXPLORE) allAbove = false;
+                  const visits = arms[armName].visits || 0;
+                  if (visits > 0) hasVisits = true;
+                  if (visits < RIVER_MIN_EXPLORE) allAbove = false;
                 }
               }
             }
-            if (hasArms) {
+            if (hasArms && hasVisits) {
               toolsRiver = allAbove
                 ? '\x1b[32m● River\x1b[0m'   // trained
-                : '\x1b[36m● River\x1b[0m';   // exploring
+                : '\x1b[36m● River\x1b[0m';   // exploring (has learning data, not all trained)
             }
             if (riverState.lastShadow && typeof riverState.lastShadow.recommendation === 'string' && riverState.lastShadow.recommendation) {
               toolsRiver = `\x1b[33m● River: ${riverState.lastShadow.recommendation}\x1b[0m`;

--- a/hooks/nf-statusline.js
+++ b/hooks/nf-statusline.js
@@ -76,22 +76,26 @@ function buildToolsLine(homeDir, dir) {
           const riverState = JSON.parse(fs.readFileSync(riverPath, 'utf8'));
           const qTable = riverState && riverState.qTable;
           if (qTable && typeof qTable === 'object') {
+            // Check if ANY arm has been visited — means "ready to start learning"
             const RIVER_MIN_EXPLORE = 20;
             let hasArms = false;
+            let hasVisits = false;
             let allAbove = true;
             for (const taskType of Object.keys(qTable)) {
               const arms = qTable[taskType];
               if (arms && typeof arms === 'object') {
                 for (const armName of Object.keys(arms)) {
                   hasArms = true;
-                  if ((arms[armName].visits || 0) < RIVER_MIN_EXPLORE) allAbove = false;
+                  const visits = arms[armName].visits || 0;
+                  if (visits > 0) hasVisits = true;
+                  if (visits < RIVER_MIN_EXPLORE) allAbove = false;
                 }
               }
             }
-            if (hasArms) {
+            if (hasArms && hasVisits) {
               toolsRiver = allAbove
                 ? '\x1b[32m● River\x1b[0m'   // trained
-                : '\x1b[36m● River\x1b[0m';   // exploring
+                : '\x1b[36m● River\x1b[0m';   // exploring (has learning data, not all trained)
             }
             if (riverState.lastShadow && typeof riverState.lastShadow.recommendation === 'string' && riverState.lastShadow.recommendation) {
               toolsRiver = `\x1b[33m● River: ${riverState.lastShadow.recommendation}\x1b[0m`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nforma.ai/nforma",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nforma.ai/nforma",
-      "version": "0.43.0",
+      "version": "0.43.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nforma.ai/nforma",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "description": "nForma — Multi-agent coding orchestrator with quorum consensus and formal verification (TLA+, Alloy, PRISM). Consensus before code, proof before production.",
   "bin": {
     "nforma": "bin/nforma-cli.js",


### PR DESCRIPTION
## Summary

Closes a gap where `/nf:link-daintree` could write Daintree-imported slots to `~/.claude.json` / `providers.json` but the resulting MCP slots silently failed to expose `health_check`, with no signal until the user manually ran `/nf:mcp-status` after a Claude Code restart.

- **`bin/unified-mcp-server.mjs`** — drop the `if (provider.health_check_args)` registration gate for `subprocess` and `ccr` provider types. Execution already defaults to `['--version']` at line 603, so the gate was silently stripping the tool whenever `providers.json` was reconstructed without that field (which is what happens after `install.js` regenerates it from `~/.claude.json` mcpServers).
- **`commands/nf/link-daintree.md`** — add **Step 2e: Smoke-probe newly-added slots**. For each new MCP slot, spawn `unified-mcp-server` out-of-band with its exact command/args/env, send `initialize` + `tools/list`, and verify both `identity` and `health_check` are exposed. Per-slot pass/fail surfaces inline and aggregates into the Step 4 closing summary; Step 4 now tells the user explicitly to restart Claude Code (since MCP tools register only at session start).

Also rolls up the 0.43.1 release-bump and the other commits already on this branch (Daintree fan-out, statusline fix, uv install, etc.).

## Test plan

- [x] `npm run test:ci` — 264 pass, 1 skip, 0 fail
- [x] `npm run check:assets` — clean
- [x] `npm run lint:isolation` — clean
- [x] Manual: spawned `unified-mcp-server` with `PROVIDER_SLOT=claude-1` and confirmed `health_check` now appears in `tools/list`
- [ ] Post-merge: re-run `/nf:link-daintree` to re-add Daintree slots stripped by an earlier install-sync; verify Step 2e probe reports `✓` for each new slot and Step 4 surfaces the restart banner
- [ ] After Claude Code restart: `/nf:mcp-status` no longer shows `error`/missing `health_check` for Daintree slots

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple AI provider integrations
  * Added automated verification to confirm newly-imported MCP servers function correctly

* **Bug Fixes**
  * Enhanced installation process with automatic dependency availability checks for River ML
  * Fixed River tool status display to accurately reflect usage state

* **Chores**
  * Version updated to 0.43.1

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nForma-AI/nForma/pull/157)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->