### PR TITLE
fix(mcp-status): read scoreboard from correct path

### DIFF
--- a/commands/nf/mcp-status.md
+++ b/commands/nf/mcp-status.md
@@ -48,7 +48,7 @@ node << 'EOF'
 const fs=require('fs'), path=require('path'), os=require('os');
 
 // Scoreboard
-const sbPath=path.join(process.cwd(),'.planning','quorum-scoreboard.json');
+const sbPath=path.join(process.cwd(),'.planning','quorum','scoreboard.json');
 let totalRounds=0, lastUpdate=null;
 if(fs.existsSync(sbPath)){
   const d=JSON.parse(fs.readFileSync(sbPath,'utf8'));


### PR DESCRIPTION
## Summary

`/nf:mcp-status` always reported "Scoreboard: no data yet (run /nf:quorum first to populate)" even when quorum had run successfully. It was looking for the scoreboard at `.planning/quorum-scoreboard.json` but the file actually lives at `.planning/quorum/scoreboard.json` (note the directory separator vs hyphen).

Caught live today: a fresh session ran `/nf:quorum` which wrote 3 new entries to `.planning/quorum/scoreboard.json`, then `/nf:mcp-status` still said "no data yet" because of the stale path lookup.

## Live verification

```
before: file not found → reported 0 rounds
after:  found 10 rounds, captured_at 2026-05-13T07:06:43
```

## Test plan

- [x] Live: scoreboard now resolves correctly, returns 10 rounds + last update timestamp
- [ ] After merge: `/nf:mcp-status` shows real scoreboard count + last update instead of "no data yet"

🤖 Generated with [Claude Code](https://claude.com/claude-code)