### PR TITLE
feat(quorum): empirical score delta calibration

### DIFF
--- a/bin/calibrate-score-deltas.cjs
+++ b/bin/calibrate-score-deltas.cjs
@@ -182,8 +182,8 @@ function deriveCalibratedDeltas(rounds, defaults, options) {
   }
 
   // Derived types: TP+ = TP + improvement bonus, TN+ = TN + improvement bonus
-  deltas['TP+'] = deltas.TP + IMPROVEMENT_BONUS;
-  deltas['TN+'] = deltas.TN + IMPROVEMENT_BONUS;
+  deltas['TP+'] = Math.max(CLAMP_MIN, Math.min(CLAMP_MAX, deltas.TP + IMPROVEMENT_BONUS));
+  deltas['TN+'] = Math.max(CLAMP_MIN, Math.min(CLAMP_MAX, deltas.TN + IMPROVEMENT_BONUS));
   perType['TP+'] = { signal: null, empiricalDelta: deltas['TP+'], rounds: 0, usedDefault: false, derived: true, note: `TP(${deltas.TP}) + ${IMPROVEMENT_BONUS}` };
   perType['TN+'] = { signal: null, empiricalDelta: deltas['TN+'], rounds: 0, usedDefault: false, derived: true, note: `TN(${deltas.TN}) + ${IMPROVEMENT_BONUS}` };
 
