### PR TITLE
fix(mcp): auto-fall-back to user-installed providers.json; backfill UNIFIED_PROVIDERS_CONFIG

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -362,14 +362,14 @@
         "filename": "bin/unified-mcp-server.mjs",
         "hashed_secret": "f8ca0d7266886f4b5be9adddc9b66017b3bf1a4b",
         "is_verified": false,
-        "line_number": 490
+        "line_number": 518
       },
       {
         "type": "Secret Keyword",
         "filename": "bin/unified-mcp-server.mjs",
         "hashed_secret": "138901a352fddde83a010e609f2091c5ebaad7bd",
         "is_verified": false,
-        "line_number": 920
+        "line_number": 948
       }
     ],
     "bin/validate-debt-entry.test.cjs": [
@@ -391,5 +391,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-12T19:04:52Z"
+  "generated_at": "2026-05-12T19:52:30Z"
 }

--- a/bin/install.js
+++ b/bin/install.js
@@ -684,18 +684,34 @@ function ensureMcpSlotsFromProviders() {
       if (selectedProviderSlots && !selectedProviderSlots.includes(providerName)) {
         continue;
       }
+      // unified-mcp-server reads its providers config from this path; without an explicit
+      // pointer it falls back to its own __dirname/providers.json (which ships empty) and
+      // exits with "Unknown PROVIDER_SLOT". Set UNIFIED_PROVIDERS_CONFIG on every entry —
+      // new entries get it on creation, existing entries get backfilled below.
+      const installedProvidersPath = path.join(os.homedir(), '.claude', 'nf', 'bin', 'providers.json');
       if (!claudeConfig.mcpServers.hasOwnProperty(providerName)) {
         // Create entry for this provider
         claudeConfig.mcpServers[providerName] = {
           type: 'stdio',
           command: 'node',
           args: [unifiedMcpPath],
-          env: { PROVIDER_SLOT: providerName }
+          env: { PROVIDER_SLOT: providerName, UNIFIED_PROVIDERS_CONFIG: installedProvidersPath }
         };
         addedCount++;
         console.log(`  ${green}✓${reset} Added MCP entry for ${providerName}`);
       } else {
-        console.log(`  ${dim}↳ MCP entry for ${providerName} already exists (skipped)${reset}`);
+        // Backfill UNIFIED_PROVIDERS_CONFIG on existing entries that are missing it —
+        // older /nf:mcp-setup runs created entries without this env, causing the spawned
+        // server to look at the empty repo source. Self-heal on every install.
+        const existing = claudeConfig.mcpServers[providerName];
+        existing.env = existing.env || {};
+        if (!existing.env.UNIFIED_PROVIDERS_CONFIG) {
+          existing.env.UNIFIED_PROVIDERS_CONFIG = installedProvidersPath;
+          addedCount++;
+          console.log(`  ${green}✓${reset} Backfilled UNIFIED_PROVIDERS_CONFIG on ${providerName}`);
+        } else {
+          console.log(`  ${dim}↳ MCP entry for ${providerName} already exists (skipped)${reset}`);
+        }
       }
     }
 

--- a/bin/unified-mcp-server.mjs
+++ b/bin/unified-mcp-server.mjs
@@ -23,11 +23,39 @@ const { resolveCli } = require('./resolve-cli.cjs');
 const { _pure: { detectInstalledProviders } } = require('./manage-agents-core.cjs');
 
 // ─── Load providers config ─────────────────────────────────────────────────────
