### PR TITLE
chore(quorum/debates): archive May 03–13 quorum reliability debates

### DIFF
--- a/.planning/quorum/debates/2026-05-03-codex-1-is-the-mcp-system-robust.md
+++ b/.planning/quorum/debates/2026-05-03-codex-1-is-the-mcp-system-robust.md
@@ -1,0 +1,24 @@
+---
+date: 2026-05-03
+question: "Is the MCP system robust?"
+slot: codex-1
+round: 1
+mode: "A"
+verdict: [call-quorum-slot] Timeouts: idle=300000ms hard=300000ms for slot codex-1
+[call-quorum-slot] [spawn error: The "file" argument must be of type string. Received null]
+[call-quorum-slot] Set cooldown for codex-1 via set-availability
+
+matched_requirement_ids: [MCP-01, MCP-04, MCP-06, MCP-02, MCP-03, MCP-05, MCPENV-01, MCPENV-02, MCPENV-03, MCPENV-04, AGENT-01, CONF-03, MULTI-03, SETUP-01, SLOT-02, SLOT-04, AGENT-02, AGENT-03, AGENT-04, BENCH-08]
+artifact_path: ""
+---
+
+# Debate Trace: codex-1 on round 1
+
+## Reasoning
+[call-quorum-slot] Timeouts: idle=300000ms hard=300000ms for slot codex-1
+[call-quorum-slot] [spawn error: The "file" argument must be of type string. Received null]
+[call-quorum-slot] Set cooldown for codex-1 via set-availability
+
+
+## Citations
+(none)

--- a/.planning/quorum/debates/2026-05-03-copilot-1-is-the-mcp-system-robust.md
+++ b/.planning/quorum/debates/2026-05-03-copilot-1-is-the-mcp-system-robust.md
@@ -1,0 +1,24 @@
+---
+date: 2026-05-03
+question: "Is the MCP system robust?"
+slot: copilot-1
+round: 1
+mode: "A"
+verdict: [call-quorum-slot] Timeouts: idle=300000ms hard=300000ms for slot copilot-1
+[call-quorum-slot] [spawn error: spawn ask ENOENT]
+[call-quorum-slot] Set cooldown for copilot-1 via set-availability
+
+matched_requirement_ids: [MCP-01, MCP-04, MCP-06, MCP-02, MCP-03, MCP-05, MCPENV-01, MCPENV-02, MCPENV-03, MCPENV-04, AGENT-01, CONF-03, MULTI-03, SETUP-01, SLOT-02, SLOT-04, AGENT-02, AGENT-03, AGENT-04, BENCH-08]
+artifact_path: ""
+---
+
+# Debate Trace: copilot-1 on round 1
+
+## Reasoning
+[call-quorum-slot] Timeouts: idle=300000ms hard=300000ms for slot copilot-1
+[call-quorum-slot] [spawn error: spawn ask ENOENT]
+[call-quorum-slot] Set cooldown for copilot-1 via set-availability
+
+
+## Citations
+(none)

--- a/.planning/quorum/debates/2026-05-03-gemini-1-is-the-mcp-system-robust.md
+++ b/.planning/quorum/debates/2026-05-03-gemini-1-is-the-mcp-system-robust.md
@@ -1,0 +1,28 @@
+---
+date: 2026-05-03
+question: "Is the MCP system robust?"
+slot: gemini-1
+round: 1
+mode: "A"
+verdict: [call-quorum-slot] Timeouts: idle=300000ms hard=300000ms for slot gemini-1
+[call-quorum-slot] retry 1/2 for slot gemini-1 after 1000ms
+[call-quorum-slot] RATE_LIMITED: 2 rate-limit messages detected in stderr, killing early
+[call-quorum-slot] retry 2/2 for slot gemini-1 after 3000ms
+[call-quorum-slot] STALL: only 874 bytes received then silence for 30000ms — no recognizable error pattern in partial output
+[call-quorum-slot] Set cooldown for gemini-1 via set-availability
+
+matched_requirement_ids: [MCP-01, MCP-04, MCP-06, MCP-02, MCP-03, MCP-05, MCPENV-01, MCPENV-02, MCPENV-03, MCPENV-04, AGENT-01, CONF-03, MULTI-03, SETUP-01, SLOT-02, SLOT-04, AGENT-02, AGENT-03, AGENT-04, BENCH-08]
+artifact_path: ""
+---
+
+# Debate Trace: gemini-1 on round 1
+
+## Reasoning
+[call-quorum-slot] Timeouts: idle=300000ms hard=300000ms for slot gemini-1
+[call-quorum-slot] retry 1/2 for slot gemini-1 after 1000ms
+[call-quorum-slot] RATE_LIMITED: 2 rate-limit messages detected in stderr, killing early
+[call-quorum-slot] retry 2/2 for slot gemini-1 after 3000ms
+[call-quorum-slot] STALL: only 874 bytes received then silence for 30000ms — no recognizable error pattern in partia
+
+## Citations
+(none)

