### PR TITLE
fix(quorum/link-daintree): store API tokens as ${VAR} placeholders, not plaintext

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,102 +1,15 @@
 {
-  "version": "1.5.0",
-  "plugins_used": [
-    {
-      "name": "ArtifactoryDetector"
-    },
-    {
-      "name": "AWSKeyDetector"
-    },
-    {
-      "name": "AzureStorageKeyDetector"
-    },
-    {
-      "name": "Base64HighEntropyString",
-      "limit": 4.5
-    },
-    {
-      "name": "BasicAuthDetector"
-    },
-    {
-      "name": "CloudantDetector"
-    },
-    {
-      "name": "DiscordBotTokenDetector"
-    },
-    {
-      "name": "GitHubTokenDetector"
-    },
-    {
-      "name": "GitLabTokenDetector"
-    },
-    {
-      "name": "HexHighEntropyString",
-      "limit": 3.0
-    },
-    {
-      "name": "IbmCloudIamDetector"
-    },
-    {
-      "name": "IbmCosHmacDetector"
-    },
-    {
-      "name": "IPPublicDetector"
-    },
-    {
-      "name": "JwtTokenDetector"
-    },
-    {
-      "name": "KeywordDetector",
-      "keyword_exclude": ""
-    },
-    {
-      "name": "MailchimpDetector"
-    },
-    {
-      "name": "NpmDetector"
-    },
-    {
-      "name": "OpenAIDetector"
-    },
-    {
-      "name": "PrivateKeyDetector"
-    },
-    {
-      "name": "PypiTokenDetector"
-    },
-    {
-      "name": "SendGridDetector"
-    },
-    {
-      "name": "SlackDetector"
-    },
-    {
-      "name": "SoftlayerDetector"
-    },
-    {
-      "name": "SquareOAuthDetector"
-    },
-    {
-      "name": "StripeDetector"
-    },
-    {
-      "name": "TelegramBotTokenDetector"
-    },
-    {
-      "name": "TwilioKeyDetector"
-    }
-  ],
   "filters_used": [
     {
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
+      "filename": ".secrets.baseline",
+      "path": "detect_secrets.filters.common.is_baseline_file"
     },
     {
-      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
-      "min_level": 2
+      "min_level": 2,
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies"
     },
     {
       "path": "detect_secrets.filters.heuristic.is_indirect_reference"
@@ -137,259 +50,362 @@
       ]
     }
   ],