@@ -259,7 +259,7 @@ async function main() {
 
   const source = metadata.usedFallback ? 'DEFAULT (insufficient data)' : 'CALIBRATED';
   process.stdout.write(
-    `[calibrate] ${source} | ${metadata.classifiedRounds || rounds.length}/${rounds.length} rounds | output: ${outputPath}\n`
+    `[calibrate] ${source} | ${metadata.classifiedRounds ?? rounds.length}/${rounds.length} rounds | output: ${outputPath}\n`
   );
 
   // Print delta summary

--- a/bin/calibrate-score-deltas.cjs
+++ b/bin/calibrate-score-deltas.cjs
@@ -1,0 +1,288 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * calibrate-score-deltas.cjs
+ *
+ * Analyzes quorum scoreboard rounds to derive empirically calibrated score
+ * deltas. Measures per-vote-type correlation with consensus outcomes and
+ * produces scaled integer deltas that replace hand-tuned constants.
+ *
+ * Usage:
+ *   node bin/calibrate-score-deltas.cjs [--scoreboard <path>] [--output <path>] [--min-rounds <n>]
+ *
+ * Output: .planning/quorum/calibrated-deltas.json
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// Current hardcoded defaults (from update-scoreboard.cjs)
+const DEFAULT_SCORE_DELTAS = {
+  TP: 1,
+  TN: 5,
+  FP: -3,
+  FN: -1,
+  'TP+': 3,
+  'TN+': 7,
+  UNAVAIL: 0,
+  '': 0,
+};
+
+const POSITIVE_VERDICTS = new Set(['APPROVE', 'CONSENSUS']);
+const NEGATIVE_VERDICTS = new Set(['BLOCK', 'GAPS_FOUND']);
+const BASE_VOTE_TYPES = ['TP', 'TN', 'FP', 'FN'];
+const IMPROVEMENT_BONUS = 2;
+const MIN_ROUNDS_DEFAULT = 30;
+const MIN_VOTES_DEFAULT = 5;
+const SCALE_FACTOR = 5;
+const CLAMP_MAX = 10;
+const CLAMP_MIN = -10;
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i++) {
+    const key = argv[i];
+    if (key.startsWith('--')) {
+      const name = key.slice(2);
+      const value = argv[i + 1] !== undefined && !argv[i + 1].startsWith('--')
+        ? argv[++i]
+        : '';
+      args[name] = value;
+    }
+  }
+  return args;
+}
+
+function defaultScoreboardPath() {
+  try {
+    return require('./planning-paths.cjs').resolveWithFallback(process.cwd(), 'quorum-scoreboard');
+  } catch (_) {
+    return '.planning/quorum/scoreboard.json';
+  }
+}
+
+function defaultOutputPath() {
+  try {
+    return require('./planning-paths.cjs').resolve(process.cwd(), 'calibrated-deltas');
+  } catch (_) {
+    return '.planning/quorum/calibrated-deltas.json';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pure functions (exported for testing)
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify a round's outcome as positive or negative based on verdict.
+ * Returns null for unclassifiable verdicts (DELIBERATE, '—').
+ */
+function classifyRoundOutcome(round) {
+  const v = round.verdict;
+  if (!v) return null;
+  if (POSITIVE_VERDICTS.has(v)) return 'positive';
+  if (NEGATIVE_VERDICTS.has(v)) return 'negative';
+  return null;
+}
+
+/**
+ * Tally per-vote-type occurrence counts in positive vs negative rounds.
+ * Only counts classified votes (skips '', UNAVAIL).
+ * Only uses rounds where classifyRoundOutcome returns non-null.
+ */
+function tallyVoteTypeOutcomes(rounds) {
+  const tallies = {};
+  for (const type of BASE_VOTE_TYPES) {
+    tallies[type] = { positive: 0, negative: 0, total: 0 };
+  }
+
+  for (const round of rounds) {
+    const outcome = classifyRoundOutcome(round);
+    if (!outcome) continue;
+
+    const votes = round.votes || {};
+    for (const [, vote] of Object.entries(votes)) {
+      if (!vote || vote === '' || vote === 'UNAVAIL') continue;
+      // Map TP+ → TP, TN+ → TN for base type tallying
+      const baseType = vote.replace('+', '');
+      if (tallies[baseType]) {
+        tallies[baseType][outcome] += 1;
+        tallies[baseType].total += 1;
+      }
+    }
+  }
+
+  return tallies;
+}
+
+/**
+ * Compute signal value for a vote type.
+ * Signal = P(positive_outcome | vote_type) - P(positive_outcome overall)
+ * Returns null if insufficient data (total < minVotes).
+ */
+function computeSignal(tallies, overallPositiveRate, voteType, minVotes) {
+  const t = tallies[voteType];
+  if (!t || t.total < minVotes) return null;
+  const pPositiveGivenType = t.positive / t.total;
+  return pPositiveGivenType - overallPositiveRate;
+}
+
+/**
+ * Derive calibrated deltas from rounds data.
+ * Falls back to defaults if insufficient data.
+ */
+function deriveCalibratedDeltas(rounds, defaults, options) {
+  const opts = {
+    minRounds: (options && options.minRounds) || MIN_ROUNDS_DEFAULT,
+    minVotes: (options && options.minVotes) || MIN_VOTES_DEFAULT,
+    scaleFactor: (options && options.scaleFactor) || SCALE_FACTOR,
+  };
+
+  const classifiedRounds = rounds.filter(r => classifyRoundOutcome(r) !== null);
+
+  if (classifiedRounds.length < opts.minRounds) {
+    return {
+      deltas: { ...defaults },
+      metadata: {
+        usedFallback: true,
+        reason: `only ${classifiedRounds.length} classified rounds (need ${opts.minRounds})`,
+        totalRounds: rounds.length,
+        classifiedRounds: classifiedRounds.length,
+        overallPositiveRate: null,
+        scaleFactor: opts.scaleFactor,
+        perType: {},
+      },
+    };
+  }
+
+  const tallies = tallyVoteTypeOutcomes(rounds);
+  const totalPositive = classifiedRounds.filter(r => classifyRoundOutcome(r) === 'positive').length;
+  const overallPositiveRate = totalPositive / classifiedRounds.length;
+
+  const deltas = {};
+  const perType = {};
+
+  // Compute base deltas
+  for (const type of BASE_VOTE_TYPES) {
+    const signal = computeSignal(tallies, overallPositiveRate, type, opts.minVotes);
+    if (signal === null) {
+      deltas[type] = defaults[type];
+      perType[type] = { signal: null, empiricalDelta: null, rounds: tallies[type] ? tallies[type].total : 0, usedDefault: true };
+    } else {
+      const raw = Math.round(signal * opts.scaleFactor);
+      const clamped = Math.max(CLAMP_MIN, Math.min(CLAMP_MAX, raw));
+      deltas[type] = clamped;
+      perType[type] = { signal: parseFloat(signal.toFixed(4)), empiricalDelta: clamped, rounds: tallies[type].total, usedDefault: false };
+    }
+  }
+
+  // Derived types: TP+ = TP + improvement bonus, TN+ = TN + improvement bonus
+  deltas['TP+'] = deltas.TP + IMPROVEMENT_BONUS;
+  deltas['TN+'] = deltas.TN + IMPROVEMENT_BONUS;
+  perType['TP+'] = { signal: null, empiricalDelta: deltas['TP+'], rounds: 0, usedDefault: false, derived: true, note: `TP(${deltas.TP}) + ${IMPROVEMENT_BONUS}` };
+  perType['TN+'] = { signal: null, empiricalDelta: deltas['TN+'], rounds: 0, usedDefault: false, derived: true, note: `TN(${deltas.TN}) + ${IMPROVEMENT_BONUS}` };
+
+  // Constants
+  deltas.UNAVAIL = 0;
+  deltas[''] = 0;
+
+  return {
+    deltas,
+    metadata: {
+      usedFallback: false,
+      totalRounds: rounds.length,
+      classifiedRounds: classifiedRounds.length,
+      overallPositiveRate: parseFloat(overallPositiveRate.toFixed(4)),
+      scaleFactor: opts.scaleFactor,
+      perType,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function loadScoreboard(scoreboardPath) {
+  const absPath = path.resolve(process.cwd(), scoreboardPath);
+  if (!fs.existsSync(absPath)) return null;
+  try {
+    const raw = fs.readFileSync(absPath, 'utf8');
+    return JSON.parse(raw);
+  } catch (_) {
+    return null;
+  }
+}
+
+function writeOutput(outputPath, content) {
+  const absPath = path.resolve(process.cwd(), outputPath);
+  fs.mkdirSync(path.dirname(absPath), { recursive: true });
+  const tmpPath = absPath + '.' + process.pid + '.tmp';
+  fs.writeFileSync(tmpPath, JSON.stringify(content, null, 2) + '\n', 'utf8');
+  fs.renameSync(tmpPath, absPath);
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const scoreboardPath = args.scoreboard || defaultScoreboardPath();
+  const outputPath = args.output || defaultOutputPath();
+  const minRounds = args['min-rounds'] ? parseInt(args['min-rounds'], 10) : MIN_ROUNDS_DEFAULT;
+
+  const data = loadScoreboard(scoreboardPath);
+  if (!data) {
+    process.stderr.write(`[calibrate] no scoreboard found at ${scoreboardPath}\n`);
+    process.exit(1);
+  }
+
+  const rounds = data.rounds || [];
+  if (rounds.length === 0) {
+    process.stderr.write('[calibrate] scoreboard has no rounds\n');
+    process.exit(1);
+  }
+
+  const { deltas, metadata } = deriveCalibratedDeltas(rounds, DEFAULT_SCORE_DELTAS, { minRounds });
+
+  const output = {
+    version: 1,
+    generated_at: new Date().toISOString(),
+    source_rounds: rounds.length,
+    deltas,
+    metadata,
+  };
+
+  writeOutput(outputPath, output);
+
+  const source = metadata.usedFallback ? 'DEFAULT (insufficient data)' : 'CALIBRATED';
+  process.stdout.write(
+    `[calibrate] ${source} | ${metadata.classifiedRounds || rounds.length}/${rounds.length} rounds | output: ${outputPath}\n`
+  );
+
+  // Print delta summary
+  const parts = BASE_VOTE_TYPES.map(t => `${t}=${deltas[t]}`);
+  parts.push(`TP+=${deltas['TP+']}`, `TN+=${deltas['TN+']}`);
+  process.stdout.write(`[calibrate] deltas: ${parts.join(' ')}\n`);
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = {
+    _pure: {
+      classifyRoundOutcome,
+      tallyVoteTypeOutcomes,
+      computeSignal,
+      deriveCalibratedDeltas,
+    },
+    DEFAULT_SCORE_DELTAS,
+  };
+}
+
+if (require.main === module) {
+  main().catch(err => {
+    process.stderr.write(`[calibrate] FATAL: ${err.message}\n`);
+    process.exit(1);
+  });
+}

--- a/bin/calibrate-score-deltas.test.cjs
+++ b/bin/calibrate-score-deltas.test.cjs
@@ -1,0 +1,362 @@
+#!/usr/bin/env node
+'use strict';
+// Test suite for bin/calibrate-score-deltas.cjs
+// Uses Node.js built-in test runner: node --test bin/calibrate-score-deltas.test.cjs
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const CAL_SCRIPT = path.join(__dirname, 'calibrate-score-deltas.cjs');
+const SB_SCRIPT = path.join(__dirname, 'update-scoreboard.cjs');
+
+const { _pure, DEFAULT_SCORE_DELTAS } = require('./calibrate-score-deltas.cjs');
+const { classifyRoundOutcome, tallyVoteTypeOutcomes, computeSignal, deriveCalibratedDeltas } = _pure;
+
+function tmpPath() {
+  return path.join(os.tmpdir(), 'nf-cal-test-' + Date.now() + '-' + Math.random().toString(36).slice(2) + '.json');
+}
+
+function cleanup(filePath) {
+  try { fs.unlinkSync(filePath); } catch (_) {}
+}
+
+function runCLI(args) {
+  const result = spawnSync('node', [CAL_SCRIPT, ...args], {
+    encoding: 'utf8',
+    timeout: 5000,
+  });
+  return {
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+    exitCode: result.status,
+  };
+}
+
+function runSB(args) {
+  const result = spawnSync('node', [SB_SCRIPT, ...args], {
+    encoding: 'utf8',
+    timeout: 5000,
+  });
+  return {
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+    exitCode: result.status,
+  };
+}
+
+// Helper: create a scoreboard with N rounds of known distribution
+function makeScoreboard(n, config) {
+  const rounds = [];
+  for (let i = 0; i < n; i++) {
+    const vote = config.vote || 'TP';
+    const verdict = config.verdict || 'APPROVE';
+    rounds.push({
+      date: '01-01',
+      task: `cal-test-${i}`,
+      round: i + 1,
+      votes: { 'claude-1:claude-model': vote },
+      verdict,
+    });
+  }
+  return { models: {}, slots: {}, rounds, categories: {} };
+}
+
+// ---------------------------------------------------------------------------
+// classifyRoundOutcome tests
+// ---------------------------------------------------------------------------
+
+test('CAL-TC1: classifyRoundOutcome returns positive for APPROVE', () => {
+  assert.strictEqual(classifyRoundOutcome({ verdict: 'APPROVE' }), 'positive');
+});
+
+test('CAL-TC2: classifyRoundOutcome returns positive for CONSENSUS', () => {
+  assert.strictEqual(classifyRoundOutcome({ verdict: 'CONSENSUS' }), 'positive');
+});
+
+test('CAL-TC3: classifyRoundOutcome returns negative for BLOCK', () => {
+  assert.strictEqual(classifyRoundOutcome({ verdict: 'BLOCK' }), 'negative');
+});
+
+test('CAL-TC4: classifyRoundOutcome returns negative for GAPS_FOUND', () => {
+  assert.strictEqual(classifyRoundOutcome({ verdict: 'GAPS_FOUND' }), 'negative');
+});
+
+test('CAL-TC5: classifyRoundOutcome returns null for DELIBERATE', () => {
+  assert.strictEqual(classifyRoundOutcome({ verdict: 'DELIBERATE' }), null);
+});
+
+test('CAL-TC5b: classifyRoundOutcome returns null for missing verdict', () => {
+  assert.strictEqual(classifyRoundOutcome({}), null);
+});
+
+// ---------------------------------------------------------------------------
+// tallyVoteTypeOutcomes tests
+// ---------------------------------------------------------------------------
+
+test('CAL-TC6: tallyVoteTypeOutcomes counts TP votes in positive rounds', () => {
+  const rounds = [
+    { verdict: 'APPROVE', votes: { a: 'TP', b: 'TP' } },
+    { verdict: 'BLOCK', votes: { a: 'FP' } },
+  ];
+  const tallies = tallyVoteTypeOutcomes(rounds);
+  assert.strictEqual(tallies.TP.positive, 2);
+  assert.strictEqual(tallies.TP.negative, 0);
+  assert.strictEqual(tallies.TP.total, 2);
+  assert.strictEqual(tallies.FP.positive, 0);
+  assert.strictEqual(tallies.FP.negative, 1);
+  assert.strictEqual(tallies.FP.total, 1);
+});
+
+test('CAL-TC6b: tallyVoteTypeOutcomes skips UNAVAIL and empty votes', () => {
+  const rounds = [
+    { verdict: 'APPROVE', votes: { a: 'TP', b: 'UNAVAIL', c: '' } },
+  ];
+  const tallies = tallyVoteTypeOutcomes(rounds);
+  assert.strictEqual(tallies.TP.total, 1);
+  assert.strictEqual(tallies.TN.total, 0);
+});
+
+test('CAL-TC6c: tallyVoteTypeOutcomes maps TP+ to TP base type', () => {
+  const rounds = [
+    { verdict: 'APPROVE', votes: { a: 'TP+' } },
+  ];
+  const tallies = tallyVoteTypeOutcomes(rounds);
+  assert.strictEqual(tallies.TP.positive, 1);
+  assert.strictEqual(tallies.TP.total, 1);
+});
+
+test('CAL-TC6d: tallyVoteTypeOutcomes skips rounds with unclassifiable verdict', () => {
+  const rounds = [
+    { verdict: 'DELIBERATE', votes: { a: 'TP' } },
+    { verdict: 'APPROVE', votes: { b: 'TN' } },
+  ];
+  const tallies = tallyVoteTypeOutcomes(rounds);
+  assert.strictEqual(tallies.TP.total, 0); // DELIBERATE round excluded
+  assert.strictEqual(tallies.TN.positive, 1);
+});
+
+// ---------------------------------------------------------------------------
+// computeSignal tests
+// ---------------------------------------------------------------------------
+
+test('CAL-TC7: computeSignal returns positive signal for vote types correlating with positive outcomes', () => {
+  const tallies = { TP: { positive: 40, negative: 5, total: 45 } };
+  const signal = computeSignal(tallies, 0.5, 'TP', 5);
+  assert.ok(signal > 0, `expected positive signal, got ${signal}`);
+  // P(positive|TP) = 40/45 ≈ 0.889, overall = 0.5, signal ≈ 0.389
+  assert.ok(Math.abs(signal - 0.3889) < 0.01, `signal ≈ 0.389, got ${signal}`);
+});
+
+test('CAL-TC8: computeSignal returns negative signal for vote types correlating with negative outcomes', () => {
+  const tallies = { FP: { positive: 5, negative: 20, total: 25 } };
+  const signal = computeSignal(tallies, 0.7, 'FP', 5);
+  assert.ok(signal < 0, `expected negative signal, got ${signal}`);
+});
+
+test('CAL-TC9: computeSignal returns null when vote count < minVotes', () => {
+  const tallies = { TN: { positive: 2, negative: 1, total: 3 } };
+  const signal = computeSignal(tallies, 0.5, 'TN', 5);
+  assert.strictEqual(signal, null);
+});
+
+// ---------------------------------------------------------------------------
+// deriveCalibratedDeltas tests
+// ---------------------------------------------------------------------------
+
+test('CAL-TC10: deriveCalibratedDeltas falls back to defaults when rounds < minRounds', () => {
+  const rounds = [
+    { verdict: 'APPROVE', votes: { a: 'TP' } },
+  ];
+  const { deltas, metadata } = deriveCalibratedDeltas(rounds, DEFAULT_SCORE_DELTAS, { minRounds: 30 });
+  assert.strictEqual(metadata.usedFallback, true);
+  assert.deepStrictEqual(deltas.TP, DEFAULT_SCORE_DELTAS.TP);
+  assert.deepStrictEqual(deltas.TN, DEFAULT_SCORE_DELTAS.TN);
+});
+
+test('CAL-TC11: deriveCalibratedDeltas produces valid deltas for synthetic 35-round dataset', () => {
+  const rounds = [];
+  // 25 APPROVE rounds with TP votes (TP correlates strongly with positive)
+  for (let i = 0; i < 25; i++) {
+    rounds.push({ verdict: 'APPROVE', votes: { a: 'TP' } });
+  }
+  // 5 BLOCK rounds with FP votes (FP correlates with negative)
+  for (let i = 0; i < 5; i++) {
+    rounds.push({ verdict: 'BLOCK', votes: { a: 'FP' } });
+  }
+  // 5 APPROVE rounds with TN votes (TN also positive but less common)
+  for (let i = 0; i < 5; i++) {
+    rounds.push({ verdict: 'APPROVE', votes: { b: 'TN' } });
+  }
+
+  const { deltas, metadata } = deriveCalibratedDeltas(rounds, DEFAULT_SCORE_DELTAS, { minRounds: 30, minVotes: 3 });
+  assert.strictEqual(metadata.usedFallback, false);
+  assert.ok(typeof deltas.TP === 'number');
+  assert.ok(typeof deltas.TN === 'number');
+  assert.ok(typeof deltas.FP === 'number');
+  assert.ok(typeof deltas.FN === 'number');
+  // TP should be positive (strongly correlates with positive outcomes)
+  assert.ok(deltas.TP > 0, `TP delta should be positive, got ${deltas.TP}`);
+  // FP should be negative (correlates with negative outcomes)
+  assert.ok(deltas.FP < 0, `FP delta should be negative, got ${deltas.FP}`);
+});
+
+test('CAL-TC12: deriveCalibratedDeltas preserves UNAVAIL=0 and empty=0', () => {
+  const rounds = [];
+  for (let i = 0; i < 35; i++) {
+    rounds.push({ verdict: 'APPROVE', votes: { a: 'TP' } });
+  }
+  const { deltas } = deriveCalibratedDeltas(rounds, DEFAULT_SCORE_DELTAS, { minRounds: 30 });
+  assert.strictEqual(deltas.UNAVAIL, 0);
+  assert.strictEqual(deltas[''], 0);
+});
+
+test('CAL-TC13: deriveCalibratedDeltas derives TP+ and TN+ from base deltas', () => {
+  const rounds = [];
+  for (let i = 0; i < 35; i++) {
+    rounds.push({ verdict: 'APPROVE', votes: { a: 'TP' } });
+  }
+  const { deltas } = deriveCalibratedDeltas(rounds, DEFAULT_SCORE_DELTAS, { minRounds: 30 });
+  assert.strictEqual(deltas['TP+'], deltas.TP + 2, 'TP+ should be TP delta + improvement bonus');
+  assert.strictEqual(deltas['TN+'], deltas.TN + 2, 'TN+ should be TN delta + improvement bonus');
+});
+
+test('CAL-TC14: deriveCalibratedDeltas clamps extreme values to [-10, +10]', () => {
+  // Create extreme data: all BLOCK rounds with TP votes (TP always in negative outcome)
+  const rounds = [];
+  for (let i = 0; i < 100; i++) {
+    rounds.push({ verdict: 'BLOCK', votes: { a: 'TP' } });
+  }
+  const { deltas } = deriveCalibratedDeltas(rounds, DEFAULT_SCORE_DELTAS, { minRounds: 30, scaleFactor: 100 });
+  assert.ok(deltas.TP >= -10, `TP delta must be >= -10, got ${deltas.TP}`);
+  assert.ok(deltas.TP <= 10, `TP delta must be <= 10, got ${deltas.TP}`);
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests (CLI subprocess)
+// ---------------------------------------------------------------------------
+
+test('CAL-TC15: CLI exits 1 when no scoreboard file found', () => {
+  const { exitCode, stderr } = runCLI(['--scoreboard', '/tmp/nonexistent-scoreboard-test-' + Date.now() + '.json']);
+  assert.strictEqual(exitCode, 1);
+  assert.ok(stderr.includes('no scoreboard'));
+});
+
+test('CAL-TC16: CLI writes calibrated-deltas.json with sufficient data', () => {
+  const sbPath = tmpPath();
+  const outPath = tmpPath();
+  try {
+    // Write scoreboard with 35 rounds
+    const sb = makeScoreboard(35, { vote: 'TP', verdict: 'APPROVE' });
+    fs.writeFileSync(sbPath, JSON.stringify(sb, null, 2));
+
+    const { exitCode, stdout } = runCLI(['--scoreboard', sbPath, '--output', outPath]);
+    assert.strictEqual(exitCode, 0);
+    assert.ok(fs.existsSync(outPath), 'output file must exist');
+
+    const output = JSON.parse(fs.readFileSync(outPath, 'utf8'));
+    assert.strictEqual(output.version, 1);
+    assert.ok(output.deltas, 'output must have deltas');
+    assert.ok(output.metadata, 'output must have metadata');
+    assert.strictEqual(typeof output.deltas.TP, 'number');
+    assert.strictEqual(output.deltas.UNAVAIL, 0);
+    assert.strictEqual(output.deltas[''], 0);
+  } finally {
+    cleanup(sbPath);
+    cleanup(outPath);
+  }
+});
+
+test('CAL-TC17: CLI writes default deltas when scoreboard has < 30 rounds', () => {
+  const sbPath = tmpPath();
+  const outPath = tmpPath();
+  try {
+    const sb = makeScoreboard(10, { vote: 'TP', verdict: 'APPROVE' });
+    fs.writeFileSync(sbPath, JSON.stringify(sb, null, 2));
+
+    const { exitCode, stdout } = runCLI(['--scoreboard', sbPath, '--output', outPath]);
+    assert.strictEqual(exitCode, 0);
+    assert.ok(stdout.includes('DEFAULT'), 'stdout must indicate fallback');
+
+    const output = JSON.parse(fs.readFileSync(outPath, 'utf8'));
+    assert.strictEqual(output.metadata.usedFallback, true);
+  } finally {
+    cleanup(sbPath);
+    cleanup(outPath);
+  }
+});
+
+test('CAL-TC18: output file contains all required keys', () => {
+  const sbPath = tmpPath();
+  const outPath = tmpPath();
+  try {
+    const sb = makeScoreboard(35, { vote: 'TP', verdict: 'APPROVE' });
+    fs.writeFileSync(sbPath, JSON.stringify(sb, null, 2));
+
+    runCLI(['--scoreboard', sbPath, '--output', outPath]);
+
+    const output = JSON.parse(fs.readFileSync(outPath, 'utf8'));
+    const required = ['TP', 'TN', 'FP', 'FN', 'TP+', 'TN+', 'UNAVAIL', ''];
+    for (const key of required) {
+      assert.strictEqual(typeof output.deltas[key], 'number', `deltas.${key} must be a number`);
+    }
+  } finally {
+    cleanup(sbPath);
+    cleanup(outPath);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Integration: update-scoreboard uses calibrated deltas
+// ---------------------------------------------------------------------------
+
+test('CAL-TC19: update-scoreboard exports loadScoreDeltas and DEFAULT_SCORE_DELTAS', () => {
+  const mod = require('./update-scoreboard.cjs');
+  assert.strictEqual(typeof mod.loadScoreDeltas, 'function');
+  assert.ok(mod.DEFAULT_SCORE_DELTAS);
+  assert.strictEqual(mod.DEFAULT_SCORE_DELTAS.TP, 1);
+});
+
+test('CAL-TC20: update-scoreboard uses calibrated deltas when config file exists', () => {
+  // Set up a temp project root with .planning/quorum/ structure
+  // loadScoreDeltas() resolves relative to CWD, so we spawn with cwd=calDir
+  const calOutput = {
+    version: 1,
+    deltas: { TP: 3, TN: 5, FP: -3, FN: -1, 'TP+': 5, 'TN+': 7, UNAVAIL: 0, '': 0 },
+    metadata: {},
+  };
+
+  const calDir = path.join(os.tmpdir(), 'nf-cal-int-' + Date.now());
+  const planningDir = path.join(calDir, '.planning', 'quorum');
+  fs.mkdirSync(planningDir, { recursive: true });
+  fs.writeFileSync(path.join(planningDir, 'calibrated-deltas.json'), JSON.stringify(calOutput, null, 2));
+
+  const sbFile = path.join(planningDir, 'scoreboard.json');
+  fs.writeFileSync(sbFile, JSON.stringify({ models: {}, slots: {}, rounds: [], categories: {} }));
+
+  try {
+    // Spawn with CWD = calDir so loadScoreDeltas() finds the config
+    const result = spawnSync('node', [
+      SB_SCRIPT,
+      '--model', 'claude',
+      '--result', 'TP',
+      '--task', 'cal-int-test',
+      '--round', '1',
+      '--verdict', 'APPROVE',
+      '--scoreboard', sbFile,
+    ], {
+      encoding: 'utf8',
+      timeout: 5000,
+      cwd: calDir,
+    });
+
+    assert.strictEqual(result.status, 0, `exit code 0, stderr: ${result.stderr}`);
+    // With calibrated TP=3, score should be 3 not 1
+    assert.ok(result.stdout.includes('score: 3'), `stdout should show score: 3, got: ${result.stdout}`);
+  } finally {
+    try { fs.rmSync(calDir, { recursive: true }); } catch (_) {}
+  }
+});

--- a/bin/calibrate-score-deltas.test.cjs
+++ b/bin/calibrate-score-deltas.test.cjs
@@ -233,6 +233,9 @@ test('CAL-TC14: deriveCalibratedDeltas clamps extreme values to [-10, +10]', () 
   const { deltas } = deriveCalibratedDeltas(rounds, DEFAULT_SCORE_DELTAS, { minRounds: 30, scaleFactor: 100 });
   assert.ok(deltas.TP >= -10, `TP delta must be >= -10, got ${deltas.TP}`);
   assert.ok(deltas.TP <= 10, `TP delta must be <= 10, got ${deltas.TP}`);
+  // Derived types also clamped
+  assert.ok(deltas['TP+'] >= -10, `TP+ delta must be >= -10, got ${deltas['TP+']}`);
+  assert.ok(deltas['TP+'] <= 10, `TP+ delta must be <= 10, got ${deltas['TP+']}`);
 });
 
 // ---------------------------------------------------------------------------

--- a/bin/planning-paths.cjs
+++ b/bin/planning-paths.cjs
@@ -51,6 +51,10 @@ const TYPES = {
     canonical: (root, p) => path.join(root, '.planning', 'quorum', 'debates', p.filename),
     legacy:    (root, p) => path.join(root, '.planning', 'debates', p.filename),
   },
+  'calibrated-deltas': {
+    canonical: (root) => path.join(root, '.planning', 'quorum', 'calibrated-deltas.json'),
+    legacy:    (root) => path.join(root, '.planning', 'calibrated-deltas.json'),
+  },
 
   // Telemetry
   'conformance-events': {

--- a/bin/update-scoreboard.cjs
+++ b/bin/update-scoreboard.cjs
@@ -31,7 +31,7 @@ const https = require('https');
 // Score delta lookup
 // ---------------------------------------------------------------------------
 
-const SCORE_DELTAS = {
+const DEFAULT_SCORE_DELTAS = {
   TP:      1,
   TN:      5,
   FP:     -3,
@@ -41,6 +41,31 @@ const SCORE_DELTAS = {
   UNAVAIL: 0,
   '':      0,
 };
+
+/**
+ * Load calibrated deltas from config file if available.
+ * Falls back to DEFAULT_SCORE_DELTAS if no config or invalid config.
+ */
+function loadScoreDeltas() {
+  try {
+    const pp = require('./planning-paths.cjs');
+    const configPath = pp.resolveWithFallback(process.cwd(), 'calibrated-deltas');
+    if (fs.existsSync(configPath)) {
+      const raw = fs.readFileSync(configPath, 'utf8');
+      const parsed = JSON.parse(raw);
+      if (parsed && parsed.deltas && typeof parsed.deltas === 'object') {
+        const required = ['TP', 'TN', 'FP', 'FN', 'TP+', 'TN+', 'UNAVAIL', ''];
+        const allPresent = required.every(k => typeof parsed.deltas[k] === 'number');
+        if (allPresent) {
+          return { deltas: parsed.deltas, source: 'calibrated' };
+        }
+      }
+    }
+  } catch (_) {
+    // Any error — fail-open to defaults
+  }
+  return { deltas: DEFAULT_SCORE_DELTAS, source: 'default' };
+}
 
 const VALID_MODELS   = ['claude', 'gemini', 'opencode', 'copilot', 'codex', 'deepseek', 'minimax', 'qwen-coder', 'kimi', 'llama4'];
 const VALID_RESULTS  = ['TP', 'TN', 'FP', 'FN', 'TP+', 'TN+', 'UNAVAIL', ''];
@@ -210,7 +235,8 @@ function loadData(scoreboard) {
 // Cumulative stats recompute (from-scratch to avoid drift)
 // ---------------------------------------------------------------------------
 
-function recomputeStats(data) {
+function recomputeStats(data, deltas) {
+  deltas = deltas || DEFAULT_SCORE_DELTAS;
   // Reset all model stats
   for (const model of VALID_MODELS) {
     if (!data.models[model]) data.models[model] = emptyModelStats();
@@ -233,7 +259,7 @@ function recomputeStats(data) {
       const m = data.models[model];
       m.invocations += 1;
 
-      const delta = SCORE_DELTAS[vote];
+      const delta = deltas[vote];
       if (delta === undefined) continue; // unknown vote code — skip
 
       m.score += delta;
@@ -255,7 +281,8 @@ function emptySlotStats(slot, modelId) {
   return { slot, model: modelId, score: 0, tp: 0, tn: 0, fp: 0, fn: 0, impr: 0, invocations: 0 };
 }
 
-function recomputeSlots(data) {
+function recomputeSlots(data, deltas) {
+  deltas = deltas || DEFAULT_SCORE_DELTAS;
   // Reset all slot stats in data.slots
   for (const key of Object.keys(data.slots)) {
     const s = data.slots[key];
@@ -270,7 +297,7 @@ function recomputeSlots(data) {
       if (!data.slots[key]) continue;  // key not in slots map — skip
       const s = data.slots[key];
       s.invocations += 1;
-      const delta = SCORE_DELTAS[vote];
+      const delta = deltas[vote];
       if (delta === undefined) continue;
       s.score += delta;
       if (vote === 'TP' || vote === 'TP+')  s.tp   += 1;
@@ -826,6 +853,7 @@ async function getAvailability(argv) {
 // ---------------------------------------------------------------------------
 
 async function mergeWave(argv) {
+  const { deltas: activeDeltas } = loadScoreDeltas();
   const args           = parseArgs(argv);
   const scoreboardPath = args.scoreboard || defaultScoreboardPath();
   const dir            = args.dir        || '.planning/scoreboard-tmp';
@@ -961,8 +989,8 @@ async function mergeWave(argv) {
   }
 
   // Recompute stats from scratch
-  recomputeStats(data);
-  recomputeSlots(data);
+  recomputeStats(data, activeDeltas);
+  recomputeSlots(data, activeDeltas);
   computeDeliveryStats(data);
   computeFlakiness(data);
 
@@ -989,6 +1017,7 @@ async function main() {
   if (rawArgs[0] === 'get-availability') return getAvailability(rawArgs.slice(1));
   if (rawArgs[0] === 'merge-wave')       return mergeWave(rawArgs.slice(1));
 
+  const { deltas: activeDeltas, source: deltaSource } = loadScoreDeltas();
   const parsed  = parseArgs(rawArgs);
   const cfg     = validate(parsed);
 
@@ -1019,7 +1048,7 @@ async function main() {
     data.rounds.push(roundEntry);
 
     // Recompute slot stats only (do NOT call recomputeStats — that is for --model path)
-    recomputeSlots(data);
+    recomputeSlots(data, activeDeltas);
 
     // Write back
     const absPath = path.resolve(process.cwd(), cfg.scoreboard);
@@ -1109,7 +1138,7 @@ async function main() {
   }
 
   // Recompute all cumulative stats from scratch
-  recomputeStats(data);
+  recomputeStats(data, activeDeltas);
 
   // Write back
   const absPath = path.resolve(process.cwd(), cfg.scoreboard);
@@ -1119,7 +1148,7 @@ async function main() {
   fs.renameSync(tmpPath3, absPath);
 
   // Print confirmation
-  const delta    = SCORE_DELTAS[cfg.result] || 0;
+  const delta    = activeDeltas[cfg.result] || 0;
   const sign     = delta >= 0 ? '+' : '';
   const newScore = data.models[cfg.model].score;
   const deltaStr = cfg.result === '' ? '(not scored)' : `${cfg.result} (${sign}${delta})`;
@@ -1132,7 +1161,7 @@ async function main() {
 
 // Guard pattern: only export when require()d by tests, not when run as a CLI script
 if (typeof module !== 'undefined') {
-  module.exports = { computeDeliveryStats, computeFlakiness, emptyData };
+  module.exports = { computeDeliveryStats, computeFlakiness, emptyData, loadScoreDeltas, DEFAULT_SCORE_DELTAS };
 }
 
 // Only run main() when invoked as a script, not when require()d by tests


### PR DESCRIPTION
## Summary

- Replaces hand-tuned `SCORE_DELTAS` constants with empirically calibrated weights derived from per-vote-type correlation with consensus outcomes
- New `bin/calibrate-score-deltas.cjs` CLI analyzes scoreboard rounds, computes signal-to-noise for each vote type (TP, TN, FP, FN), and writes scaled integer deltas to `calibrated-deltas.json`
- `update-scoreboard.cjs` loads calibrated deltas from config with fail-open fallback to `DEFAULT_SCORE_DELTAS`

Closes #175

## Test plan

- [x] 24 new tests in `bin/calibrate-score-deltas.test.cjs` — pure function unit tests + CLI integration tests
- [x] All 28 existing `update-scoreboard.test.cjs` tests pass (no regressions)
- [x] Full CI suite: 1550/1550 pass
- [x] `npm run lint:isolation` passes
- [ ] Manual: run `node bin/calibrate-score-deltas.cjs --scoreboard <path>` against a real scoreboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic calibration of score deltas derived from round outcomes, with fallback to defaults when insufficient historical data is available.
  * Score deltas can now be dynamically loaded from external configuration files at runtime instead of using hardcoded values.

* **Tests**
  * Added comprehensive test suite covering calibration logic and integration behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nForma-AI/nForma/pull/189?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->