### PR TITLE
fix(quorum): backport CLI fallback to probe-quorum-slots

### DIFF
--- a/bin/probe-quorum-slots.cjs
+++ b/bin/probe-quorum-slots.cjs
@@ -22,12 +22,14 @@ const { spawn } = require('child_process');
 const fs         = require('fs');
 const path       = require('path');
 const os         = require('os');
+const { resolveCli } = require('./resolve-cli.cjs');
 
 // ─── Find providers.json (mirrors call-quorum-slot.cjs logic) ────────────────
 function findProviders() {
   const searchPaths = [
-    path.join(__dirname, 'providers.json'),
-    path.join(os.homedir(), '.claude', 'nf-bin', 'providers.json'),
+    path.join(os.homedir(), '.claude', 'nf', 'bin', 'providers.json'),   // canonical (slash)
+    path.join(__dirname, 'providers.json'),                              // same dir (nf-bin)
+    path.join(os.homedir(), '.claude', 'nf-bin', 'providers.json'),      // installed fallback
   ];
   try {
     const claudeJson = JSON.parse(fs.readFileSync(path.join(os.homedir(), '.claude.json'), 'utf8'));
@@ -36,7 +38,13 @@ function findProviders() {
     if (serverScript) searchPaths.unshift(path.join(path.dirname(serverScript), 'providers.json'));
   } catch (_) {}
   for (const p of searchPaths) {
-    try { if (fs.existsSync(p)) return JSON.parse(fs.readFileSync(p, 'utf8')).providers; } catch (_) {}
+    try {
+      if (fs.existsSync(p)) {
+        const providers = JSON.parse(fs.readFileSync(p, 'utf8')).providers;
+        // Skip empty files (the shipped repo source is empty by design); fall through to next path
+        if (Array.isArray(providers) && providers.length > 0) return providers;
+      }
+    } catch (_) { /* try next */ }
   }
   return null;
 }
@@ -62,9 +70,22 @@ function probeSlot(provider, timeoutMs, spawnCwd) {
     const args = provider.args_template.map(a => (a === '{prompt}' ? 'OK' : a));
     const env  = { ...process.env, ...(provider.env ?? {}) };
 
+    // Mirror call-quorum-slot.cjs CLI resolution (PR #164): `cli` is optional in
+    // providers.json; fall back to `mainTool` so spawn() never receives null.
+    const cliSource = provider.cli || provider.mainTool;
+    if (cliSource && !provider.resolvedCli) {
+      const bareName = cliSource.split('/').pop();
+      provider.resolvedCli = resolveCli(bareName);
+    }
+    const spawnTarget = provider.resolvedCli || provider.cli || provider.mainTool;
+    if (!spawnTarget) {
+      resolve({ slot: provider.name, healthy: false, latencyMs: Date.now() - start, error: 'spawn: no resolvable CLI (cli, resolvedCli, and mainTool all empty)' });
+      return;
+    }
+
     let child;
     try {
-      child = spawn(provider.cli, args, {
+      child = spawn(spawnTarget, args, {
         env,
         cwd:      spawnCwd,
         stdio:    ['pipe', 'pipe', 'pipe'],


### PR DESCRIPTION
## Summary

- Backport PR #164's \`resolvedCli || cli || mainTool\` fallback chain to \`bin/probe-quorum-slots.cjs\` so it no longer crashes with \`spawn: file argument must be of type string. Received null\` when invoked.
- Backport PR #165's \`findProviders()\` skip-empty + canonical-first ordering so the repo's empty \`bin/providers.json\` skeleton doesn't short-circuit the search before the installed providers.json is found.

## Why

\`provider.cli\` is null for all 5 sub slots (codex-1, gemini-1, opencode-1, copilot-1, claude-1) in the canonical \`~/.claude/nf/bin/providers.json\`. The hot path (\`call-quorum-slot.cjs\`) handles this via the three-tier fallback added in #164, but the diagnostic probe script was missing the same fix. Calling it directly would crash before reaching any slot.

Surfaced by a \`/nf:quorum\` self-test run where codex-1 caught the gap (cited \`bin/probe-quorum-slots.cjs:27,67\`). Quorum reached consensus that the hot-path was fine but the probe tool needed the same backport.

## Test plan

- [x] \`node bin/probe-quorum-slots.cjs --slots codex-1,gemini-1,opencode-1,copilot-1,claude-1 --timeout 8000\` returns valid JSON (3 healthy, 2 timeouts at 8s — gemini-1 and claude-1 are real LLM calls; not a regression).
- [x] \`npm run lint:isolation\` → passes
- [x] \`node --test test/quorum-preflight-probe.test.cjs\` → 9/9 pass
- [ ] CI: run full \`test:ci\` suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Graceful failure when no executable can be resolved for a provider—slots now report failures instead of attempting to spawn invalid commands.
  * Robust provider-file loading: skips empty provider lists and continues on parse/read errors.

* **Improvements**
  * Expanded automatic discovery paths for provider configuration files.
  * Caches resolved executables and improves fallback logic when CLI specs are missing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nForma-AI/nForma/pull/180)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->