-const configPath = process.env.UNIFIED_PROVIDERS_CONFIG
-  ?? join(__dirname, 'providers.json');
-let providers;
+// Precedence:
+//   1. UNIFIED_PROVIDERS_CONFIG env (explicit override — set by /nf:link-daintree)
+//   2. __dirname/providers.json (repo source — populated when running from a dev checkout)
+//   3. ~/.claude/nf/bin/providers.json (user-installed copy — populated by install.js)
+// The shipped repo source is empty by design (populated at install time). Without the
+// step-3 fallback, Claude Code MCP entries that lack UNIFIED_PROVIDERS_CONFIG hit the
+// empty repo source and exit with "Unknown PROVIDER_SLOT" on every session start.
+function loadProvidersConfig() {
+  const explicit = process.env.UNIFIED_PROVIDERS_CONFIG;
+  if (explicit) {
+    return { path: explicit, data: JSON.parse(fs.readFileSync(explicit, 'utf8')) };
+  }
+  const repoPath = join(__dirname, 'providers.json');
+  let repoData = null;
+  try {
+    repoData = JSON.parse(fs.readFileSync(repoPath, 'utf8'));
+    if (Array.isArray(repoData?.providers) && repoData.providers.length > 0) {
+      return { path: repoPath, data: repoData };
+    }
+  } catch (_) { /* fall through to user-installed */ }
+  const userPath = join(os.homedir(), '.claude', 'nf', 'bin', 'providers.json');
+  if (fs.existsSync(userPath)) {
+    return { path: userPath, data: JSON.parse(fs.readFileSync(userPath, 'utf8')) };
+  }
+  // Last resort: return whatever we read from repo (even if empty) so warning path triggers below
+  return { path: repoPath, data: repoData ?? { providers: [] } };
+}
+
+let configPath, providers;
 try {
-  providers = JSON.parse(fs.readFileSync(configPath, 'utf8')).providers;
+  const loaded = loadProvidersConfig();
+  configPath = loaded.path;
+  providers = loaded.data.providers;
 } catch (e) {
   process.stderr.write(`[unified-mcp-server] Failed to load config: ${e.message}\n`);
   process.exit(1);
@@ -35,7 +63,7 @@ try {
 
 // Guard: handle empty providers array gracefully
 if (!Array.isArray(providers) || providers.length === 0) {
-  process.stderr.write('[unified-mcp-server] WARNING: No providers configured in providers.json — server will start with zero tools\n');
+  process.stderr.write(`[unified-mcp-server] WARNING: No providers configured in ${configPath} — server will start with zero tools\n`);
   providers = providers || [];
 }
 


### PR DESCRIPTION
## Summary

Closes the **real** root cause of the persistent `unhealthy@1ms` / `error` state in `/nf:mcp-status` that PRs #158 / #159 / #161 didn't fully address. Even on a fresh Claude Code session with all prior fixes pulled into main, every vanilla MCP slot still exits with `Unknown PROVIDER_SLOT` and never registers its tools.

### Root cause

The mcpServers entries that `/nf:mcp-setup` historically created have only `env: { PROVIDER_SLOT: <name> }` — no `UNIFIED_PROVIDERS_CONFIG`. The MCP server defaults to `__dirname/providers.json`, which **ships intentionally empty** (populated at install time into `~/.claude/nf/bin/providers.json`). So the spawned server sees zero providers, can't find its PROVIDER_SLOT, and exits before any tools register.

### Fix

Two complementary changes:

**1. `bin/unified-mcp-server.mjs`** — when neither `UNIFIED_PROVIDERS_CONFIG` nor a populated repo-source `providers.json` is available, fall back to `~/.claude/nf/bin/providers.json`. This **self-heals existing user installs** with zero install re-run required — the next session start picks up the right config.

Precedence: explicit env → populated repo source → user-installed copy.

**2. `bin/install.js`** — when creating mcpServers entries OR re-processing existing ones, set `UNIFIED_PROVIDERS_CONFIG` explicitly. Old entries get **backfilled** on next install so the env is self-documenting going forward.

### Verified live

```
$ PROVIDER_SLOT=codex-1 node bin/unified-mcp-server.mjs
[mcp] Resolved codex: codex -> /Users/jonathanborduas/.nvm/.../bin/codex
[mcp] Resolved gemini: gemini -> /Users/jonathanborduas/.nvm/.../bin/gemini
[mcp] Resolved opencode: opencode -> /opt/homebrew/bin/opencode
[mcp] Resolved copilot: copilot -> /opt/homebrew/bin/copilot
[mcp] Resolved claude:  claude -> /Users/jonathanborduas/.local/bin/claude
[unified-mcp-server] started [slot: codex-1]
→ health_check returns: {"healthy":true,"latencyMs":38}
```

Previously: exited with `Unknown PROVIDER_SLOT: codex-1` at session start.

## Test plan

- [x] `npm run test:ci` — 1550 pass, 0 fail
- [x] `npm run lint:isolation` — clean
- [x] `npm run check:assets` — clean
- [x] Live: spawn server with only `PROVIDER_SLOT` env, no `UNIFIED_PROVIDERS_CONFIG` → starts cleanly, health_check returns healthy:true
- [ ] After merge + restart Claude Code: `/nf:mcp-status` shows all 7 slots `available`

🤖 Generated with [Claude Code](https://claude.com/claude-code)