### PR TITLE
fix(install): backfill UNIFIED_PROVIDERS_CONFIG when repo source is empty

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -639,6 +639,35 @@ function ensureMcpSlotsFromProviders() {
             fs.renameSync(tmpPath, globalProvidersJson);
             console.log(`  ${green}✓${reset} Synced ${merged.providers.length} slot(s) to ${globalProvidersJson}`);
           }
+
+          // Backfill UNIFIED_PROVIDERS_CONFIG on existing mcpServers entries that are
+          // missing it. The main backfill loop further down only runs when the repo
+          // source providers.json is populated (the non-empty branch) — for users
+          // whose repo source is empty (the typical case after install), this branch
+          // returns early and the main backfill never executes. Self-heal here too.
+          try {
+            const claudeJsonForBackfill = JSON.parse(fs.readFileSync(claudeJsonPath, 'utf8'));
+            if (claudeJsonForBackfill?.mcpServers) {
+              let backfilled = 0;
+              for (const slotName of mcpSlots) {
+                const entry = claudeJsonForBackfill.mcpServers[slotName];
+                if (!entry) continue;
+                entry.env = entry.env || {};
+                if (!entry.env.UNIFIED_PROVIDERS_CONFIG) {
+                  entry.env.UNIFIED_PROVIDERS_CONFIG = globalProvidersJson;
+                  backfilled++;
+                }
+              }
+              if (backfilled > 0) {
+                const tmpPath = claudeJsonPath + '.tmp';
+                fs.writeFileSync(tmpPath, JSON.stringify(claudeJsonForBackfill, null, 2) + '\n', 'utf8');
+                fs.renameSync(tmpPath, claudeJsonPath);
+                console.log(`  ${green}✓${reset} Backfilled UNIFIED_PROVIDERS_CONFIG on ${backfilled} mcpServers entry/entries`);
+              }
+            }
+          } catch (e) {
+            console.warn(`  ${yellow}⚠${reset} Could not backfill UNIFIED_PROVIDERS_CONFIG: ${e.message}`);
+          }
         } catch (e) {
           console.warn(`  ${yellow}⚠${reset} Could not sync providers to ${globalProvidersJson}: ${e.message}`);
         }


### PR DESCRIPTION
## Summary

Follow-up to #162. The backfill loop I added there lives in the *non-empty* branch of `ensureMcpSlotsFromProviders` — but the typical install state has `bin/providers.json` empty (populated only at install time). The empty branch returns early at line 646 and never reaches the backfill, so no existing user's mcpServers entries actually got `UNIFIED_PROVIDERS_CONFIG` backfilled on `npm install`.

Confirmed live: I just pulled main (with #162) and ran `node bin/install.js --claude --global`. The 5 vanilla mcpServers entries (codex-1, gemini-1, opencode-1, copilot-1, claude-1) still showed `UNIFIED_PROVIDERS_CONFIG: ✗ MISSING`.

## Fix

Add the same backfill inline in the empty-source branch, right after the reconstructed providers.json is written. Iterates the same `mcpSlots` list used to build the reconstruction. Self-heals on first install after this lands.

Verified live by stripping the env from 5 entries, running install, and seeing all 5 backfilled cleanly:

```
✓ Synced 7 slot(s) to /Users/jonathanborduas/.claude/nf/bin/providers.json
✓ Backfilled UNIFIED_PROVIDERS_CONFIG on 5 mcpServers entry/entries
```

## Test plan

- [x] Live: strip env from 5 entries, install, verify all 5 backfilled
- [x] All 7 slots end up with `UNIFIED_PROVIDERS_CONFIG: ✓`
- [ ] After merge + Claude Code restart: `/nf:mcp-status` shows all slots `available`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installer's self-healing capabilities to automatically repair configuration files when necessary during installation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nForma-AI/nForma/pull/163)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->