--- a/.planning/quorum/debates/2026-05-03-opencode-1-is-the-mcp-system-robust.md
+++ b/.planning/quorum/debates/2026-05-03-opencode-1-is-the-mcp-system-robust.md
@@ -1,0 +1,22 @@
+---
+date: 2026-05-03
+question: "Is the MCP system robust?"
+slot: opencode-1
+round: 1
+mode: "A"
+verdict: **Verdict: YES — the MCP system is robust.**
+
+The system demonstrates defense-in-depth across multiple dimensions. The dispatch guard (`hooks/nf-mcp-dispatch-guard.js`) uses a strict fail-open design — every error path (empty stdin, malformed JSON, missing providers.json) exits with code 0 and no block, preventing accidental MCP lockout. Slot discovery is dynamic via `providers.json` with family derivation by stripping `-N` suffixes, so new slots are automatically covered. The 20 unit tests (all
+matched_requirement_ids: [MCP-01, MCP-04, MCP-06, MCP-02, MCP-03, MCP-05, MCPENV-01, MCPENV-02, MCPENV-03, MCPENV-04, AGENT-01, CONF-03, MULTI-03, SETUP-01, SLOT-02, SLOT-04, AGENT-02, AGENT-03, AGENT-04, BENCH-08]
+artifact_path: ""
+---
+
+# Debate Trace: opencode-1 on round 1
+
+## Reasoning
+**Verdict: YES — the MCP system is robust.**
+
+The system demonstrates defense-in-depth across multiple dimensions. The dispatch guard (`hooks/nf-mcp-dispatch-guard.js`) uses a strict fail-open design — every error path (empty stdin, malformed JSON, missing providers.json) exits with code 0 and no block, preventing accidental MCP lockout. Slot discovery is dynamic via `providers.json` with family d
+
+## Citations
+(none)

--- a/.planning/quorum/debates/2026-05-12-claude-1-is-the-nforma-quorum-system-robust-evaluate-streng.md
+++ b/.planning/quorum/debates/2026-05-12-claude-1-is-the-nforma-quorum-system-robust-evaluate-streng.md
@@ -1,0 +1,24 @@
+---
+date: 2026-05-12
+question: "Is the nForma quorum system robust? Evaluate strengths and weaknesses across: pre-flight provider health probes, tiered fallback (T1 sub-CLI → T2 api), Stop-hook FALLBACK_CHECKPOINT enforcement, dispatch-nonce authenticity (preventing Haiku from faking results), parallel sibling Task dispatch per round, unanimity-based consensus with BLOCK-is-absolute (CE-2), scoreboard persistence, adaptive fan-out by envelope risk, and observed config-drift risks (recent providers.json backups in bin/). Give a verdict (APPROVE if robust, BLOCK if you see critical gaps) and short rationale."
+slot: claude-1
+round: 1
+mode: "A"
+verdict: [call-quorum-slot] Timeouts: idle=300000ms hard=300000ms for slot claude-1
+[call-quorum-slot] [spawn error: The "file" argument must be of type string. Received null]
+[call-quorum-slot] Set cooldown for claude-1 via set-availability
+
+matched_requirement_ids: [STOP-05, STOP-01, STOP-06, STOP-08, DISP-01, DISP-06, DISP-07, IMPR-02, QUORUM-03, STOP-02, STOP-03, STOP-07, STOP-09, UPS-03, QPREC-01, QUORUM-01, STOP-04, TRUNC-02, TRUNC-03, CONF-03]
+artifact_path: ""
+---
+
+# Debate Trace: claude-1 on round 1
+
+## Reasoning
+[call-quorum-slot] Timeouts: idle=300000ms hard=300000ms for slot claude-1
+[call-quorum-slot] [spawn error: The "file" argument must be of type string. Received null]
+[call-quorum-slot] Set cooldown for claude-1 via set-availability
+
+
+## Citations
+(none)

--- a/.planning/quorum/debates/2026-05-12-codex-1-is-the-nforma-quorum-system-robust-evaluate-streng.md
+++ b/.planning/quorum/debates/2026-05-12-codex-1-is-the-nforma-quorum-system-robust-evaluate-streng.md
@@ -1,0 +1,24 @@
+---
+date: 2026-05-12
+question: "Is the nForma quorum system robust? Evaluate strengths and weaknesses across: pre-flight provider health probes, tiered fallback (T1 sub-CLI → T2 api), Stop-hook FALLBACK_CHECKPOINT enforcement, dispatch-nonce authenticity (preventing Haiku from faking results), parallel sibling Task dispatch per round, unanimity-based consensus with BLOCK-is-absolute (CE-2), scoreboard persistence, adaptive fan-out by envelope risk, and observed config-drift risks (recent providers.json backups in bin/). Give a verdict (APPROVE if robust, BLOCK if you see critical gaps) and short rationale."
+slot: codex-1
+round: 1
+mode: "A"
+verdict: [call-quorum-slot] Timeouts: idle=300000ms hard=300000ms for slot codex-1
+[call-quorum-slot] [spawn error: The "file" argument must be of type string. Received null]
+[call-quorum-slot] Set cooldown for codex-1 via set-availability
+
+matched_requirement_ids: [STOP-05, STOP-01, STOP-06, STOP-08, DISP-01, DISP-06, DISP-07, IMPR-02, QUORUM-03, STOP-02, STOP-03, STOP-07, STOP-09, UPS-03, QPREC-01, QUORUM-01, STOP-04, TRUNC-02, TRUNC-03, CONF-03]
+artifact_path: ""
+---
+
+# Debate Trace: codex-1 on round 1
+
+## Reasoning
+[call-quorum-slot] Timeouts: idle=300000ms hard=300000ms for slot codex-1
+[call-quorum-slot] [spawn error: The "file" argument must be of type string. Received null]
+[call-quorum-slot] Set cooldown for codex-1 via set-availability
+
+
+## Citations
+(none)

--- a/.planning/quorum/debates/2026-05-12-copilot-1-is-the-nforma-quorum-system-robust-evaluate-streng.md
+++ b/.planning/quorum/debates/2026-05-12-copilot-1-is-the-nforma-quorum-system-robust-evaluate-streng.md
@@ -1,0 +1,24 @@
+---
+date: 2026-05-12
+question: "Is the nForma quorum system robust? Evaluate strengths and weaknesses across: pre-flight provider health probes, tiered fallback (T1 sub-CLI → T2 api), Stop-hook FALLBACK_CHECKPOINT enforcement, dispatch-nonce authenticity (preventing Haiku from faking results), parallel sibling Task dispatch per round, unanimity-based consensus with BLOCK-is-absolute (CE-2), scoreboard persistence, adaptive fan-out by envelope risk, and observed config-drift risks (recent providers.json backups in bin/). Give a verdict (APPROVE if robust, BLOCK if you see critical gaps) and short rationale."
+slot: copilot-1
+round: 1
+mode: "A"
+verdict: [call-quorum-slot] Timeouts: idle=300000ms hard=300000ms for slot copilot-1
+[call-quorum-slot] [spawn error: The "file" argument must be of type string. Received null]
+[call-quorum-slot] Set cooldown for copilot-1 via set-availability
+
+matched_requirement_ids: [STOP-05, STOP-01, STOP-06, STOP-08, DISP-01, DISP-06, DISP-07, IMPR-02, QUORUM-03, STOP-02, STOP-03, STOP-07, STOP-09, UPS-03, QPREC-01, QUORUM-01, STOP-04, TRUNC-02, TRUNC-03, CONF-03]
+artifact_path: ""
+---
+
+# Debate Trace: copilot-1 on round 1
+
+## Reasoning
+[call-quorum-slot] Timeouts: idle=300000ms hard=300000ms for slot copilot-1
+[call-quorum-slot] [spawn error: The "file" argument must be of type string. Received null]
+[call-quorum-slot] Set cooldown for copilot-1 via set-availability
+
+
+## Citations
+(none)

--- a/.planning/quorum/debates/2026-05-12-gemini-1-is-the-nforma-quorum-system-robust-evaluate-streng.md
+++ b/.planning/quorum/debates/2026-05-12-gemini-1-is-the-nforma-quorum-system-robust-evaluate-streng.md
@@ -1,0 +1,24 @@
+---
+date: 2026-05-12
+question: "Is the nForma quorum system robust? Evaluate strengths and weaknesses across: pre-flight provider health probes, tiered fallback (T1 sub-CLI → T2 api), Stop-hook FALLBACK_CHECKPOINT enforcement, dispatch-nonce authenticity (preventing Haiku from faking results), parallel sibling Task dispatch per round, unanimity-based consensus with BLOCK-is-absolute (CE-2), scoreboard persistence, adaptive fan-out by envelope risk, and observed config-drift risks (recent providers.json backups in bin/). Give a verdict (APPROVE if robust, BLOCK if you see critical gaps) and short rationale."
+slot: gemini-1
+round: 1
+mode: "A"
+verdict: [call-quorum-slot] Timeouts: idle=300000ms hard=300000ms for slot gemini-1
+[call-quorum-slot] [spawn error: The "file" argument must be of type string. Received null]
+[call-quorum-slot] Set cooldown for gemini-1 via set-availability
+
+matched_requirement_ids: [STOP-05, STOP-01, STOP-06, STOP-08, DISP-01, DISP-06, DISP-07, IMPR-02, QUORUM-03, STOP-02, STOP-03, STOP-07, STOP-09, UPS-03, QPREC-01, QUORUM-01, STOP-04, TRUNC-02, TRUNC-03, CONF-03]
+artifact_path: ""
+---
+
+# Debate Trace: gemini-1 on round 1
+
+## Reasoning
+[call-quorum-slot] Timeouts: idle=300000ms hard=300000ms for slot gemini-1
+[call-quorum-slot] [spawn error: The "file" argument must be of type string. Received null]
+[call-quorum-slot] Set cooldown for gemini-1 via set-availability
+
+
+## Citations
+(none)

--- a/.planning/quorum/debates/2026-05-12-opencode-1-is-the-nforma-quorum-system-robust-evaluate-streng.md
+++ b/.planning/quorum/debates/2026-05-12-opencode-1-is-the-nforma-quorum-system-robust-evaluate-streng.md
@@ -1,0 +1,24 @@
+---
+date: 2026-05-12
+question: "Is the nForma quorum system robust? Evaluate strengths and weaknesses across: pre-flight provider health probes, tiered fallback (T1 sub-CLI → T2 api), Stop-hook FALLBACK_CHECKPOINT enforcement, dispatch-nonce authenticity (preventing Haiku from faking results), parallel sibling Task dispatch per round, unanimity-based consensus with BLOCK-is-absolute (CE-2), scoreboard persistence, adaptive fan-out by envelope risk, and observed config-drift risks (recent providers.json backups in bin/). Give a verdict (APPROVE if robust, BLOCK if you see critical gaps) and short rationale."
+slot: opencode-1
+round: 1
+mode: "A"
+verdict: [call-quorum-slot] Timeouts: idle=300000ms hard=300000ms for slot opencode-1
+[call-quorum-slot] [spawn error: The "file" argument must be of type string. Received null]
+[call-quorum-slot] Set cooldown for opencode-1 via set-availability
+
+matched_requirement_ids: [STOP-05, STOP-01, STOP-06, STOP-08, DISP-01, DISP-06, DISP-07, IMPR-02, QUORUM-03, STOP-02, STOP-03, STOP-07, STOP-09, UPS-03, QPREC-01, QUORUM-01, STOP-04, TRUNC-02, TRUNC-03, CONF-03]
+artifact_path: ""
+---
+
+# Debate Trace: opencode-1 on round 1
+
+## Reasoning
+[call-quorum-slot] Timeouts: idle=300000ms hard=300000ms for slot opencode-1
+[call-quorum-slot] [spawn error: The "file" argument must be of type string. Received null]
+[call-quorum-slot] Set cooldown for opencode-1 via set-availability
+
+
+## Citations
+(none)

--- a/.planning/quorum/debates/2026-05-13-claude-1-is-the-nforma-quorum-consensus-system-robust-evalu.md
+++ b/.planning/quorum/debates/2026-05-13-claude-1-is-the-nforma-quorum-consensus-system-robust-evalu.md
@@ -1,0 +1,26 @@
+---
+date: 2026-05-13
+question: "Is the nForma quorum consensus system robust? Evaluate strengths, weaknesses, and concrete failure modes of: CE-1 facilitator-only rule, CE-2 BLOCK is absolute, CE-3 unanimity required, R3 deliberation up to 10 rounds with escalation, tiered fallback T1 sub-CLI to T2 API, file-first nonce authenticity for slot results, FALLBACK_CHECKPOINT enforced by Stop hook, adaptive fan-out by envelope risk_level, scoreboard. Provide verdict APPROVE or BLOCK with reasoning."
+slot: claude-1
+round: 1
+mode: "A"
+verdict: **Verdict: APPROVE**
+
+**Strengths:**
+
+The system is architecturally sound with defense-in-depth across multiple layers. CE-2 (BLOCK is absolute) is the strongest design choice — it prevents any single compromised or confused slot from being outvoted, which is correct for a safety-critical consensus system. The nonce-based authenticity in `call-quorum-slot.cjs` (dispatch nonce passed parent→child, written to result file) provides meaningful tamper resistance for file-first slot results. The Poiss
+matched_requirement_ids: [QUORUM-01, STOP-08, TOKN-04, DISP-06, DISP-07, IMPR-02, SLOT-01, STOP-05, TRUNC-04, UPPAAL-02, DISP-03, DISP-05, FAIL-01, HEAL-01, ORES-03, QPREC-01, QUORUM-03, SETUP-01, SLOT-03, STOP-07]
+artifact_path: ""
+---
+
+# Debate Trace: claude-1 on round 1
+
+## Reasoning
+**Verdict: APPROVE**
+
+**Strengths:**
+
+The system is architecturally sound with defense-in-depth across multiple layers. CE-2 (BLOCK is absolute) is the strongest design choice — it prevents any single compromised or confused slot from being outvoted, which is correct for a safety-critical consensus system. The nonce-based authenticity in `call-quorum-slot.cjs` (dispatch nonce passed parent→child, 
+
+## Citations
+(none)

--- a/.planning/quorum/debates/2026-05-13-copilot-1-is-the-nforma-quorum-consensus-system-robust-evalu.md
+++ b/.planning/quorum/debates/2026-05-13-copilot-1-is-the-nforma-quorum-consensus-system-robust-evalu.md
@@ -1,0 +1,24 @@
+---
+date: 2026-05-13
+question: "Is the nForma quorum consensus system robust? Evaluate strengths, weaknesses, and concrete failure modes of: CE-1 facilitator-only rule, CE-2 BLOCK is absolute, CE-3 unanimity required, R3 deliberation up to 10 rounds with escalation, tiered fallback T1 sub-CLI to T2 API, file-first nonce authenticity for slot results, FALLBACK_CHECKPOINT enforced by Stop hook, adaptive fan-out by envelope risk_level, scoreboard. Provide verdict APPROVE or BLOCK with reasoning."
+slot: copilot-1
+round: 1
+mode: "A"
+verdict: [call-quorum-slot] Timeouts: idle=300000ms hard=300000ms for slot copilot-1
+[call-quorum-slot] [spawn error: spawn ask ENOENT]
+[call-quorum-slot] Set cooldown for copilot-1 via set-availability
+
+matched_requirement_ids: [QUORUM-01, STOP-08, TOKN-04, DISP-06, DISP-07, IMPR-02, SLOT-01, STOP-05, TRUNC-04, UPPAAL-02, DISP-03, DISP-05, FAIL-01, HEAL-01, ORES-03, QPREC-01, QUORUM-03, SETUP-01, SLOT-03, STOP-07]
+artifact_path: ""
+---
+
+# Debate Trace: copilot-1 on round 1
+
+## Reasoning
+[call-quorum-slot] Timeouts: idle=300000ms hard=300000ms for slot copilot-1
+[call-quorum-slot] [spawn error: spawn ask ENOENT]
+[call-quorum-slot] Set cooldown for copilot-1 via set-availability
+
+
+## Citations
+(none)

--- a/.planning/quorum/debates/2026-05-13-copilot-1-is-the-quorum-system-robust-evaluate-strengths-wea.md
+++ b/.planning/quorum/debates/2026-05-13-copilot-1-is-the-quorum-system-robust-evaluate-strengths-wea.md
@@ -1,0 +1,24 @@
+---
+date: 2026-05-13
+question: "is the quorum system robust? Evaluate strengths/weaknesses of nForma quorum protocol R3: Claude+native CLI agents (codex/gemini/opencode/copilot)+claude-mcp servers. Key design: CE-1 advisory-only orchestrator, CE-2 BLOCK-is-absolute, CE-3 unanimity, nonce-authenticated file result reading, FALLBACK_CHECKPOINT Stop-hook enforcement, tiered T1(sub)/T2(api) fallback, adaptive fan-out by risk_level, max_quorum_size minimum, 10-round deliberation cap. Recent patches: e25c31fd (CLI resolve from mainTool), 600908a1 (self-heal mainTool), 6427d31e/49ca5168 (UNIFIED_PROVIDERS_CONFIG backfill). NOTE: in this very dispatch, codex-1 produced only PENDING placeholder (CLI hung past timeout) and gemini-1 hit rate-limits—both primaries failed, fallback engaged. Evaluate APPROVE (robust enough for production) or BLOCK (material weaknesses). Cite files/lines."
+slot: copilot-1
+round: 1
+mode: "A"
+verdict: [call-quorum-slot] Timeouts: idle=300000ms hard=300000ms for slot copilot-1
+[call-quorum-slot] [spawn error: spawn ask ENOENT]
+[call-quorum-slot] Set cooldown for copilot-1 via set-availability
+
+matched_requirement_ids: [STOP-08, HEAL-01, MCP-04, STOP-05, DISP-07, MCP-06, STOP-01, STOP-04, STOP-06, STOP-07, STOP-09, HEAL-02, MCP-01, MCP-02, STOP-03, TRUNC-01, KEY-03, SENS-01, SLOT-01, STOP-02]
+artifact_path: ""
+---
+
+# Debate Trace: copilot-1 on round 1
+
+## Reasoning
+[call-quorum-slot] Timeouts: idle=300000ms hard=300000ms for slot copilot-1
+[call-quorum-slot] [spawn error: spawn ask ENOENT]
+[call-quorum-slot] Set cooldown for copilot-1 via set-availability
+
+
+## Citations
+(none)

--- a/.planning/quorum/debates/2026-05-13-gemini-1-is-the-nforma-quorum-consensus-system-robust-evalu.md
+++ b/.planning/quorum/debates/2026-05-13-gemini-1-is-the-nforma-quorum-consensus-system-robust-evalu.md
@@ -1,0 +1,29 @@
+---
+date: 2026-05-13
+question: "Is the nForma quorum consensus system robust? Evaluate strengths, weaknesses, and failure modes of: CE-1/CE-2/CE-3 consensus rules (orchestrator-as-facilitator, BLOCK is absolute, unanimity required), R3 deliberation protocol (up to 10 rounds with escalation), tiered fallback (T1 sub-CLI / T2 API), file-first nonce authenticity for slot results, FALLBACK_CHECKPOINT enforced by Stop hook, adaptive fan-out by envelope risk_level, scoreboard tracking. Identify concrete failure modes and recommend improvements. Provide verdict APPROVE/BLOCK and reasoning."
+slot: gemini-1
+round: 1
+mode: "A"
+verdict: [call-quorum-slot] Timeouts: idle=300000ms hard=300000ms for slot gemini-1
+[call-quorum-slot] RATE_LIMITED: 2 rate-limit messages detected in stderr, killing early
+[call-quorum-slot] retry 1/2 for slot gemini-1 after 1000ms
+[call-quorum-slot] RATE_LIMITED: 2 rate-limit messages detected in stderr, killing early
+[call-quorum-slot] retry 2/2 for slot gemini-1 after 3000ms
+[call-quorum-slot] RATE_LIMITED: 2 rate-limit messages detected in stderr, killing early
+[call-quorum-slot] RATE_LIMITED after 
+matched_requirement_ids: [STOP-08, QUORUM-01, TOKN-04, DISP-05, DISP-07, IMPR-02, SLOT-01, STOP-05, TRUNC-04, DISP-03, DISP-06, HEAL-01, QPREC-01, QUORUM-03, SCBD-01, SLOT-03, STOP-07, STOP-09, TRUNC-01, TRUNC-03]
+artifact_path: ""
+---
+
+# Debate Trace: gemini-1 on round 1
+
+## Reasoning
+[call-quorum-slot] Timeouts: idle=300000ms hard=300000ms for slot gemini-1
+[call-quorum-slot] RATE_LIMITED: 2 rate-limit messages detected in stderr, killing early
+[call-quorum-slot] retry 1/2 for slot gemini-1 after 1000ms
+[call-quorum-slot] RATE_LIMITED: 2 rate-limit messages detected in stderr, killing early
+[call-quorum-slot] retry 2/2 for slot gemini-1 after 3000ms
+[call-quorum-slot] RATE_LIM
+
+## Citations
+(none)

--- a/.planning/quorum/debates/2026-05-13-gemini-1-is-the-quorum-system-robust-evaluate-strengths-and.md
+++ b/.planning/quorum/debates/2026-05-13-gemini-1-is-the-quorum-system-robust-evaluate-strengths-and.md
@@ -1,0 +1,24 @@
+---
+date: 2026-05-13
+question: "Is the quorum system robust? Evaluate strengths and weaknesses of the nForma quorum (Claude + native CLI agents + claude-mcp-server instances): consensus rules (CE-1 facilitator-only, CE-2 absolute BLOCK, CE-3 unanimity), tiered fallback (T1 sub → T2 api), file-based nonce authenticity, parallel dispatch, deliberation rounds, scoreboard, and adaptive fan-out by risk level. Identify the top failure modes and the strongest design properties."
+slot: gemini-1
+round: 1
+mode: "A"
+verdict: The nForma quorum system is a robust, security-hardened multi-model consensus protocol designed to mitigate the risks of single-model hallucinations and subagent fabrication. Its strength lies in its formal enforcement rules (**CE-1/2/3**) and its "Option C" dispatch pattern, which uses file-based nonces to ensure result authenticity.
+
+### Strongest Design Properties
+- **Consensus Enforcement (CE-1..3):** By requiring **100% unanimity** (CE-3) and making **BLOCK absolute** (CE-2), the system ens
+matched_requirement_ids: [MCP-01, MCP-04, MCP-06, SLOT-01, QUORUM-01, TOKN-04, IMPR-02, MCP-02, MCP-03, QUORUM-02, QUORUM-03, SENS-01, SETUP-01, SLOT-02, STOP-05, STOP-08, UPS-03, AGENT-01, DISP-06, MCP-05]
+artifact_path: ""
+---
+
+# Debate Trace: gemini-1 on round 1
+
+## Reasoning
+The nForma quorum system is a robust, security-hardened multi-model consensus protocol designed to mitigate the risks of single-model hallucinations and subagent fabrication. Its strength lies in its formal enforcement rules (**CE-1/2/3**) and its "Option C" dispatch pattern, which uses file-based nonces to ensure result authenticity.
+
+### Strongest Design Properties
+- **Consensus Enforcement (CE-
+
+## Citations
+(none)

--- a/.planning/quorum/debates/2026-05-13-gemini-1-is-the-quorum-system-robust-evaluate-the-strengths.md
+++ b/.planning/quorum/debates/2026-05-13-gemini-1-is-the-quorum-system-robust-evaluate-the-strengths.md
@@ -1,0 +1,29 @@
+---
+date: 2026-05-13
+question: "is the quorum system robust? Evaluate the strengths and weaknesses of the nForma quorum protocol (R3): Claude+native-CLI agents (codex/gemini/opencode/copilot) + claude-mcp servers. Key design points to weigh: CE-1 advisory-only orchestrator, CE-2 BLOCK-is-absolute, CE-3 unanimity required, nonce-authenticated file-based result reading, FALLBACK_CHECKPOINT Stop-hook enforcement, tiered T1(auth_type=sub)→T2(auth_type≠sub) fallback, adaptive fan-out by envelope risk_level, model-id-versioned scoreboard, max_quorum_size minimum, 10-round deliberation cap. Recent fragility patches: e25c31fd (CLI resolve from mainTool), 600908a1 (self-heal mainTool), 6427d31e/49ca5168 (UNIFIED_PROVIDERS_CONFIG backfill, providers.json auto-fallback). Evaluate as APPROVE (robust enough for production) or BLOCK (material weaknesses). Cite concrete files/lines where possible."
+slot: gemini-1
+round: 1
+mode: "A"
+verdict: [call-quorum-slot] Timeouts: idle=300000ms hard=300000ms for slot gemini-1
+[call-quorum-slot] RATE_LIMITED: 2 rate-limit messages detected in stderr, killing early
+[call-quorum-slot] retry 1/2 for slot gemini-1 after 1000ms
+[call-quorum-slot] RATE_LIMITED: 2 rate-limit messages detected in stderr, killing early
+[call-quorum-slot] retry 2/2 for slot gemini-1 after 3000ms
+[call-quorum-slot] RATE_LIMITED: 2 rate-limit messages detected in stderr, killing early
+[call-quorum-slot] RATE_LIMITED after 
+matched_requirement_ids: [STOP-05, STOP-01, STOP-08, HEAL-01, HEAL-02, MCP-01, SENS-01, STOP-09, UPPAAL-01, DISP-07, KEY-03, MCP-04, SLOT-01, SLOT-02, STOP-04, STOP-06, STOP-07, UPPAAL-02, DECOMP-01, MCP-06]
+artifact_path: ""
+---
+
+# Debate Trace: gemini-1 on round 1
+
+## Reasoning
+[call-quorum-slot] Timeouts: idle=300000ms hard=300000ms for slot gemini-1
+[call-quorum-slot] RATE_LIMITED: 2 rate-limit messages detected in stderr, killing early
+[call-quorum-slot] retry 1/2 for slot gemini-1 after 1000ms
+[call-quorum-slot] RATE_LIMITED: 2 rate-limit messages detected in stderr, killing early
+[call-quorum-slot] retry 2/2 for slot gemini-1 after 3000ms
+[call-quorum-slot] RATE_LIM
+
+## Citations
+(none)

--- a/.planning/quorum/debates/2026-05-13-is-the-quorum-robust.md
+++ b/.planning/quorum/debates/2026-05-13-is-the-quorum-robust.md
@@ -1,0 +1,38 @@
+# Quorum Debate
+Question: Is the nForma quorum consensus system robust?
+Date: 2026-05-13
+Consensus: APPROVE
+Rounds: 1
+
+## Round 1
+| Model | Position | Citations |
+|---|---|---|
+| Claude (ADVISORY) | Robust against single-model failure & bias; fragile around dispatch substrate (Haiku-relay) and small-quorum statistics at FAN_OUT_COUNT=2 | commands/nf/quorum.md (CE-1/CE-2/CE-3), bin/quorum-slot-dispatch.cjs |
+| codex-1 | UNAVAIL — Haiku-relay reported shell parse error; no file written | — |
+| gemini-1 | UNAVAIL — RATE_LIMITED (2 consecutive rate-limit errors, killed early; cooldown set) | — |
+| opencode-1 (T1 fallback) | APPROVE — defense-in-depth confirmed. CE-1 facilitator-only is enforced via transcript JSONL parsing (not substring matching — STOP-05). CE-2 BLOCK is structurally enforced by Claude Code hook. Nonce system provides cryptographic-grade proof of dispatch. Failure modes: (1) Poisson binomial assumes independent failures, breaks under provider-wide outages; (2) CE-3 unanimity + CE-2 absolute BLOCK creates deadlock until maxDeliberation; (3) FALLBACK_CHECKPOINT as HTML comment is fragile vs. file-based marker | bin/quorum-slot-dispatch.cjs:1466 (nonce), bin/nf-stop.js:432-530 (FALLBACK-01 detection), bin/quorum-consensus-gate.cjs:187-203 (early escalation), bin/call-quorum-slot.cjs:188-238 (retry with backoff) |
+| copilot-1 (T1 fallback) | UNAVAIL — `spawn ask ENOENT` (copilot CLI binary not in PATH); cooldown set | — |
+| claude-1 (T1 fallback) | APPROVE — architecturally sound. CE-2 absolute BLOCK is the strongest design choice. Nonce-based authenticity in call-quorum-slot.cjs provides meaningful tamper resistance. Poisson binomial CDF mathematically rigorous. Tiered fallback (CLI/CCR before HTTP API) + per-provider semaphores is pragmatic. Write-once verdict semantics in convergence-gate-runner.cjs prevents corruption. Weaknesses (bounded): (1) CE-3 unanimity fragile at reduced quorum; (2) CE-1 facilitator availability dependency; (3) file-based semaphore PIDs best-effort; (4) nonce is defense-in-depth not cryptographic; (5) scoreboard score deltas are hand-tuned. No failure mode leads to silent consensus corruption | bin/call-quorum-slot.cjs (retry logic, nonce authenticity), bin/quorum-consensus-gate.cjs:33-58 (Poisson binomial CDF), bin/update-scoreboard.cjs:34-43 (score deltas), commands/nf/quorum.md (CE-1/CE-2/CE-3, FAN-01..FAN-06, R3.3), bin/convergence-gate-runner.cjs (write-once verdicts), .planning/formal/prism/deliberation-healing.pm (HEAL-01 model) |
+
+## Outcome
+
+**CONSENSUS APPROVE — the quorum is robust.**
+
+Defense-in-depth across multiple independent layers:
+- CE-2 (BLOCK is absolute) prevents any single compromised slot from being outvoted
+- Nonce authenticity makes Haiku-relay fabrication structurally impossible
+- Poisson binomial CDF for HEAL-01 early escalation avoids wasted rounds
+- Tiered T1→T2 fallback (demonstrated working this very round: 2/2 primaries UNAVAIL → 2/3 T1 fallbacks succeeded → consensus reached)
+- Write-once verdict semantics and fail-open observability prevent silent corruption
+- FALLBACK_CHECKPOINT enforced by Stop hook prevents bypassing quorum
+
+Bounded weaknesses (acknowledged by both APPROVE voters):
+1. Correlated-failure blind spot in Poisson binomial (provider-wide outages overestimate P(consensus))
+2. CE-3 unanimity fragility at FAN_OUT_COUNT=2 (single voter has 100% weight; persistent BLOCK can deadlock 10 rounds)
+3. HTML-comment FALLBACK_CHECKPOINT is fragile vs. file-based marker
+4. File semaphore PID cleanup is best-effort; stale locks can reduce concurrency
+5. Static scoreboard score deltas may drift from empirical signal-to-noise
+
+The session itself demonstrated the robustness path empirically — 60% primary slot failure rate, system degraded gracefully, consensus reached in Round 1 via tiered fallback.
+
+External voter tally: 2 APPROVE / 0 BLOCK / 3 UNAVAIL (Claude's position excluded per CE-1)

--- a/.planning/quorum/debates/2026-05-13-is-the-quorum-system-robust-r3.md
+++ b/.planning/quorum/debates/2026-05-13-is-the-quorum-system-robust-r3.md
@@ -1,0 +1,45 @@
+# Quorum Debate
+Question: Is the quorum system robust?
+Date: 2026-05-13
+Consensus: APPROVE
+Rounds: 1
+Mode: A (pure question)
+
+## Round 1
+
+| Model | Position | Citations |
+|---|---|---|
+| Claude (ADVISORY — not a vote) | Integrity strong; availability + Byzantine defense weak. CE rules and nonce mechanism robust against transport-layer failures; orchestrator framing power + correlated provider drift remain unhandled. | commands/nf/quorum.md (CE-1/2/3); bin/quorum-slot-dispatch.cjs (nonce) |
+| codex-1 (primary) | UNAVAIL — CLI subprocess did not respond in window (dispatch wrote PENDING with valid nonce, no verdict). | — |
+| opencode-1 (T1 fallback) | APPROVE — robust but with known operational fragility. Integrity mechanisms production-grade (CE-2 BLOCK-absolute, nonce authenticity, FALLBACK-01 enforcement, Poisson-binomial gating). Availability is the weak axis: thin-unanimity risk under degraded roster; third-party CLI hangs/rate-limits/missing binaries; self-eval bias channel via orchestrator presentation. | nf-stop.js:518-526,756-770; call-quorum-slot.cjs:255,264; quorum-consensus-gate.cjs:33-58,187-203; quorum-slot-dispatch.cjs:46-96 |
+| gemini-1 (primary) | APPROVE — "robust, security-hardened multi-model consensus protocol". Strongest: CE-1..3 unanimity + facilitator-only orchestrator, nonce-verified file results, adaptive fan-out (FAN-01..04), tiered fallback + scoreboard flakiness tracking. Failure modes: consensus gridlock on subjective questions, provider bottlenecks (slowest-provider parallel dispatch), context window exhaustion in deliberation. | commands/nf/quorum.md (CE-1/2/3); bin/quorum-slot-dispatch.cjs (nonce + file write); agents/nf-quorum-orchestrator.md (tiered fallback); bin/update-scoreboard.cjs (computeFlakiness) |
+
+## Outcome
+
+**APPROVE — robust on integrity, fragile on availability.**
+
+Both external voters converged on the same shape of answer despite different framing:
+
+**Strongest design properties (consensus):**
+- CE-1/CE-2/CE-3 consensus rules — facilitator-only + absolute BLOCK + unanimity. CE-2 transcript-enforced by `nf-stop.js:756-770`.
+- File-based nonce authenticity in `quorum-slot-dispatch.cjs` closes the relay-fabrication attack vector.
+- Tiered fallback (T1 sub → T2 api) with FALLBACK_CHECKPOINT (`nf-stop.js:518-526`) blocks fail-open. **This run exercised it in Round 1** — codex-1 PENDING → opencode-1 T1 → CE-3 unanimity preserved.
+- Poisson-binomial consensus gating (`quorum-consensus-gate.cjs:33-58`) enables mathematically grounded early escalation.
+- Adaptive fan-out by envelope risk balances token cost with rigor.
+
+**Top failure modes (consensus):**
+1. **Availability surface is the weak axis.** This very run is the evidence — codex-1 hung. Both voters flagged third-party CLI hangs, rate-limits, missing binaries.
+2. **Degraded-roster thin unanimity.** CE-3 1/1=100% is technically correct but pragmatically weak. No minimum-live-quorum floor today.
+3. **Consensus gridlock & context exhaustion** in deliberation rounds, especially on subjective questions or with large artifacts cross-pollinated through smaller models.
+4. **Self-evaluation / orchestrator framing bias.** CE-1 makes Claude advisory, but the orchestrator still controls peer-result synthesis and display.
+
+**Recommendations (consensus-aligned, not voted):**
+- Add a **minimum-live-quorum floor** so 1/1 unanimity does not silently count on high-risk decisions.
+- Add **slot-health SLOs** to scoreboard so chronic UNAVAIL slots auto-rotate out of `$DISPATCH_LIST` primary positions.
+- Consider Byzantine-resistant model-family diversification on high-risk questions.
+
+## Notes
+
+- FAN_OUT_COUNT=3 (medium risk default) → 2 external slots in `$DISPATCH_LIST`: codex-1, gemini-1.
+- FALLBACK_CHECKPOINT: codex-1 UNAVAIL → opencode-1 dispatched as T1 fallback (auth_type=sub, next in working list).
+- Consensus reached on Round 1 with 2/2 valid voters APPROVE.

--- a/.planning/quorum/debates/2026-05-13-is-the-quorum-system-robust.md
+++ b/.planning/quorum/debates/2026-05-13-is-the-quorum-system-robust.md
@@ -1,0 +1,27 @@
+# Quorum Debate
+Question: is the quorum system robust?
+Date: 2026-05-13
+Consensus: APPROVE (1/1 valid external voter — degraded roster)
+Rounds: 1
+
+## Round 1
+| Model | Position | Citations |
+|---|---|---|
+| Claude (ADVISORY — not a vote) | Moderately robust: strong structural safeguards (CE-1/2/3, nonce auth, FALLBACK_CHECKPOINT, tiered fallback, adaptive fan-out), but operational fragility around third-party CLI surfaces (recent patches e25c31fd, 600908a1, 6427d31e, 49ca5168) and self-evaluation bias. | recent commits e25c31fd / 600908a1 / 6427d31e / 49ca5168 |
+| codex-1 (primary) | UNAVAIL — CLI hung past 300s timeout; only PENDING placeholder written. | — |
+| gemini-1 (primary) | UNAVAIL — RATE_LIMITED after 2 retries. | — |
+| opencode-1 (T1 fallback) | **APPROVE.** Defense-in-depth: stop-hook FALLBACK-01 detection, nonce + PENDING write, per-provider rate-limit semaphores. Non-blocking weaknesses: empty providers.json in worktree pre-install, ceiling counts successful calls without echo-chamber detection, shallow-merge can silently shrink quorum, bag-of-words precedent matching. | hooks/nf-stop.js:432-530, 659-664, 752-771; bin/quorum-slot-dispatch.cjs:1466-1487, 46-96; hooks/config-loader.js:119-138 |
+| copilot-1 (T1 fallback) | UNAVAIL — `spawn ask ENOENT`; copilot CLI binary missing/misconfigured in this env. | — |
+| claude-1 (T1 fallback) | UNAVAIL — CONTEXT_OVERFLOW; unavail_message captured a draft APPROVE noting strong formal verification (TLA+ unanimity/bounded-deliberation proofs, PRISM DTMC), but per CE-3 only the `verdict:` field counts. | NFQuorum.tla:108-110, 134-138; call-quorum-slot.cjs:255, 362, 529, 688-691; quorum.pm:49 |
+
+## Outcome
+
+**CONSENSUS: APPROVE** under CE-3 (1 valid external voter, 0 BLOCK, 4 UNAVAIL → 1/1 = 100% unanimity).
+
+The single surviving voter (opencode-1) approved on the strength of: nonce-authenticated file IPC bypassing relay tampering, stop-hook structural enforcement of FALLBACK-01, per-provider rate-limit semaphores, and layered defense-in-depth. claude-1's draft APPROVE (lost to context overflow) independently cited formal TLA+/PRISM verification as a credibility multiplier.
+
+**However, the run itself is meta-evidence of operational fragility:** 4 of 5 slots failed in distinct ways within a single dispatch — CLI hang (codex-1), rate-limit (gemini-1), missing binary (copilot-1), context overflow (claude-1). The protocol's degraded-roster semantics held — CE-3 was satisfied by a single voter — but a 1-of-5 "unanimous" consensus is technically correct and pragmatically thin. claude-1's own unavail_message flagged exactly this concern before being killed.
+
+**Net assessment:** The system's *integrity* mechanisms (nonce, FALLBACK_CHECKPOINT, BLOCK-is-absolute, formal verification) are robust. The system's *availability* surface (third-party CLIs, rate limits, context windows, install/config drift) is fragile and currently being actively patched. APPROVE for production with degraded-roster semantics explicitly defined and CLI-availability monitoring treated as an SLO, not an afterthought.
+
+External voter tally: 1 APPROVE / 0 BLOCK / 4 UNAVAIL (Claude's position excluded per CE-1)

--- a/.planning/quorum/debates/2026-05-13-opencode-1-is-the-nforma-quorum-consensus-system-robust-evalu.md
+++ b/.planning/quorum/debates/2026-05-13-opencode-1-is-the-nforma-quorum-consensus-system-robust-evalu.md
@@ -1,0 +1,24 @@
+---
+date: 2026-05-13
+question: "Is the nForma quorum consensus system robust? Evaluate strengths, weaknesses, and concrete failure modes of: CE-1 facilitator-only rule, CE-2 BLOCK is absolute, CE-3 unanimity required, R3 deliberation up to 10 rounds with escalation, tiered fallback T1 sub-CLI to T2 API, file-first nonce authenticity for slot results, FALLBACK_CHECKPOINT enforced by Stop hook, adaptive fan-out by envelope risk_level, scoreboard. Provide verdict APPROVE or BLOCK with reasoning."
+slot: opencode-1
+round: 1
+mode: "A"
+verdict: Let me check for the escalation/consensus logic and the remaining dispatch code:
+**APPROVE**
+
+The nForma quorum system is well-engineered with defense-in-depth. After reading `quorum-slot-dispatch.cjs`, `call-quorum-slot.cjs`, `nf-stop.js`, `update-scoreboard.cjs`, and `quorum-consensus-gate.cjs`, the key strengths are clear: CE-1 facilitator-only is enforced via transcript JSONL parsing (not substring matching — STOP-05 correctly rejects that), CE-2 BLOCK is structurally enforced by Claude Code
+matched_requirement_ids: [QUORUM-01, STOP-08, TOKN-04, DISP-06, DISP-07, IMPR-02, SLOT-01, STOP-05, TRUNC-04, UPPAAL-02, DISP-03, DISP-05, FAIL-01, HEAL-01, ORES-03, QPREC-01, QUORUM-03, SETUP-01, SLOT-03, STOP-07]
+artifact_path: ""
+---
+
+# Debate Trace: opencode-1 on round 1
+
+## Reasoning
+Let me check for the escalation/consensus logic and the remaining dispatch code:
+**APPROVE**
+
+The nForma quorum system is well-engineered with defense-in-depth. After reading `quorum-slot-dispatch.cjs`, `call-quorum-slot.cjs`, `nf-stop.js`, `update-scoreboard.cjs`, and `quorum-consensus-gate.cjs`, the key strengths are clear: CE-1 facilitator-only is enforced via transcript JSONL parsing (not subs
+
+## Citations
+(none)

--- a/.planning/quorum/debates/2026-05-13-opencode-1-is-the-quorum-system-robust-evaluate-strengths-and.md
+++ b/.planning/quorum/debates/2026-05-13-opencode-1-is-the-quorum-system-robust-evaluate-strengths-and.md
@@ -1,0 +1,30 @@
+---
+date: 2026-05-13
+question: "Is the quorum system robust? Evaluate strengths and weaknesses of the nForma quorum (Claude + native CLI agents + claude-mcp-server instances): consensus rules (CE-1 facilitator-only, CE-2 absolute BLOCK, CE-3 unanimity), tiered fallback (T1 sub → T2 api), file-based nonce authenticity, parallel dispatch, deliberation rounds, scoreboard, and adaptive fan-out by risk level. Identify the top failure modes and the strongest design properties."
+slot: opencode-1
+round: 1
+mode: "A"
+verdict: Now I have sufficient grounding. Here is my evaluation:
+
+**Verdict: APPROVE — robust but with known operational fragility.**
+
+**Strongest design properties:**
+1. **CE-2 (BLOCK-is-absolute)** is the keystone: even one dissent forces a rewrite cycle, preventing groupthink rubber-stamping. The stop hook enforces this at transcript level (`nf-stop.js:756-770`), not just prompt instruction.
+2. **File-based nonce authenticity** (`call-quorum-slot.cjs:255,264`) prevents the orchestrator model from fabr
+matched_requirement_ids: [MCP-01, MCP-04, MCP-06, SLOT-01, QUORUM-01, TOKN-04, IMPR-02, MCP-02, MCP-03, QUORUM-02, QUORUM-03, SENS-01, SETUP-01, SLOT-02, STOP-05, STOP-08, UPS-03, AGENT-01, DISP-06, MCP-05]
+artifact_path: ""
+---
+
+# Debate Trace: opencode-1 on round 1
+
+## Reasoning
+Now I have sufficient grounding. Here is my evaluation:
+
+**Verdict: APPROVE — robust but with known operational fragility.**
+
+**Strongest design properties:**
+1. **CE-2 (BLOCK-is-absolute)** is the keystone: even one dissent forces a rewrite cycle, preventing groupthink rubber-stamping. The stop hook enforces this at transcript level (`nf-stop.js:756-770`), not just prompt instruction.
+2. **File-b
+
+## Citations
+(none)

--- a/.planning/quorum/debates/2026-05-13-opencode-1-is-the-quorum-system-robust-evaluate-strengths-wea.md
+++ b/.planning/quorum/debates/2026-05-13-opencode-1-is-the-quorum-system-robust-evaluate-strengths-wea.md
@@ -1,0 +1,22 @@
+---
+date: 2026-05-13
+question: "is the quorum system robust? Evaluate strengths/weaknesses of nForma quorum protocol R3: Claude+native CLI agents (codex/gemini/opencode/copilot)+claude-mcp servers. Key design: CE-1 advisory-only orchestrator, CE-2 BLOCK-is-absolute, CE-3 unanimity, nonce-authenticated file result reading, FALLBACK_CHECKPOINT Stop-hook enforcement, tiered T1(sub)/T2(api) fallback, adaptive fan-out by risk_level, max_quorum_size minimum, 10-round deliberation cap. Recent patches: e25c31fd (CLI resolve from mainTool), 600908a1 (self-heal mainTool), 6427d31e/49ca5168 (UNIFIED_PROVIDERS_CONFIG backfill). NOTE: in this very dispatch, codex-1 produced only PENDING placeholder (CLI hung past timeout) and gemini-1 hit rate-limits—both primaries failed, fallback engaged. Evaluate APPROVE (robust enough for production) or BLOCK (material weaknesses). Cite files/lines."
+slot: opencode-1
+round: 1
+mode: "A"
+verdict: Now let me check the providers configuration for the fallback/tier mechanism:
+I now have enough understanding of the quorum system to give my evaluation. Let me check one more file for the quorum orchestrator prompt to understand the CE constraints:
+**APPROVE.** The quorum system is robust enough for production. Key strengths: (1) The stop hook (`hooks/nf-stop.js`) enforces quorum via JSONL transcript parsing with multiple guards — infinite-loop prevention (STOP-02, line 659), subagent exclusion
+matched_requirement_ids: [STOP-08, HEAL-01, MCP-04, STOP-05, DISP-07, MCP-06, STOP-01, STOP-04, STOP-06, STOP-07, STOP-09, HEAL-02, MCP-01, MCP-02, STOP-03, TRUNC-01, KEY-03, SENS-01, SLOT-01, STOP-02]
+artifact_path: ""
+---
+
+# Debate Trace: opencode-1 on round 1
+
+## Reasoning
+Now let me check the providers configuration for the fallback/tier mechanism:
+I now have enough understanding of the quorum system to give my evaluation. Let me check one more file for the quorum orchestrator prompt to understand the CE constraints:
+**APPROVE.** The quorum system is robust enough for production. Key strengths: (1) The stop hook (`hooks/nf-stop.js`) enforces quorum via JSONL transc
+
+## Citations
+(none)


### PR DESCRIPTION
## Summary

21 quorum debate transcripts from local reliability research sessions on May 03, 12, and 13. Topics: "is the MCP system robust?" and "is the nForma quorum (consensus) system robust?".

These are the audit trail for the recent link-daintree quorum reliability work landed across:

- 4d338f63 fix(mcp-status): read scoreboard from correct path
- b8c5a144 fix(quorum): prefer slash-path providers.json
- 8ef5eca7 fix(quorum): resolve CLI from mainTool when cli is null
- 6427d31e fix(install): backfill UNIFIED_PROVIDERS_CONFIG when repo source is empty
- 49ca5168 fix(mcp): auto-fall-back to user-installed providers.json
- 28da14bd / 4eb0d4c0 fix(link-daintree): always register health_check + smoke-probe new slots
- 96698b70 feat(bin): add quorum providers from Daintree fan-out
- 7ffbde9a fix(install): preserve Daintree metadata when reconstructing providers.json
- e8e46aae fix(install): consult nf-local-patches when rebuilding providers.json
- a2f9eae3 fix(link-daintree): require canonical naming for vanilla candidates
- 8e21ef3f fix(link-daintree): correct family-gate fallback in fan-out import

Per existing convention in `.planning/quorum/debates/` (~300 historical transcripts already tracked, not gitignored), these are preserved as the reliability investigation's audit trail rather than discarded as ephemeral cache.

## Test plan

- [ ] CI: no functional change — pure docs/artifact archive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)