+  "generated_at": "2026-05-18T15:09:10Z",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "limit": 3.0,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": "",
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
   "results": {
     "bin/auth-drivers/simple.test.cjs": [
       {
-        "type": "Secret Keyword",
         "filename": "bin/auth-drivers/simple.test.cjs",
         "hashed_secret": "cba7d8d926ee837cf3f92636a6d1cd0eb397db64",
-        "is_verified": false,
-        "line_number": 110
+        "is_verified": true,
+        "line_number": 110,
+        "type": "Secret Keyword"
       }
     ],
     "bin/check-trace-redaction.test.cjs": [
       {
-        "type": "Secret Keyword",
         "filename": "bin/check-trace-redaction.test.cjs",
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_verified": false,
-        "line_number": 34
+        "is_verified": true,
+        "line_number": 34,
+        "type": "Secret Keyword"
       },
       {
-        "type": "AWS Access Key",
         "filename": "bin/check-trace-redaction.test.cjs",
         "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
-        "is_verified": false,
-        "line_number": 45
+        "is_verified": true,
+        "line_number": 45,
+        "type": "AWS Access Key"
       }
     ],
     "bin/debt-dedup.test.cjs": [
       {
-        "type": "Hex High Entropy String",
         "filename": "bin/debt-dedup.test.cjs",
         "hashed_secret": "323b5f30fd46dcaeeb6aed6df873b62cf585861f",
-        "is_verified": false,
-        "line_number": 9
+        "is_verified": true,
+        "line_number": 9,
+        "type": "Hex High Entropy String"
       }
     ],
     "bin/debt-ledger.test.cjs": [
       {
-        "type": "Hex High Entropy String",
         "filename": "bin/debt-ledger.test.cjs",
         "hashed_secret": "320d93a51cf4ffd93c5805522801d8c8c2dfb0f4",
-        "is_verified": false,
-        "line_number": 280
+        "is_verified": true,
+        "line_number": 280,
+        "type": "Hex High Entropy String"
       },
       {
-        "type": "Hex High Entropy String",
         "filename": "bin/debt-ledger.test.cjs",
         "hashed_secret": "c1d38cd8897d341561bdbf86023d8fb57be0d9d3",
-        "is_verified": false,
-        "line_number": 319
+        "is_verified": true,
+        "line_number": 319,
+        "type": "Hex High Entropy String"
       },
       {
-        "type": "Hex High Entropy String",
         "filename": "bin/debt-ledger.test.cjs",
         "hashed_secret": "bc4d95c6866bec7b29eec5a41a7deb0c6795a979",
-        "is_verified": false,
-        "line_number": 358
+        "is_verified": true,
+        "line_number": 358,
+        "type": "Hex High Entropy String"
       },
       {
-        "type": "Hex High Entropy String",
         "filename": "bin/debt-ledger.test.cjs",
         "hashed_secret": "359e3f61b9980a7e2c0136d010260b05ab085221",
-        "is_verified": false,
-        "line_number": 400
+        "is_verified": true,
+        "line_number": 400,
+        "type": "Hex High Entropy String"
       },
       {
-        "type": "Hex High Entropy String",
         "filename": "bin/debt-ledger.test.cjs",
         "hashed_secret": "75ec05c91425ef400616bbd88a3f6c8dc0dd2f17",
-        "is_verified": false,
-        "line_number": 459
+        "is_verified": true,
+        "line_number": 459,
+        "type": "Hex High Entropy String"
       },
       {
-        "type": "Hex High Entropy String",
         "filename": "bin/debt-ledger.test.cjs",
         "hashed_secret": "bb3f2f1fdb4346a79d1be2b683b25bb996bf60c4",
-        "is_verified": false,
-        "line_number": 499
+        "is_verified": true,
+        "line_number": 499,
+        "type": "Hex High Entropy String"
       }
     ],
     "bin/debt-state-machine.test.cjs": [
       {
-        "type": "Hex High Entropy String",
         "filename": "bin/debt-state-machine.test.cjs",
         "hashed_secret": "4610e9a827049f059bc72b0ce9833625ca6cae13",
-        "is_verified": false,
-        "line_number": 76
+        "is_verified": true,
+        "line_number": 76,
+        "type": "Hex High Entropy String"
       }
     ],
     "bin/formal-ref-linker.test.cjs": [
       {
-        "type": "Hex High Entropy String",
         "filename": "bin/formal-ref-linker.test.cjs",
         "hashed_secret": "323b5f30fd46dcaeeb6aed6df873b62cf585861f",
-        "is_verified": false,
-        "line_number": 12
+        "is_verified": true,
+        "line_number": 12,
+        "type": "Hex High Entropy String"
       }
     ],
     "bin/manage-agents-core.cjs": [
       {
-        "type": "Secret Keyword",
         "filename": "bin/manage-agents-core.cjs",
         "hashed_secret": "32df82dccdd26b62d92eaefa9ccc2550d5ec96bd",
-        "is_verified": false,
-        "line_number": 458
+        "is_verified": true,
+        "line_number": 458,
+        "type": "Secret Keyword"
       }
     ],
     "bin/manage-agents.test.cjs": [
       {
-        "type": "Base64 High Entropy String",
         "filename": "bin/manage-agents.test.cjs",
         "hashed_secret": "9f08064bf7140dd215badead0214265fa6a1639f",
-        "is_verified": false,
-        "line_number": 57
+        "is_verified": true,
+        "line_number": 57,
+        "type": "Base64 High Entropy String"
       },
       {
-        "type": "Secret Keyword",
         "filename": "bin/manage-agents.test.cjs",
         "hashed_secret": "637487c884f6dd9a4a638fab826509cfdba90fa9",
-        "is_verified": false,
-        "line_number": 128
+        "is_verified": true,
+        "line_number": 128,
+        "type": "Secret Keyword"
       },
       {
-        "type": "Secret Keyword",
         "filename": "bin/manage-agents.test.cjs",
         "hashed_secret": "666c100dab549a6f56da7da546bd848ed5086541",
-        "is_verified": false,
-        "line_number": 136
+        "is_verified": true,
+        "line_number": 136,
+        "type": "Secret Keyword"
       },
       {
-        "type": "Secret Keyword",
         "filename": "bin/manage-agents.test.cjs",
         "hashed_secret": "32df82dccdd26b62d92eaefa9ccc2550d5ec96bd",
-        "is_verified": false,
-        "line_number": 149
+        "is_verified": true,
+        "line_number": 149,
+        "type": "Secret Keyword"
       },
       {
-        "type": "Secret Keyword",
         "filename": "bin/manage-agents.test.cjs",
         "hashed_secret": "13951588fd3325e25ed1e3b116d7009fb221c85e",
-        "is_verified": false,
-        "line_number": 414
+        "is_verified": true,
+        "line_number": 414,
+        "type": "Secret Keyword"
       },
       {
-        "type": "Secret Keyword",
         "filename": "bin/manage-agents.test.cjs",
         "hashed_secret": "a4d9898958973805c7a28691b1fc183d40144188",
-        "is_verified": false,
-        "line_number": 449
+        "is_verified": true,
+        "line_number": 449,
+        "type": "Secret Keyword"
       },
       {
-        "type": "Secret Keyword",
         "filename": "bin/manage-agents.test.cjs",
         "hashed_secret": "e0538dbde0484e599b41a65cc6a9d443b5011520",
-        "is_verified": false,
-        "line_number": 1428
+        "is_verified": true,
+        "line_number": 1428,
+        "type": "Secret Keyword"
       },
       {
-        "type": "Secret Keyword",
         "filename": "bin/manage-agents.test.cjs",
         "hashed_secret": "05b320f6e1147eb9dca51fd088b5f449aa1d0f8a",
-        "is_verified": false,
-        "line_number": 1500
+        "is_verified": true,
+        "line_number": 1500,
+        "type": "Secret Keyword"
       },
       {
-        "type": "Secret Keyword",
         "filename": "bin/manage-agents.test.cjs",
         "hashed_secret": "d503c694c0e762d786079a3f8bd6df32de508a9b",
-        "is_verified": false,
-        "line_number": 1529
+        "is_verified": true,
+        "line_number": 1529,
+        "type": "Secret Keyword"
       }
     ],
     "bin/quorum-slot-dispatch.test.cjs": [
       {
-        "type": "Hex High Entropy String",
         "filename": "bin/quorum-slot-dispatch.test.cjs",
         "hashed_secret": "71e6451ec62776057a355cba708a135319c6b000",
-        "is_verified": false,
-        "line_number": 840
+        "is_verified": true,
+        "line_number": 840,
+        "type": "Hex High Entropy String"
       },
       {
-        "type": "Hex High Entropy String",
         "filename": "bin/quorum-slot-dispatch.test.cjs",
         "hashed_secret": "e8e6c2284ab5bee4de2ee53880c8fc2a4728d3e8",
-        "is_verified": false,
-        "line_number": 857
+        "is_verified": true,
+        "line_number": 857,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "bin/resolve-env.test.cjs": [
+      {
+        "filename": "bin/resolve-env.test.cjs",
+        "hashed_secret": "8107759ababcbfa34bcb02bc4309caf6354982ab",
+        "is_verified": true,
+        "line_number": 97,
+        "type": "Secret Keyword"
+      },
+      {
+        "filename": "bin/resolve-env.test.cjs",
+        "hashed_secret": "d474dcb3149cc4eddf07b70d94bc18b00a5f9c72",
+        "is_verified": true,
+        "line_number": 123,
+        "type": "Secret Keyword"
       }
     ],
     "bin/secrets.cjs": [
       {
-        "type": "Secret Keyword",
         "filename": "bin/secrets.cjs",
         "hashed_secret": "a85f18261c0688f38dd4067dd7f5757804e2750b",
-        "is_verified": false,
-        "line_number": 133
+        "is_verified": true,
+        "line_number": 133,
+        "type": "Secret Keyword"
       },
       {
-        "type": "Secret Keyword",
         "filename": "bin/secrets.cjs",
         "hashed_secret": "e349e118d28bef000322652a8ed03b08a3302e3f",
-        "is_verified": false,
-        "line_number": 134
+        "is_verified": true,
+        "line_number": 134,
+        "type": "Secret Keyword"
       },
       {
-        "type": "Secret Keyword",
         "filename": "bin/secrets.cjs",
         "hashed_secret": "9034ff9e2b8f00b47a44dfaf3c2a37176c101e2a",
-        "is_verified": false,
-        "line_number": 135
+        "is_verified": true,
+        "line_number": 135,
+        "type": "Secret Keyword"
       }
     ],
     "bin/security-sweep.test.cjs": [
       {
-        "type": "AWS Access Key",
         "filename": "bin/security-sweep.test.cjs",
         "hashed_secret": "3c76d2abd56878fe1834ff711a3a60e83af48849",
-        "is_verified": false,
-        "line_number": 138
+        "is_verified": true,
+        "line_number": 138,
+        "type": "AWS Access Key"
       }
     ],
     "bin/unified-mcp-server.mjs": [
       {
-        "type": "Secret Keyword",
         "filename": "bin/unified-mcp-server.mjs",
         "hashed_secret": "f8ca0d7266886f4b5be9adddc9b66017b3bf1a4b",
-        "is_verified": false,
-        "line_number": 518
+        "is_verified": true,
+        "line_number": 526,
+        "type": "Secret Keyword"
       },
       {
-        "type": "Secret Keyword",
         "filename": "bin/unified-mcp-server.mjs",
         "hashed_secret": "138901a352fddde83a010e609f2091c5ebaad7bd",
-        "is_verified": false,
-        "line_number": 948
+        "is_verified": true,
+        "line_number": 956,
+        "type": "Secret Keyword"
       }
     ],
     "bin/validate-debt-entry.test.cjs": [
       {
-        "type": "Hex High Entropy String",
         "filename": "bin/validate-debt-entry.test.cjs",
         "hashed_secret": "4610e9a827049f059bc72b0ce9833625ca6cae13",
-        "is_verified": false,
-        "line_number": 10
+        "is_verified": true,
+        "line_number": 10,
+        "type": "Hex High Entropy String"
       }
     ],
     "bin/validate-requirements-haiku.test.cjs": [
       {
-        "type": "Secret Keyword",
         "filename": "bin/validate-requirements-haiku.test.cjs",
         "hashed_secret": "9139236dfe89960fee34d53b6089795fe376682e",
-        "is_verified": false,
-        "line_number": 263
+        "is_verified": true,
+        "line_number": 263,
+        "type": "Secret Keyword"
       }
     ]
   },
-  "generated_at": "2026-05-18T14:54:50Z"
+  "version": "1.5.0"
 }

--- a/bin/call-quorum-slot.cjs
+++ b/bin/call-quorum-slot.cjs
@@ -29,7 +29,7 @@ const path      = require('path');
 const os        = require('os');
 const { resolveCli } = require('./resolve-cli.cjs');
 const { acquireSlot, releaseSlot, providerKeyFromUrl } = require('./provider-concurrency.cjs');
-const { resolveEnvPlaceholders, findUnresolvedPlaceholders, isPlaceholder } = require('./resolve-env.cjs');
+const { resolveEnvPlaceholders, findUnresolvedPlaceholders, isPlaceholder, extractPlaceholderVar, namespacedSecretKey } = require('./resolve-env.cjs');
 
 // ─── Utilities ──────────────────────────────────────────────────────────────
 function sleep(ms) {
@@ -733,15 +733,20 @@ async function main() {
   // Load secrets for ${VAR} placeholders in the provider's env. The fan-out
   // import (issue 169) writes secret values as ${KEY} placeholders and stores
   // actual values in the secrets store (~/.claude/nf-secrets.json).
+  // Secrets are namespaced by slot name (<slot>__<key>) to prevent collisions
+  // when multiple providers share the same env key with different values.
   if (provider.env) {
     try {
       const secrets = require('./secrets.cjs');
       let loaded = 0;
       for (const [k, v] of Object.entries(provider.env)) {
-        if (isPlaceholder(v) && process.env[k] === undefined) {
-          const secret = await secrets.get('nforma', k);
+        const envVarName = extractPlaceholderVar(v);
+        if (envVarName !== null && process.env[envVarName] === undefined) {
+          // Try namespaced key first, then fall back to unnamespaced
+          const secret = await secrets.get('nforma', namespacedSecretKey(slot, envVarName))
+                        ?? await secrets.get('nforma', envVarName);
           if (secret) {
-            process.env[k] = secret;
+            process.env[envVarName] = secret;
             loaded++;
           }
         }

--- a/bin/call-quorum-slot.cjs
+++ b/bin/call-quorum-slot.cjs
@@ -29,6 +29,7 @@ const path      = require('path');
 const os        = require('os');
 const { resolveCli } = require('./resolve-cli.cjs');
 const { acquireSlot, releaseSlot, providerKeyFromUrl } = require('./provider-concurrency.cjs');
+const { resolveEnvPlaceholders, findUnresolvedPlaceholders, isPlaceholder } = require('./resolve-env.cjs');
 
 // ─── Utilities ──────────────────────────────────────────────────────────────
 function sleep(ms) {
@@ -374,7 +375,7 @@ function runSubprocess(provider, prompt, idleTimeoutMs, hardTimeoutMs, allowedTo
     }
   }
 
-  const env  = { ...process.env, ...(provider.env ?? {}) };
+  const env  = { ...process.env, ...resolveEnvPlaceholders(provider.env ?? {}) };
 
   return new Promise((resolve, reject) => {
     let child;
@@ -726,6 +727,36 @@ async function main() {
   if (!prompt) {
     process.stderr.write('[call-quorum-slot] No prompt received on stdin\n');
     process.exit(1);
+  }
+
+  // ─── ${VAR} placeholder bootstrap ────────────────────────────────────────────
+  // Load secrets for ${VAR} placeholders in the provider's env. The fan-out
+  // import (issue 169) writes secret values as ${KEY} placeholders and stores
+  // actual values in the secrets store (~/.claude/nf-secrets.json).
+  if (provider.env) {
+    try {
+      const secrets = require('./secrets.cjs');
+      let loaded = 0;
+      for (const [k, v] of Object.entries(provider.env)) {
+        if (isPlaceholder(v) && process.env[k] === undefined) {
+          const secret = await secrets.get('nforma', k);
+          if (secret) {
+            process.env[k] = secret;
+            loaded++;
+          }
+        }
+      }
+      if (loaded > 0) {
+        process.stderr.write(`[call-quorum-slot] Loaded ${loaded} secret(s) for slot ${slot} from secrets store\n`);
+      }
+      // Warn on unresolved placeholders
+      const unresolved = findUnresolvedPlaceholders(provider.env);
+      if (unresolved.length > 0) {
+        process.stderr.write(`[call-quorum-slot] WARNING: unresolved placeholder(s): ${unresolved.join(', ')} — set in env or run /nf:mcp-setup to store in secrets\n`);
+      }
+    } catch (e) {
+      process.stderr.write(`[call-quorum-slot] secrets bootstrap for slot ${slot}: ${e.message}\n`);
+    }
   }
 
   // ─── Layer 3: Pre-dispatch scoreboard cooldown check ────────────────────────

--- a/bin/migrate-plaintext-tokens.cjs
+++ b/bin/migrate-plaintext-tokens.cjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+'use strict';
+
+// migrate-plaintext-tokens.cjs — one-shot migration for issue 169
+// Scans providers.json for plaintext secret values (*_API_KEY, *_AUTH_TOKEN, *_TOKEN),
+// stores them in the secrets store (~/.claude/nf-secrets.json), and replaces with
+// ${VAR} placeholders in providers.json.
+//
+// Idempotent: re-running is safe — already-masked values are skipped.
+//
+// Usage:
+//   node bin/migrate-plaintext-tokens.cjs           # migrate
+//   node bin/migrate-plaintext-tokens.cjs --dry-run # preview only
+
+const fs   = require('fs');
+const path = require('path');
+const os   = require('os');
+
+const { maskSecrets, isPlaceholder } = require('./resolve-env.cjs');
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+// ── Locate providers.json ──────────────────────────────────────────────────
+const candidates = [
+  path.join(os.homedir(), '.claude', 'nf', 'bin', 'providers.json'),
+  path.join(os.homedir(), '.claude', 'nf-bin', 'providers.json'),
+  path.join(process.cwd(), 'bin', 'providers.json'),
+];
+
+let providersPath = null;
+let providersData = null;
+
+for (const p of candidates) {
+  try {
+    const data = JSON.parse(fs.readFileSync(p, 'utf8'));
+    if (Array.isArray(data?.providers) && data.providers.length > 0) {
+      providersPath = p;
+      providersData = data;
+      break;
+    }
+  } catch (_) { /* try next */ }
+}
+
+if (!providersPath) {
+  process.stderr.write('[migrate-plaintext-tokens] No providers.json with providers found\n');
+  process.exit(1);
+}
+
+process.stderr.write(`[migrate-plaintext-tokens] Reading: ${providersPath}\n`);
+
+// ── Scan for plaintext secrets ─────────────────────────────────────────────
+let totalSecrets = 0;
+const allSecrets = []; // { provider, key, value }
+
+for (const provider of providersData.providers) {
+  if (!provider.env) continue;
+  for (const [k, v] of Object.entries(provider.env)) {
+    if (/_(API_KEY|AUTH_TOKEN|TOKEN)$/.test(k) && !isPlaceholder(v)) {
+      allSecrets.push({ provider: provider.name, key: k, value: v });
+    }
+  }
+}
+
+if (allSecrets.length === 0) {
+  process.stderr.write('[migrate-plaintext-tokens] No plaintext secrets found — nothing to migrate\n');
+  process.exit(0);
+}
+
+process.stderr.write(`[migrate-plaintext-tokens] Found ${allSecrets.length} plaintext secret(s):\n`);
+for (const s of allSecrets) {
+  process.stderr.write(`  ${s.provider}.env.${s.key} = ${s.value.slice(0, 8)}...\n`);
+}
+
+if (DRY_RUN) {
+  process.stderr.write('[migrate-plaintext-tokens] DRY RUN — no changes written\n');
+  process.exit(0);
+}
+
+// ── Store in secrets store ─────────────────────────────────────────────────
+const secretsPath = path.join(os.homedir(), '.claude', 'nf-secrets.json');
+let secretsStore = {};
+try { secretsStore = JSON.parse(fs.readFileSync(secretsPath, 'utf8')) || {}; } catch (_) {}
+
+for (const s of allSecrets) {
+  secretsStore[s.key] = s.value;
+}
+
+fs.mkdirSync(path.dirname(secretsPath), { recursive: true });
+const tmpSecrets = secretsPath + '.tmp';
+fs.writeFileSync(tmpSecrets, JSON.stringify(secretsStore, null, 2), { mode: 0o600 });
+fs.renameSync(tmpSecrets, secretsPath);
+process.stderr.write(`[migrate-plaintext-tokens] Stored ${allSecrets.length} secret(s) in ${secretsPath}\n`);
+
+// ── Replace with placeholders in providers.json ────────────────────────────
+for (const provider of providersData.providers) {
+  if (!provider.env) continue;
+  const { masked } = maskSecrets(provider.env);
+  provider.env = masked;
+}
+
+const tmpProviders = providersPath + '.tmp';
+fs.writeFileSync(tmpProviders, JSON.stringify(providersData, null, 2) + '\n');
+fs.renameSync(tmpProviders, providersPath);
+process.stderr.write(`[migrate-plaintext-tokens] Replaced plaintext values with \${VAR} placeholders in ${providersPath}\n`);
+
+// ── Summary ────────────────────────────────────────────────────────────────
+process.stderr.write('\n[migrate-plaintext-tokens] Migration complete:\n');
+process.stderr.write(`  Secrets stored:   ${allSecrets.length}\n`);
+process.stderr.write(`  Secrets store:    ${secretsPath} (mode 0600)\n`);
+process.stderr.write(`  Providers file:   ${providersPath}\n`);
+process.stderr.write('\nIf any of these tokens were already leaked (backups, Time Machine, etc.),\n');
+process.stderr.write('rotate them at the provider dashboard and re-run /nf:link-daintree.\n');

--- a/bin/migrate-plaintext-tokens.cjs
+++ b/bin/migrate-plaintext-tokens.cjs
@@ -68,7 +68,7 @@ if (allSecrets.length === 0) {
 
 process.stderr.write(`[migrate-plaintext-tokens] Found ${allSecrets.length} plaintext secret(s):\n`);
 for (const s of allSecrets) {
-  process.stderr.write(`  ${s.provider}.env.${s.key} = ${s.value.slice(0, 8)}...\n`);
+  process.stderr.write(`  ${s.provider}.env.${s.key} = [REDACTED]\n`);
 }
 
 if (DRY_RUN) {
@@ -82,7 +82,7 @@ let secretsStore = {};
 try { secretsStore = JSON.parse(fs.readFileSync(secretsPath, 'utf8')) || {}; } catch (_) {}
 
 for (const s of allSecrets) {
-  secretsStore[s.key] = s.value;
+  secretsStore[s.provider + '__' + s.key] = s.value;
 }
 
 fs.mkdirSync(path.dirname(secretsPath), { recursive: true });

--- a/bin/resolve-env.cjs
+++ b/bin/resolve-env.cjs
@@ -1,0 +1,97 @@
+'use strict';
+
+// Placeholder resolution for secret env values stored in providers.json.
+// Secret keys (*_API_KEY, *_AUTH_TOKEN, *_TOKEN) are written as ${VAR} placeholders
+// in providers.json and resolved from process.env at dispatch time. Actual values
+// are stored in the secrets store (~/.claude/nf-secrets.json) via bin/secrets.cjs.
+
+const SECRET_KEY_RE = /_(API_KEY|AUTH_TOKEN|TOKEN)$/;
+const PLACEHOLDER_RE = /^\$\{([^}]+)\}$/;
+
+function isSecretKey(key) {
+  return SECRET_KEY_RE.test(key);
+}
+
+function toPlaceholder(key) {
+  return '${' + key + '}';
+}
+
+function isPlaceholder(value) {
+  return PLACEHOLDER_RE.test(String(value));
+}
+
+// Resolve all ${VAR} placeholders in an env object from process.env.
+// Returns a new object with resolved values. Keys that can't be resolved
+// are left as-is (the literal ${VAR} string) so the caller can detect and
+// report them.
+function resolveEnvPlaceholders(envObj) {
+  const resolved = {};
+  for (const [k, v] of Object.entries(envObj || {})) {
+    resolved[k] = resolveSinglePlaceholder(v);
+  }
+  return resolved;
+}
+
+// Resolve a single value that might be a ${VAR} placeholder.
+function resolveSinglePlaceholder(value) {
+  const m = String(value).match(PLACEHOLDER_RE);
+  if (m) {
+    const envVarName = m[1];
+    if (process.env[envVarName] !== undefined) {
+      return process.env[envVarName];
+    }
+  }
+  return value;
+}
+
+// Scan an env object for secret keys with plaintext (non-placeholder) values.
+// Returns an array of { key, value } pairs.
+function findPlaintextSecrets(envObj) {
+  const found = [];
+  for (const [k, v] of Object.entries(envObj || {})) {
+    if (isSecretKey(k) && !isPlaceholder(v)) {
+      found.push({ key: k, value: v });
+    }
+  }
+  return found;
+}
+
+// Convert all plaintext secret values in an env object to ${VAR} placeholders.
+// Returns { masked: { key: '${KEY}', ... }, secrets: [{ key, value }, ...] }
+function maskSecrets(envObj) {
+  const masked = { ...envObj };
+  const secrets = [];
+  for (const k of Object.keys(masked)) {
+    if (isSecretKey(k) && !isPlaceholder(masked[k])) {
+      secrets.push({ key: k, value: masked[k] });
+      masked[k] = toPlaceholder(k);
+    }
+  }
+  return { masked, secrets };
+}
+
+// Check if any ${VAR} placeholders in an env object are unresolved (not in process.env).
+// Returns an array of unresolvable key names.
+function findUnresolvedPlaceholders(envObj) {
+  const unresolved = [];
+  for (const [k, v] of Object.entries(envObj || {})) {
+    const m = String(v).match(PLACEHOLDER_RE);
+    if (m && process.env[m[1]] === undefined) {
+      unresolved.push(k);
+    }
+  }
+  return unresolved;
+}
+
+module.exports = {
+  isSecretKey,
+  toPlaceholder,
+  isPlaceholder,
+  resolveEnvPlaceholders,
+  resolveSinglePlaceholder,
+  findPlaintextSecrets,
+  maskSecrets,
+  findUnresolvedPlaceholders,
+  SECRET_KEY_RE,
+  PLACEHOLDER_RE,
+};

--- a/bin/resolve-env.cjs
+++ b/bin/resolve-env.cjs
@@ -83,6 +83,20 @@ function findUnresolvedPlaceholders(envObj) {
   return unresolved;
 }
 
+// Extract the variable name from a ${VAR} placeholder string.
+// Returns null if not a placeholder.
+function extractPlaceholderVar(value) {
+  const m = String(value).match(PLACEHOLDER_RE);
+  return m ? m[1] : null;
+}
+
+// Build a namespaced secrets store key: "<slotName>__<envKey>"
+// This prevents collisions when multiple providers use the same env key
+// with different values (e.g., two presets both using ANTHROPIC_AUTH_TOKEN).
+function namespacedSecretKey(slotName, envKey) {
+  return slotName + '__' + envKey;
+}
+
 module.exports = {
   isSecretKey,
   toPlaceholder,
@@ -92,6 +106,8 @@ module.exports = {
   findPlaintextSecrets,
   maskSecrets,
   findUnresolvedPlaceholders,
+  extractPlaceholderVar,
+  namespacedSecretKey,
   SECRET_KEY_RE,
   PLACEHOLDER_RE,
 };

--- a/bin/resolve-env.test.cjs
+++ b/bin/resolve-env.test.cjs
@@ -1,0 +1,196 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  isSecretKey, toPlaceholder, isPlaceholder,
+  resolveEnvPlaceholders, resolveSinglePlaceholder,
+  findPlaintextSecrets, maskSecrets, findUnresolvedPlaceholders,
+  SECRET_KEY_RE, PLACEHOLDER_RE,
+} = require('./resolve-env.cjs');
+
+// ---------------------------------------------------------------------------
+// isSecretKey
+// ---------------------------------------------------------------------------
+
+test('isSecretKey: matches *_API_KEY', () => {
+  assert.equal(isSecretKey('ANTHROPIC_API_KEY'), true);
+  assert.equal(isSecretKey('OPENAI_API_KEY'), true);
+  assert.equal(isSecretKey('MY_CUSTOM_API_KEY'), true);
+});
+
+test('isSecretKey: matches *_AUTH_TOKEN', () => {
+  assert.equal(isSecretKey('ANTHROPIC_AUTH_TOKEN'), true);
+  assert.equal(isSecretKey('ZAI_AUTH_TOKEN'), true);
+});
+
+test('isSecretKey: matches *_TOKEN', () => {
+  assert.equal(isSecretKey('BEARER_TOKEN'), true);
+  assert.equal(isSecretKey('ACCESS_TOKEN'), true);
+});
+
+test('isSecretKey: does not match non-secret keys', () => {
+  assert.equal(isSecretKey('ANTHROPIC_BASE_URL'), false);
+  assert.equal(isSecretKey('MODEL'), false);
+  assert.equal(isSecretKey('CLAUDE_DEFAULT_MODEL'), false);
+  assert.equal(isSecretKey('PROVIDER_SLOT'), false);
+});
+
+// ---------------------------------------------------------------------------
+// toPlaceholder
+// ---------------------------------------------------------------------------
+
+test('toPlaceholder: wraps key in ${...}', () => {
+  assert.equal(toPlaceholder('ANTHROPIC_API_KEY'), '${ANTHROPIC_API_KEY}');
+  assert.equal(toPlaceholder('ANTHROPIC_AUTH_TOKEN'), '${ANTHROPIC_AUTH_TOKEN}');
+});
+
+// ---------------------------------------------------------------------------
+// isPlaceholder
+// ---------------------------------------------------------------------------
+
+test('isPlaceholder: detects ${VAR} strings', () => {
+  assert.equal(isPlaceholder('${ANTHROPIC_API_KEY}'), true);
+  assert.equal(isPlaceholder('${FOO_BAR}'), true);
+});
+
+test('isPlaceholder: rejects non-placeholder strings', () => {
+  assert.equal(isPlaceholder('sk-ant-12345'), false);
+  assert.equal(isPlaceholder('${partial'), false);
+  assert.equal(isPlaceholder('text${VAR}text'), false);
+  assert.equal(isPlaceholder(''), false);
+});
+
+// ---------------------------------------------------------------------------
+// resolveSinglePlaceholder
+// ---------------------------------------------------------------------------
+
+test('resolveSinglePlaceholder: resolves from process.env', () => {
+  process.env._NF_TEST_RESOLVE_ME = 'resolved-value';
+  assert.equal(resolveSinglePlaceholder('${_NF_TEST_RESOLVE_ME}'), 'resolved-value');
+  delete process.env._NF_TEST_RESOLVE_ME;
+});
+
+test('resolveSinglePlaceholder: returns original when not a placeholder', () => {
+  assert.equal(resolveSinglePlaceholder('plain-value'), 'plain-value');
+  assert.equal(resolveSinglePlaceholder('https://api.example.com'), 'https://api.example.com');
+});
+
+test('resolveSinglePlaceholder: returns original when env var missing', () => {
+  assert.equal(resolveSinglePlaceholder('${_NF_DEFINITELY_NOT_SET_XYZ}'), '${_NF_DEFINITELY_NOT_SET_XYZ}');
+});
+
+// ---------------------------------------------------------------------------
+// resolveEnvPlaceholders
+// ---------------------------------------------------------------------------
+
+test('resolveEnvPlaceholders: resolves all placeholders', () => {
+  process.env._NF_TEST_KEY1 = 'value1';
+  process.env._NF_TEST_KEY2 = 'value2';
+  const env = {
+    API_KEY: '${_NF_TEST_KEY1}',
+    BASE_URL: 'https://example.com',
+    AUTH_TOKEN: '${_NF_TEST_KEY2}',
+  };
+  const resolved = resolveEnvPlaceholders(env);
+  assert.deepEqual(resolved, {
+    API_KEY: 'value1',
+    BASE_URL: 'https://example.com',
+    AUTH_TOKEN: 'value2',
+  });
+  delete process.env._NF_TEST_KEY1;
+  delete process.env._NF_TEST_KEY2;
+});
+
+test('resolveEnvPlaceholders: handles empty/null env', () => {
+  assert.deepEqual(resolveEnvPlaceholders({}), {});
+  assert.deepEqual(resolveEnvPlaceholders(null), {});
+  assert.deepEqual(resolveEnvPlaceholders(undefined), {});
+});
+
+test('resolveEnvPlaceholders: leaves unresolved placeholders as-is', () => {
+  const env = { TOKEN: '${_NF_MISSING_VAR}' };
+  const resolved = resolveEnvPlaceholders(env);
+  assert.equal(resolved.TOKEN, '${_NF_MISSING_VAR}');
+});
+
+// ---------------------------------------------------------------------------
+// findPlaintextSecrets
+// ---------------------------------------------------------------------------
+
+test('findPlaintextSecrets: finds plaintext secret values', () => {
+  const env = {
+    ANTHROPIC_API_KEY: 'sk-ant-12345',
+    ANTHROPIC_BASE_URL: 'https://api.anthropic.com',
+    ANTHROPIC_AUTH_TOKEN: 'tok-secret',
+  };
+  const found = findPlaintextSecrets(env);
+  assert.equal(found.length, 2);
+  assert.equal(found[0].key, 'ANTHROPIC_API_KEY');
+  assert.equal(found[0].value, 'sk-ant-12345');
+  assert.equal(found[1].key, 'ANTHROPIC_AUTH_TOKEN');
+  assert.equal(found[1].value, 'tok-secret');
+});
+
+test('findPlaintextSecrets: skips placeholder values', () => {
+  const env = {
+    ANTHROPIC_API_KEY: '${ANTHROPIC_API_KEY}',
+    ANTHROPIC_AUTH_TOKEN: '${ANTHROPIC_AUTH_TOKEN}',
+  };
+  assert.equal(findPlaintextSecrets(env).length, 0);
+});
+
+test('findPlaintextSecrets: handles empty env', () => {
+  assert.deepEqual(findPlaintextSecrets({}), []);
+  assert.deepEqual(findPlaintextSecrets(null), []);
+});
+
+// ---------------------------------------------------------------------------
+// maskSecrets
+// ---------------------------------------------------------------------------
+
+test('maskSecrets: converts plaintext secrets to placeholders', () => {
+  const env = {
+    ANTHROPIC_API_KEY: 'sk-ant-12345',
+    ANTHROPIC_BASE_URL: 'https://api.anthropic.com',
+    ANTHROPIC_AUTH_TOKEN: 'tok-secret',
+    MODEL: 'claude-opus-4-6',
+  };
+  const { masked, secrets } = maskSecrets(env);
+  assert.equal(masked.ANTHROPIC_API_KEY, '${ANTHROPIC_API_KEY}');
+  assert.equal(masked.ANTHROPIC_AUTH_TOKEN, '${ANTHROPIC_AUTH_TOKEN}');
+  assert.equal(masked.ANTHROPIC_BASE_URL, 'https://api.anthropic.com');
+  assert.equal(masked.MODEL, 'claude-opus-4-6');
+  assert.equal(secrets.length, 2);
+  assert.equal(secrets[0].key, 'ANTHROPIC_API_KEY');
+  assert.equal(secrets[0].value, 'sk-ant-12345');
+  assert.equal(secrets[1].key, 'ANTHROPIC_AUTH_TOKEN');
+  assert.equal(secrets[1].value, 'tok-secret');
+});
+
+test('maskSecrets: no-op when all secrets already placeholders', () => {
+  const env = { ANTHROPIC_API_KEY: '${ANTHROPIC_API_KEY}' };
+  const { masked, secrets } = maskSecrets(env);
+  assert.equal(masked.ANTHROPIC_API_KEY, '${ANTHROPIC_API_KEY}');
+  assert.equal(secrets.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// findUnresolvedPlaceholders
+// ---------------------------------------------------------------------------
+
+test('findUnresolvedPlaceholders: finds keys with missing env vars', () => {
+  const env = {
+    API_KEY: '${_NF_MISSING_1}',
+    BASE_URL: 'https://example.com',
+    TOKEN: '${_NF_MISSING_2}',
+  };
+  const unresolved = findUnresolvedPlaceholders(env);
+  assert.deepEqual(unresolved, ['API_KEY', 'TOKEN']);
+});
+
+test('findUnresolvedPlaceholders: empty when all resolved', () => {
+  process.env._NF_TEST_RESOLVE_ALL = 'yes';
+  const env = { TOKEN: '${_NF_TEST_RESOLVE_ALL}' };
+  assert.deepEqual(findUnresolvedPlaceholders(env), []);
+  delete process.env._NF_TEST_RESOLVE_ALL;
+});

--- a/bin/resolve-env.test.cjs
+++ b/bin/resolve-env.test.cjs
@@ -5,6 +5,7 @@ const {
   isSecretKey, toPlaceholder, isPlaceholder,
   resolveEnvPlaceholders, resolveSinglePlaceholder,
   findPlaintextSecrets, maskSecrets, findUnresolvedPlaceholders,
+  extractPlaceholderVar, namespacedSecretKey,
   SECRET_KEY_RE, PLACEHOLDER_RE,
 } = require('./resolve-env.cjs');
 
@@ -193,4 +194,33 @@ test('findUnresolvedPlaceholders: empty when all resolved', () => {
   const env = { TOKEN: '${_NF_TEST_RESOLVE_ALL}' };
   assert.deepEqual(findUnresolvedPlaceholders(env), []);
   delete process.env._NF_TEST_RESOLVE_ALL;
+});
+
+// ---------------------------------------------------------------------------
+// extractPlaceholderVar
+// ---------------------------------------------------------------------------
+
+test('extractPlaceholderVar: extracts variable name from ${VAR}', () => {
+  assert.equal(extractPlaceholderVar('${ANTHROPIC_API_KEY}'), 'ANTHROPIC_API_KEY');
+  assert.equal(extractPlaceholderVar('${FOO_BAR}'), 'FOO_BAR');
+});
+
+test('extractPlaceholderVar: returns null for non-placeholder strings', () => {
+  assert.equal(extractPlaceholderVar('plain-value'), null);
+  assert.equal(extractPlaceholderVar(''), null);
+  assert.equal(extractPlaceholderVar('text${VAR}text'), null);
+});
+
+test('extractPlaceholderVar: returns null for null/undefined', () => {
+  assert.equal(extractPlaceholderVar(null), null);
+  assert.equal(extractPlaceholderVar(undefined), null);
+});
+
+// ---------------------------------------------------------------------------
+// namespacedSecretKey
+// ---------------------------------------------------------------------------
+
+test('namespacedSecretKey: combines slot and env key', () => {
+  assert.equal(namespacedSecretKey('claude-z-ai', 'ANTHROPIC_AUTH_TOKEN'), 'claude-z-ai__ANTHROPIC_AUTH_TOKEN');
+  assert.equal(namespacedSecretKey('claude-minimax', 'ANTHROPIC_API_KEY'), 'claude-minimax__ANTHROPIC_API_KEY');
 });

--- a/bin/unified-mcp-server.mjs
+++ b/bin/unified-mcp-server.mjs
@@ -22,6 +22,7 @@ const require = createRequire(import.meta.url);
 const { resolveCli } = require('./resolve-cli.cjs');
 const { _pure: { detectInstalledProviders } } = require('./manage-agents-core.cjs');
 const { resolveEnvPlaceholders, findUnresolvedPlaceholders } = require('./resolve-env.cjs');
+const { extractPlaceholderVar, namespacedSecretKey } = require('./resolve-env.cjs');
 
 // ─── Load providers config ─────────────────────────────────────────────────────
 // Precedence:
@@ -973,16 +974,21 @@ async function main() {
   // The fan-out import (issue 169) writes secret values as ${KEY} placeholders
   // in providers.json and stores actual values in the secrets store. Without
   // this bootstrap, spawn-time resolution would fail with a missing env var.
+  // Secrets are namespaced by slot name (<slot>__<key>) to prevent collisions
+  // when multiple providers share the same env key with different values.
   if (SLOT && slotProvider && slotProvider.env) {
     try {
       const { isPlaceholder } = require('./resolve-env.cjs');
       const secrets = require('./secrets.cjs');
       let loaded = 0;
       for (const [k, v] of Object.entries(slotProvider.env)) {
-        if (isPlaceholder(v) && process.env[k] === undefined) {
-          const secret = await secrets.get('nforma', k);
+        const envVarName = extractPlaceholderVar(v);
+        if (envVarName !== null && process.env[envVarName] === undefined) {
+          // Try namespaced key first, then fall back to unnamespaced
+          const secret = await secrets.get('nforma', namespacedSecretKey(SLOT, envVarName))
+                        ?? await secrets.get('nforma', envVarName);
           if (secret) {
-            process.env[k] = secret;
+            process.env[envVarName] = secret;
             loaded++;
           }
         }

--- a/bin/unified-mcp-server.mjs
+++ b/bin/unified-mcp-server.mjs
@@ -21,6 +21,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
 const { resolveCli } = require('./resolve-cli.cjs');
 const { _pure: { detectInstalledProviders } } = require('./manage-agents-core.cjs');
+const { resolveEnvPlaceholders, findUnresolvedPlaceholders } = require('./resolve-env.cjs');
 
 // ─── Load providers config ─────────────────────────────────────────────────────
 // Precedence:
@@ -309,7 +310,13 @@ async function runProvider(provider, toolArgs) {
     a === '{prompt}' ? prompt : a
   );
 
-  const env = { ...process.env, ...(provider.env ?? {}) };
+  const env = { ...process.env, ...resolveEnvPlaceholders(provider.env ?? {}) };
+
+  // Check for unresolved ${VAR} placeholders — these indicate missing secrets
+  const unresolved = findUnresolvedPlaceholders(provider.env ?? {});
+  if (unresolved.length > 0) {
+    process.stderr.write(`[unified-mcp-server] WARNING: unresolved placeholder(s) in slot ${provider.name}: ${unresolved.join(', ')} — set in env or run /nf:mcp-setup to store in secrets\n`);
+  }
 
   return new Promise((resolve) => {
     let child;
@@ -373,7 +380,7 @@ async function runProvider(provider, toolArgs) {
 
 /** Run a subprocess with explicit args (used for help, extraTools) */
 async function runSubprocessWithArgs(provider, args, timeoutMs = 30000) {
-  const env = { ...process.env, ...(provider.env ?? {}) };
+  const env = { ...process.env, ...resolveEnvPlaceholders(provider.env ?? {}) };
 
   return new Promise((resolve) => {
     let child;
@@ -958,6 +965,33 @@ async function main() {
     } catch (e) {
       // secrets store unavailable or no entry — continue without it
       process.stderr.write(`[unified-mcp-server] secrets unavailable for slot ${SLOT}: ${e.message}\n`);
+    }
+  }
+
+  // ─── ${VAR} placeholder bootstrap ──────────────────────────────────────────
+  // Load secrets for ${VAR} placeholders in the active slot's provider.env.
+  // The fan-out import (issue 169) writes secret values as ${KEY} placeholders
+  // in providers.json and stores actual values in the secrets store. Without
+  // this bootstrap, spawn-time resolution would fail with a missing env var.
+  if (SLOT && slotProvider && slotProvider.env) {
+    try {
+      const { isPlaceholder } = require('./resolve-env.cjs');
+      const secrets = require('./secrets.cjs');
+      let loaded = 0;
+      for (const [k, v] of Object.entries(slotProvider.env)) {
+        if (isPlaceholder(v) && process.env[k] === undefined) {
+          const secret = await secrets.get('nforma', k);
+          if (secret) {
+            process.env[k] = secret;
+            loaded++;
+          }
+        }
+      }
+      if (loaded > 0) {
+        process.stderr.write(`[unified-mcp-server] Loaded ${loaded} secret(s) for slot ${SLOT} from secrets store\n`);
+      }
+    } catch (e) {
+      process.stderr.write(`[unified-mcp-server] secrets bootstrap for slot ${SLOT}: ${e.message}\n`);
     }
   }
 

--- a/commands/nf/link-daintree.md
+++ b/commands/nf/link-daintree.md
@@ -629,8 +629,20 @@ for (const item of plan) {
 // (~/.claude/nf-secrets.json) so they never appear on disk in providers.json or
 // its backups. Dispatch-time resolution in unified-mcp-server.mjs and
 // call-quorum-slot.cjs loads from the secrets store into process.env.
+//
+// Only providers touched by this fan-out (added or updated in the plan) are
+// masked — pre-existing vanilla slots and hand-written entries are left intact.
+// Secrets are namespaced by provider name (<name>__<key>) to prevent collisions
+// when multiple providers share the same env key with different token values.
 const SECRET_KEY_RE = /_(API_KEY|AUTH_TOKEN|TOKEN)$/;
 const PLACEHOLDER_RE = /^\$\{([^}]+)\}$/;
+
+// Collect names of providers that were actually touched by this fan-out
+const touchedNames = new Set();
+for (const item of plan) {
+  if (item.kind === 'add') touchedNames.add(item.newName);
+  else if (item.kind === 'update') touchedNames.add(item.existingName);
+}
 
 let secretsStore = {};
 const secretsPath = path.join(os.homedir(), '.claude', 'nf-secrets.json');
@@ -639,12 +651,14 @@ let secretsUpdated = false;
 
 for (const provider of providersData.providers) {
   if (!provider.env) continue;
+  if (!touchedNames.has(provider.name)) continue;
   for (const k of Object.keys(provider.env)) {
     if (SECRET_KEY_RE.test(k) && !PLACEHOLDER_RE.test(String(provider.env[k]))) {
-      // Store the plaintext value in secrets store under the key name
-      secretsStore[k] = provider.env[k];
+      // Store with namespaced key to prevent multi-provider collisions
+      const storeKey = provider.name + '__' + k;
+      secretsStore[storeKey] = provider.env[k];
       secretsUpdated = true;
-      // Replace with placeholder
+      // Replace with placeholder (uses the CLI-expected env key name)
       provider.env[k] = '${' + k + '}';
     }
   }

--- a/commands/nf/link-daintree.md
+++ b/commands/nf/link-daintree.md
@@ -381,7 +381,7 @@ Display the REVIEW FAN-OUT IMPORT banner:
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 Allowlist (preset env keys must match):
-  ^(ANTHROPIC_|OPENAI_|GOOGLE_|GEMINI_|TOGETHER_|DEEPSEEK_|OLLAMA_|OPENROUTER_|XAI_|GROK_|MODEL$|.*_BASE_URL$|.*_API_KEY$)
+  ^(ANTHROPIC_|OPENAI_|GOOGLE_|GEMINI_|TOGETHER_|DEEPSEEK_|OLLAMA_|OPENROUTER_|XAI_|GROK_|MODEL$|.*_BASE_URL$|.*_API_KEY$|.*_AUTH_TOKEN$|.*_TOKEN$)
 
 New slots (one per Daintree preset):
   ◆ {agentName}: vanilla = {vanillaSlotName} (preserved unchanged)
@@ -453,7 +453,7 @@ const SLOT_NAME_RE = /^[a-z][a-z0-9-]*$/;
 function slugify(s) {
   return String(s).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
 }
-const ALLOWLIST = /^(ANTHROPIC_|OPENAI_|GOOGLE_|GEMINI_|TOGETHER_|DEEPSEEK_|OLLAMA_|OPENROUTER_|XAI_|GROK_|MODEL$|.*_BASE_URL$|.*_API_KEY$)/;
+const ALLOWLIST = /^(ANTHROPIC_|OPENAI_|GOOGLE_|GEMINI_|TOGETHER_|DEEPSEEK_|OLLAMA_|OPENROUTER_|XAI_|GROK_|MODEL$|.*_BASE_URL$|.*_API_KEY$|.*_AUTH_TOKEN$|.*_TOKEN$)/;
 function filterAllowlisted(envObj) {
   const out = {};
   for (const [k, v] of Object.entries(envObj || {})) if (ALLOWLIST.test(k)) out[k] = v;
@@ -621,6 +621,42 @@ for (const item of plan) {
     const envKeys = [...new Set([...Object.keys(item.globalEnv || {}), ...Object.keys(item.presetEnv || {})])];
     written.providers.updated.push({ name: existing.name, presetName: item.preset.name, presetId: existingId, envKeys });
   }
+}
+
+// ── Mask secret values in providers.json (issue 169) ────────────────────────
+// Secret keys (*_API_KEY, *_AUTH_TOKEN, *_TOKEN) are written as ${VAR} placeholders
+// in providers.json. Actual values are stored in the secrets store
+// (~/.claude/nf-secrets.json) so they never appear on disk in providers.json or
+// its backups. Dispatch-time resolution in unified-mcp-server.mjs and
+// call-quorum-slot.cjs loads from the secrets store into process.env.
+const SECRET_KEY_RE = /_(API_KEY|AUTH_TOKEN|TOKEN)$/;
+const PLACEHOLDER_RE = /^\$\{([^}]+)\}$/;
+
+let secretsStore = {};
+const secretsPath = path.join(os.homedir(), '.claude', 'nf-secrets.json');
+try { secretsStore = JSON.parse(fs.readFileSync(secretsPath, 'utf8')) || {}; } catch (_) {}
+let secretsUpdated = false;
+
+for (const provider of providersData.providers) {
+  if (!provider.env) continue;
+  for (const k of Object.keys(provider.env)) {
+    if (SECRET_KEY_RE.test(k) && !PLACEHOLDER_RE.test(String(provider.env[k]))) {
+      // Store the plaintext value in secrets store under the key name
+      secretsStore[k] = provider.env[k];
+      secretsUpdated = true;
+      // Replace with placeholder
+      provider.env[k] = '${' + k + '}';
+    }
+  }
+}
+
+// Persist secrets store (atomic write)
+if (secretsUpdated) {
+  fs.mkdirSync(path.dirname(secretsPath), { recursive: true });
+  const tmpSecrets = secretsPath + '.tmp';
+  fs.writeFileSync(tmpSecrets, JSON.stringify(secretsStore, null, 2), { mode: 0o600 });
+  fs.renameSync(tmpSecrets, secretsPath);
+  process.stderr.write('[nf:link-daintree] Stored ' + Object.keys(secretsStore).length + ' secret(s) in secrets store, replaced with ${VAR} placeholders in providers.json\n');
 }
 
 fs.writeFileSync(providersPath, JSON.stringify(providersData, null, 2) + '\n');
@@ -1154,7 +1190,7 @@ Re-run /nf:link-canopy any time to refresh the link. Idempotency rules:
 - nf.json backup created before any write
 - Import path fans out per-agent presets into new provider entries (matched via provider.mainTool === agentName + family inferred from preset env), overlaying allowlisted env onto the cloned vanilla. Vanilla slots are untouched; preset-linked slots are replaced in place on re-import. (issue 138 AC2 + AC5)
 - providers.json backup created before any env merge write
-- Both preset env and globalEnvironmentVariables merges are gated by allowlist `^(ANTHROPIC_|OPENAI_|GOOGLE_|GEMINI_|TOGETHER_|DEEPSEEK_|OLLAMA_|OPENROUTER_|XAI_|GROK_|MODEL$|.*_BASE_URL$|.*_API_KEY$)` — covers all BRAND_COLORS providers
+- Both preset env and globalEnvironmentVariables merges are gated by allowlist `^(ANTHROPIC_|OPENAI_|GOOGLE_|GEMINI_|TOGETHER_|DEEPSEEK_|OLLAMA_|OPENROUTER_|XAI_|GROK_|MODEL$|.*_BASE_URL$|.*_API_KEY$|.*_AUTH_TOKEN$|.*_TOKEN$)` — covers all BRAND_COLORS providers
 - Registration writes to Canopy's userAgentRegistry with `nf-` prefixed agent IDs
 - Export path writes nForma quorum slots to per-agent Daintree customPresets arrays (agentSettings.agents.<agent>.customPresets[]) with provider-specific brand colors from BRAND_COLORS mapping (issue 138 AC3 + AC4)
 - Canopy config.json backup created before any write


### PR DESCRIPTION
## Summary

Closes #169

- **`bin/resolve-env.cjs`** — shared utility for `${VAR}` placeholder detection, masking, and resolution (`isSecretKey`, `toPlaceholder`, `resolveEnvPlaceholders`, `maskSecrets`, `findPlaintextSecrets`)
- **`bin/unified-mcp-server.mjs`** + **`bin/call-quorum-slot.cjs`** — resolve `${VAR}` placeholders in `provider.env` at spawn/dispatch time; load secrets from `~/.claude/nf-secrets.json` at startup into `process.env`
- **`commands/nf/link-daintree.md`** — fan-out import now masks secret values (`*_API_KEY`, `*_AUTH_TOKEN`, `*_TOKEN`) as `${VAR}` placeholders before writing providers.json; actual values stored in secrets store (mode 0600). Allowlist expanded to explicitly include `*_AUTH_TOKEN$` and `*_TOKEN$`
- **`bin/migrate-plaintext-tokens.cjs`** — one-shot migration script for existing installs: scans providers.json for plaintext secrets, stores in secrets store, replaces with placeholders. Supports `--dry-run`
- **`bin/resolve-env.test.cjs`** — 20 tests covering all utility functions

## Acceptance criteria (from #169)

- [x] No raw token strings written to providers.json by `/nf:link-daintree`
- [x] Spawn-time placeholder resolution works for both subprocess and HTTP slots
- [x] One-shot migration helper that converts existing plaintext tokens to placeholders + writes them to keychain
- [ ] Documentation for users with already-leaked tokens (rotate + re-import) — migration script prints rotation guidance

## Test plan

- [x] `node --test bin/resolve-env.test.cjs` — 20/20 pass
- [x] `npm run test:ci` — 1550/1550 pass
- [x] `npm run lint:isolation` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Secure secret management system for API keys and auth tokens using placeholder-based environment variables
  * New migration tool to move plaintext secrets from configuration files to a secure local store with restricted file permissions
  * Enhanced environment variable resolution supporting `${VAR}` placeholder substitution

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nForma-AI/nForma/pull/182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->