### PR TITLE
fix(link-daintree): make fan-out idempotent (canonical vanilla + preserve metadata on install)

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -560,13 +560,26 @@ function ensureMcpSlotsFromProviders() {
           // Daintree metadata from preset-cloned slots and re-running /nf:link-daintree would
           // fail to recognize them as preset-linked, creating duplicate -N slots instead of
           // updating in place.
+          // Build existingByName by reading from two sources, in order of freshness:
+          //   1. nf-local-patches/nf/bin/providers.json — saveLocalPatches() backs up the
+          //      user's pre-wipe providers.json here. Earlier in this same install,
+          //      copyWithPathReplacement wiped ~/.claude/nf/, removing the live nf/bin/
+          //      providers.json. The patches backup is the only place the user's metadata
+          //      (daintree_preset_id, env, model) still lives.
+          //   2. ~/.claude/nf/bin/providers.json — current live file (whatever the mirror
+          //      step just put there, typically stale once nf/ has been wiped).
+          // Patches backup wins where both have the same slot name, because it carries
+          // the metadata the wipe destroyed.
           const existingByName = new Map();
-          try {
-            if (fs.existsSync(globalProvidersJson)) {
-              const existing = JSON.parse(fs.readFileSync(globalProvidersJson, 'utf8'));
-              for (const p of existing.providers || []) existingByName.set(p.name, p);
-            }
-          } catch (_) { /* fall through with empty map */ }
+          const patchedProvidersPath = path.join(os.homedir(), '.claude', PATCHES_DIR_NAME, 'nf', 'bin', 'providers.json');
+          for (const candidatePath of [globalProvidersJson, patchedProvidersPath]) {
+            try {
+              if (fs.existsSync(candidatePath)) {
+                const existing = JSON.parse(fs.readFileSync(candidatePath, 'utf8'));
+                for (const p of existing.providers || []) existingByName.set(p.name, p);
+              }
+            } catch (_) { /* skip unreadable / malformed */ }
+          }
 
           // Step 1: Sync slots from ~/.claude.json (fan-out creates MCP entries here)
           // Only include slots whose prefix is a known coding agent CLI.

--- a/bin/install.js
+++ b/bin/install.js
@@ -553,6 +553,21 @@ function ensureMcpSlotsFromProviders() {
         const globalProvidersJson = path.join(os.homedir(), '.claude', 'nf', 'bin', 'providers.json');
         const merged = { providers: [] };
         try {
+          // Preserve existing entries — when reconstructing providers.json from ~/.claude.json
+          // mcpServers, fields like `daintree_preset_id`, `daintree_preset_name`,
+          // `daintree_preset_family`, `env`, `model`, and `health_check_args` only live in the
+          // installed providers.json. Without preserving them, every install would strip
+          // Daintree metadata from preset-cloned slots and re-running /nf:link-daintree would
+          // fail to recognize them as preset-linked, creating duplicate -N slots instead of
+          // updating in place.
+          const existingByName = new Map();
+          try {
+            if (fs.existsSync(globalProvidersJson)) {
+              const existing = JSON.parse(fs.readFileSync(globalProvidersJson, 'utf8'));
+              for (const p of existing.providers || []) existingByName.set(p.name, p);
+            }
+          } catch (_) { /* fall through with empty map */ }
+
           // Step 1: Sync slots from ~/.claude.json (fan-out creates MCP entries here)
           // Only include slots whose prefix is a known coding agent CLI.
           const KNOWN_CLI_PREFIXES = ['claude', 'codex', 'gemini', 'opencode', 'copilot', 'kilo', 'cursor', 'windsurf', 'antigravity', 'augment', 'trae', 'cline'];
@@ -565,7 +580,9 @@ function ensureMcpSlotsFromProviders() {
             // Infer mainTool from slot name prefix (e.g., "claude-z-ai" → "claude")
             const dashIdx = slotName.indexOf('-');
             const mainTool = dashIdx > 0 ? slotName.slice(0, dashIdx) : slotName;
-            merged.providers.push({
+            // Base shape derived from slot name; existing entry's fields (if any) win on overlay
+            // — preserves daintree_preset_id, env, model, etc.
+            const base = {
               name: slotName,
               provider: mainTool,
               type: 'subprocess',
@@ -573,7 +590,9 @@ function ensureMcpSlotsFromProviders() {
               mainTool,
               display_type: mainTool + '-cli',
               display_provider: mainTool.charAt(0).toUpperCase() + mainTool.slice(1),
-            });
+            };
+            const existing = existingByName.get(slotName);
+            merged.providers.push(existing ? { ...base, ...existing } : base);
           }
           // Step 2: Also add PATH-detected CLIs that aren't already in ~/.claude.json
           const { resolveCli } = require('./resolve-cli.cjs');

--- a/commands/nf/link-daintree.md
+++ b/commands/nf/link-daintree.md
@@ -354,7 +354,7 @@ The new slot name is `{agentName}-{slug}` — using the **Daintree agent name** 
 | `OPENROUTER_*` | `openrouter` |
 | `OLLAMA_*` | `ollama` |
 
-If no family can be inferred (e.g., preset only has generic `MODEL` / `*_BASE_URL` / `*_API_KEY`), the family check is bypassed and any provider with `mainTool === agentName` is acceptable as the vanilla. If multiple vanilla candidates exist after both gates, prefer the one with no `daintree_preset_id` field (the original) and the lowest numeric suffix (`claude-1` over `claude-2`).
+If no family can be inferred (e.g., preset only has generic `MODEL` / `*_BASE_URL` / `*_API_KEY`), the family check is bypassed and any provider with `mainTool === agentName` is acceptable as the vanilla. Vanilla candidates must additionally match the canonical install naming pattern `^<agentName>-<N>$` (e.g., `claude-1`, `claude-2`) and have no `daintree_preset_id` — this excludes preset-cloned slots like `claude-z-ai` (including legacy ones created before the `daintree_preset_id` annotation existed) from being mis-selected as a vanilla source. Among the remaining candidates, the lowest numeric suffix wins (`claude-1` over `claude-2`).
 
 **Idempotency (AC5).** Each new slot carries a `daintree_preset_id` field equal to `preset.id`. On re-import:
 - A **vanilla** slot (no `daintree_preset_id`) is never touched. Its env, model, and description survive every re-import.
@@ -480,16 +480,21 @@ function inferFamily(envObj) {
 
 // ── Find vanilla provider for a Daintree agent + family ────────────────
 function findVanilla(agentName, family) {
-  const candidates = providersData.providers.filter(p => p.mainTool === agentName);
+  // Vanilla candidates must match the canonical install shape `<agentName>-<N>` AND have no
+  // daintree_preset_id. The naming-pattern gate excludes preset-cloned slots like
+  // `claude-z-ai` whose env was overlaid from a Daintree preset; without it, a legacy
+  // preset-clone created before daintree_preset_id annotations existed would win the
+  // suffix-0 sort and be selected as a vanilla source, propagating preset env into new clones.
+  const canonical = new RegExp('^' + agentName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '-\\d+$');
+  const candidates = providersData.providers.filter(p =>
+    p.mainTool === agentName && canonical.test(p.name) && !p.daintree_preset_id
+  );
   const familyMatch = family ? candidates.filter(p => p.provider === family) : candidates;
   const pool = familyMatch.length ? familyMatch : candidates;
-  // Prefer provider without daintree_preset_id, then lowest numeric suffix
+  // Lowest numeric suffix wins (`claude-1` over `claude-2`)
   pool.sort((a, b) => {
-    const aIsClone = !!a.daintree_preset_id;
-    const bIsClone = !!b.daintree_preset_id;
-    if (aIsClone !== bIsClone) return aIsClone ? 1 : -1;
-    const an = parseInt((a.name.match(/-(\d+)$/) || [])[1] || '0', 10);
-    const bn = parseInt((b.name.match(/-(\d+)$/) || [])[1] || '0', 10);
+    const an = parseInt(a.name.match(/-(\d+)$/)[1], 10);
+    const bn = parseInt(b.name.match(/-(\d+)$/)[1], 10);
     return an - bn;
   });
   return pool[0] || null;


### PR DESCRIPTION
## Summary

Closes **two compounding bugs** in `/nf:link-daintree` idempotency that together caused the fan-out to create duplicate `-N` slots on re-run instead of updating in place.

### Bug 1 — `findVanilla` picks preset-cloned slots as vanilla source

`findVanilla` sorted by "no `daintree_preset_id` first, then lowest numeric suffix." A legacy preset-clone like `claude-z-ai` (no annotation, no numeric suffix → ranked as suffix 0) won the sort over `claude-1`, propagating Z.AI preset env into every new clone.

**Fix:** vanilla candidates must additionally match the canonical install naming pattern `^<agentName>-\d+$` AND have no `daintree_preset_id`. Excludes preset-clones regardless of annotation state. (`commands/nf/link-daintree.md`)

### Bug 2 — `install.js` strips Daintree metadata on every sync

When `bin/providers.json` is empty (the shipped state — populated at install time), the installer reconstructs the installed `providers.json` from `~/.claude.json` mcpServers, but built each entry from a minimal name-derived shape, **silently dropping `daintree_preset_id`, `daintree_preset_name`, `daintree_preset_family`, `env`, and `model`** from existing entries.

That meant: any install sync stripped the `daintree_preset_id` annotation from preset-clones, breaking the re-import recognition path. Next `/nf:link-daintree` couldn't match preset → existing slot, so it created `-2` / `-3` duplicates.

**Fix:** read the existing `~/.claude/nf/bin/providers.json` into a `name → entry` map, then overlay the existing entry on top of the derived base shape. Existing fields win on conflict. (`bin/install.js`)

### Reproduced + verified

- Simulation of `findVanilla` against representative providers.json: picks `claude-1` not `claude-z-ai` ✓
- Full test suite: **1550/1550 pass**
- Live verification: after applying the install fix + re-annotating legacy slots, running install.js no longer strips `daintree_preset_id` ✓

## Test plan

- [x] `npm run test:ci` — 1550 pass, 0 fail
- [x] `npm run lint:isolation` — clean
- [x] `npm run check:assets` — clean
- [x] `findVanilla` simulation: `claude/anthropic` → `claude-1`, `codex/openai` → `codex-1`, only-preset-clones → `null`
- [ ] After merge + restart: re-run `/nf:link-daintree` from clean state; verify no `-N` duplicates created on re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where provider metadata and configuration settings could be lost during reinstalls in global mode, ensuring all previously saved provider data is preserved.
  * Improved the provider selection algorithm to be more precise and prevent unintended provider matches during installation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nForma-AI/nForma/pull/159)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->