### PR TITLE
fix(autopilot): trust server state over gh exit code on merge

### DIFF
--- a/scripts/pr-merge-autopilot.sh
+++ b/scripts/pr-merge-autopilot.sh
@@ -754,8 +754,15 @@ if [[ "$MERGE_READY" == "true" ]]; then
       status_green "Merged PR #$PR_NUMBER via squash merge"
       status_green "Branch deleted"
     else
-      status_red "Failed to merge PR #$PR_NUMBER"
-      exit 1
+      # gh pr merge may fail when GitHub auto-merged the PR during the polling
+      # loop. Re-query server state before reporting failure.
+      POST_MERGE_STATE=$(gh pr view "$PR_NUMBER" --json state,mergedAt,mergeCommit --jq '.state' 2>/dev/null || echo "UNKNOWN")
+      if [[ "$POST_MERGE_STATE" == "MERGED" ]]; then
+        status_green "PR #$PR_NUMBER was already merged (likely via GitHub auto-merge)"
+      else
+        status_red "Failed to merge PR #$PR_NUMBER (state: $POST_MERGE_STATE)"
+        exit 1
+      fi
     fi
   else
     status_yellow "Would merge PR #$PR_NUMBER via squash and delete branch"


### PR DESCRIPTION
## Summary
- `pr-merge-autopilot.sh` falsely reported "Failed to merge" when GitHub auto-merged the PR during the polling loop (race condition with `gh pr merge --squash`)
- After `gh pr merge` returns non-zero, re-query `gh pr view` to check actual server state before reporting failure
- If PR is `MERGED`, report success; only report failure if still `OPEN` or other non-MERGED state

## Test plan
- [x] `bash -n` syntax check passes
- [x] `npm run test:ci` — 1550/1550 pass
- [ ] Manual: run autopilot against a PR with GitHub auto-merge enabled and confirm race-merged PRs report success

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)