### PR TITLE
fix(quorum): resolve CLI from mainTool when cli is null (call-quorum-slot)

### DIFF
--- a/bin/call-quorum-slot.cjs
+++ b/bin/call-quorum-slot.cjs
@@ -353,9 +353,17 @@ function runSubprocess(provider, prompt, idleTimeoutMs, hardTimeoutMs, allowedTo
   const { args, useStdinPrompt, isCcr } = buildSpawnArgs(provider, prompt, allowedToolsFlag);
 
   // XPLAT-01: resolve CLI path at dispatch time (once per invocation)
-  if (provider.type === 'subprocess' && provider.cli) {
-    const bareName = provider.cli.split('/').pop();
-    provider.resolvedCli = resolveCli(bareName);
+  // `cli` is optional in providers.json — when absent, fall back to `mainTool` as the bare
+  // binary name. Without this fallback, `provider.resolvedCli` stays undefined and the spawn
+  // below hands `null` to child_process.spawn, throwing "The 'file' argument must be of type
+  // string. Received null" before any model is contacted — taking the entire quorum offline.
+  // Same fix as PR #161 applied to bin/unified-mcp-server.mjs.
+  if (provider.type === 'subprocess') {
+    const cliSource = provider.cli || provider.mainTool;
+    if (cliSource) {
+      const bareName = cliSource.split('/').pop();
+      provider.resolvedCli = resolveCli(bareName);
+    }
   }
 
   const env  = { ...process.env, ...(provider.env ?? {}) };
@@ -365,7 +373,12 @@ function runSubprocess(provider, prompt, idleTimeoutMs, hardTimeoutMs, allowedTo
     try {
       // detached: true creates a new process group — required to kill all descendants
       // (ccr → Claude Code → node, opencode → LLM subprocess, etc.)
-      child = spawn(provider.resolvedCli ?? provider.cli, args, { env, cwd: spawnCwd, stdio: ['pipe', 'pipe', 'pipe'], detached: true });
+      // Chain of fallbacks: resolvedCli (preferred, absolute path) → cli (raw field) →
+      // mainTool (bare binary name, last resort). Guards against spawn(null) in case the
+      // resolution above produced no value.
+      const spawnTarget = provider.resolvedCli || provider.cli || provider.mainTool;
+      if (!spawnTarget) throw new Error(`provider ${provider.name} has no resolvable CLI (cli, resolvedCli, and mainTool all empty)`);
+      child = spawn(spawnTarget, args, { env, cwd: spawnCwd, stdio: ['pipe', 'pipe', 'pipe'], detached: true });
     } catch (err) {
       reject(new Error(`[spawn error: ${err.message}]`));
       return;


### PR DESCRIPTION
## Summary

Same bug class as #161, applied to a different file. PR #161 fixed `bin/unified-mcp-server.mjs` to fall back to `provider.mainTool` when `provider.cli` is null. The quorum dispatch path in `bin/call-quorum-slot.cjs` had the identical bug and was missed.

### Symptom

Reported live today by `/nf:quorum is the quorum system robust?` in a fresh Claude Code session — all 5 slots failed identically:

```
codex-1    (primary)      UNAVAIL — spawn error: The "file" argument must be of type string. Received null
gemini-1   (primary)      UNAVAIL — spawn error: ...
opencode-1 (T1 fallback)  UNAVAIL — spawn error: ...
copilot-1  (T1 fallback)  UNAVAIL — spawn error: ...
claude-1   (T1 fallback)  UNAVAIL — spawn error: ...

CONSENSUS: BLOCKED — 0 APPROVE / 0 BLOCK / 5 UNAVAIL
```

### Root cause

Line 356 gated `resolveCli` on `provider.cli` being truthy. Every slot in the user's reconstructed `providers.json` has `cli: null` (only `mainTool` is set), so `resolveCli` never ran, `provider.resolvedCli` stayed `undefined`, and the spawn at line 368 handed `null` to `child_process.spawn`.

The MCP/health-probe path was fixed in #161 — but `/nf:quorum` doesn't go through the MCP server; it goes through `call-quorum-slot.cjs` directly, which had the identical untouched bug.

### Fix

- **Line 356:** fall back to `provider.mainTool` as the bare name when `cli` is null. Same chain as PR #161 used in unified-mcp-server.mjs.
- **Line 368:** build `spawnTarget` with explicit fallback chain (`resolvedCli` → `cli` → `mainTool`) and throw a descriptive error if all three are empty, instead of letting `spawn(null)` throw a cryptic one.

## Test plan

- [x] `npm run test:ci` — 1550 pass, 0 fail
- [x] Simulated: `cli: null, mainTool: 'codex'` provider → `resolvedCli = /.nvm/.../bin/codex`, `spawnTarget` resolves correctly
- [ ] After merge + install + Claude Code restart: `/nf:quorum <question>` should dispatch successfully through all available slots instead of failing 5/5 with spawn:null

🤖 Generated with [Claude Code](https://claude.com/claude-code)