### PR TITLE
fix(mcp/install): resolve CLI from mainTool when cli is null; self-heal mainTool

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -362,14 +362,14 @@
         "filename": "bin/unified-mcp-server.mjs",
         "hashed_secret": "f8ca0d7266886f4b5be9adddc9b66017b3bf1a4b",
         "is_verified": false,
-        "line_number": 484
+        "line_number": 490
       },
       {
         "type": "Secret Keyword",
         "filename": "bin/unified-mcp-server.mjs",
         "hashed_secret": "138901a352fddde83a010e609f2091c5ebaad7bd",
         "is_verified": false,
-        "line_number": 914
+        "line_number": 920
       }
     ],
     "bin/validate-debt-entry.test.cjs": [
@@ -391,5 +391,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-12T12:09:20Z"
+  "generated_at": "2026-05-12T19:04:52Z"
 }

--- a/bin/install.js
+++ b/bin/install.js
@@ -605,7 +605,13 @@ function ensureMcpSlotsFromProviders() {
               display_provider: mainTool.charAt(0).toUpperCase() + mainTool.slice(1),
             };
             const existing = existingByName.get(slotName);
-            merged.providers.push(existing ? { ...base, ...existing } : base);
+            // Overlay existing on top of base (preserves Daintree metadata, env, etc.)
+            // BUT force `name` and `mainTool` from the base (slot-name-derived). Otherwise
+            // historical corruption like `copilot-1: { mainTool: 'ask' }` would persist
+            // forever and cause the MCP server to spawn the wrong binary at health_check.
+            merged.providers.push(existing
+              ? { ...base, ...existing, name: base.name, mainTool: base.mainTool }
+              : base);
           }
           // Step 2: Also add PATH-detected CLIs that aren't already in ~/.claude.json
           const { resolveCli } = require('./resolve-cli.cjs');

--- a/bin/unified-mcp-server.mjs
+++ b/bin/unified-mcp-server.mjs
@@ -41,11 +41,17 @@ if (!Array.isArray(providers) || providers.length === 0) {
 
 // Resolve CLI paths at startup (XPLAT-01: cross-platform path discovery)
 for (const provider of providers) {
-  if (provider.type === 'subprocess' && provider.cli) {
-    const bareName = provider.cli.split('/').pop();
+  if (provider.type === 'subprocess') {
+    // `cli` is optional in providers.json — when absent, fall back to `mainTool`
+    // as the bare binary name. Without this fallback, `provider.resolvedCli`
+    // stays unset and the spawn at runtime hands `null` to child_process.spawn,
+    // failing with ENOENT/EINVAL and reporting healthy:false at ~1ms latency.
+    const cliSource = provider.cli || provider.mainTool;
+    if (!cliSource) continue;
+    const bareName = cliSource.split('/').pop();
     provider.resolvedCli = resolveCli(bareName);
-    if (provider.cli !== provider.resolvedCli) {
-      process.stderr.write(`[mcp] Resolved ${bareName}: ${provider.cli} -> ${provider.resolvedCli}\n`);
+    if (cliSource !== provider.resolvedCli) {
+      process.stderr.write(`[mcp] Resolved ${bareName}: ${cliSource} -> ${provider.resolvedCli}\n`);
     }
     // Also resolve service commands if present (e.g., ccr start/stop/status)
     if (provider.service) {


### PR DESCRIPTION
## Summary

Closes two related bugs that made **every subprocess slot** report `healthy: false` at ~1ms latency in `/nf:mcp-status` — codex-1, gemini-1, opencode-1, copilot-1, claude-1, claude-z-ai, claude-minimax. All MCP servers were alive (identity worked), but every `health_check` call failed instantly.

### Bug 1 — `unified-mcp-server.mjs` never resolves CLI when `provider.cli` is null

The startup loop at line 44 gated `resolveCli()` on `provider.cli` being truthy:

```js
if (provider.type === 'subprocess' && provider.cli) {
  // resolve...
}
```

Every slot that's reconstructed by install.js's fallback path has `cli: null` (only `mainTool` is set). So `resolveCli` never ran, `provider.resolvedCli` stayed `undefined`, and the runtime spawn (`spawn(provider.resolvedCli ?? provider.cli, …)`) handed `null` to `child_process.spawn` — failing with `ENOENT`/`EINVAL` instantly and reporting `healthy: false @ 1ms`.

**Fix:** fall back to `provider.mainTool` as the bare binary name when `provider.cli` is missing.

### Bug 2 — `install.js` preserves stale corrupt `mainTool` forever

When my earlier fix overlaid `existing` entries on top of the base shape, every field — including `name` and `mainTool` — was preserved from `existing`. Historical corruption like `copilot-1: { mainTool: 'ask' }` (from a long-since-rolled-back install configuration) persisted across every install, making the MCP server try to spawn a binary called `ask` (which doesn't exist on PATH).

**Fix:** explicitly force `name` and `mainTool` from the base shape after the spread. Daintree metadata, env, model, args_template, helpArgs, oauth_rotation, deep_probe, etc. still preserve from existing.

## Verified live on all 7 user slots

```
codex-1            healthy=true  latency=63ms
gemini-1           healthy=true  latency=431ms
opencode-1         healthy=true  latency=602ms
copilot-1          healthy=true  latency=484ms
claude-1           healthy=true  latency=49ms
claude-z-ai        healthy=true  latency=55ms
claude-minimax     healthy=true  latency=54ms
```

## Test plan

- [x] `npm run test:ci` — 1550 pass, 0 fail
- [x] `npm run lint:isolation` — clean
- [x] `npm run check:assets` — clean
- [x] Live verification: all 7 slots now return `healthy:true` (was `false@1ms` before)
- [ ] After merge + Claude Code restart: `/nf:mcp-status` shows all slots `available` with realistic latencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed provider configuration synchronization to ensure previously corrupted entries are properly corrected rather than persisting when configuration mappings are regenerated.

* **Improvements**
  * Enhanced provider initialization with improved CLI path resolution that includes fallback mechanisms for more reliable and robust startup behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nForma-AI/nForma/pull/161)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->