### PR TITLE
fix(quorum): replace truthy gate in detectInstalledProviders

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -240,7 +240,7 @@
         "filename": "bin/manage-agents-core.cjs",
         "hashed_secret": "32df82dccdd26b62d92eaefa9ccc2550d5ec96bd",
         "is_verified": false,
-        "line_number": 454
+        "line_number": 458
       }
     ],
     "bin/manage-agents.test.cjs": [
@@ -391,5 +391,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-13T15:55:56Z"
+  "generated_at": "2026-05-18T14:54:50Z"
 }

--- a/bin/manage-agents-core.cjs
+++ b/bin/manage-agents-core.cjs
@@ -340,12 +340,12 @@ function writeProvidersJson(data) {
  * detectInstalledProviders(providers) — filter providers to those whose CLI binary is present.
  *
  * Rules:
- * - HTTP-only slots (no `cli` field OR type === 'http') are always included.
- * - For subprocess/ccr slots, use the already-resolved `resolvedCli` field if present,
- *   otherwise fall back to `cli`. This function MUST be called after the resolveCli() loop
- *   in unified-mcp-server.mjs so that resolvedCli is populated before probing.
- *   If resolvedCli is absent (e.g. called out-of-order or in isolation), the raw `cli`
- *   field is used as a best-effort fallback. Test with fs.accessSync(path, fs.constants.X_OK).
+ * - HTTP-only slots (type === 'http') are always included.
+ * - For subprocess slots, resolve the binary path via resolvedCli > cli > mainTool.
+ *   `mainTool` is the bare CLI name inferred from slot-name prefix (e.g. "claude" from "claude-1").
+ *   If none of these fields yield a path, the slot is excluded with a diagnostic log.
+ *   This function MUST be called after the resolveCli() loop in unified-mcp-server.mjs so
+ *   that resolvedCli is populated when available. Test with fs.accessSync(path, fs.constants.X_OK).
  * - De-duplicate probes: slots sharing the same binary path check the filesystem
  *   only once per unique path.
  * - Fail-open: any unexpected error returns the full providers list unchanged.
@@ -359,9 +359,13 @@ function detectInstalledProviders(providers) {
     const checked = new Map(); // binaryPath -> boolean (installed)
     return providers.filter(p => {
       // HTTP-only slots have no CLI to probe — always include
-      if (!p.cli || p.type === 'http') return true;
-      // Use resolvedCli (set by resolveCli() loop) if available; fall back to raw cli field
-      const binaryPath = p.resolvedCli || p.cli;
+      if (p.type === 'http') return true;
+      // Resolve binary: resolvedCli > cli > mainTool (bare name from ~/.claude.json reconstruction)
+      const binaryPath = p.resolvedCli || p.cli || p.mainTool;
+      if (!binaryPath) {
+        process.stderr.write(`[manage-agents-core] detectInstalledProviders: ${p.name} has no resolvable CLI (cli, resolvedCli, mainTool all empty) — excluded\n`);
+        return false;
+      }
       if (checked.has(binaryPath)) return checked.get(binaryPath);
       let installed = false;
       try {


### PR DESCRIPTION
## Summary
- Replaces `!p.cli || p.type === 'http'` truthy gate with explicit `p.type === 'http'` type check
- Adds `mainTool` to the binary resolution chain (`resolvedCli || cli || mainTool`) so slots reconstructed from `~/.claude.json` are properly probed
- Slots with no resolvable binary at any field are now excluded with a clear diagnostic instead of silently passing through as UNAVAIL

Closes #174

## Test plan
- [x] `npm run test:ci` — 1550/1550 pass
- [x] `npm run lint:isolation` — all checks passed
- [x] `npm run check:assets` — up to date
- [ ] Verify HTTP slots still pass (type check preserved)
- [ ] Verify subprocess slots with `cli: null` + valid `mainTool` are probed via mainTool
- [ ] Verify slots with no resolvable CLI are excluded with diagnostic

🤖 Generated with [Claude Code](https://claude.com/claude-code)