### PR TITLE
feat(quorum): add min_live_voters floor for thin-consensus safety

### DIFF
--- a/.planning/formal/tla/MCStopHook.cfg
+++ b/.planning/formal/tla/MCStopHook.cfg
@@ -13,10 +13,12 @@
 SPECIFICATION Spec
 CONSTANTS
     MaxTurnLines = 500
+    MinLiveVoters = 2
 INVARIANT TypeOK
 INVARIANT SafetyInvariant1
 INVARIANT SafetyInvariant2
 INVARIANT SafetyInvariant3
+INVARIANT FloorSafety
 PROPERTY LivenessProperty1
 PROPERTY LivenessProperty2
 PROPERTY LivenessProperty3

--- a/.planning/formal/tla/NFQuorum_xstate.tla
+++ b/.planning/formal/tla/NFQuorum_xstate.tla
@@ -25,9 +25,10 @@ VARIABLES
     deliberationRounds,  \* default: 0  annotation: deliberationRounds + 1
     maxDeliberation,  \* default: 9  annotation: const
     maxSize,  \* default: 3  annotation: (no annotation)
+    minLiveVoters,  \* default: 2  annotation: floor for valid consensus (issue #170)
     polledCount  \* default: 0  annotation: (no annotation)
 
-vars == <<state, slotsAvailable, successCount, deliberationRounds, maxDeliberation, maxSize, polledCount>>
+vars == <<state, slotsAvailable, successCount, deliberationRounds, maxDeliberation, maxSize, minLiveVoters, polledCount>>
 
 \* ── Type invariant ────────────────────────────────────────────────────────────
 \* @requirement QUORUM-01
@@ -38,6 +39,7 @@ TypeOK ==
     /\ deliberationRounds \in Nat  \* FIXME: tighten bound if needed
     /\ maxDeliberation \in Nat  \* FIXME: tighten bound if needed
     /\ maxSize \in Nat  \* FIXME: tighten bound if needed
+    /\ minLiveVoters \in Nat
     /\ polledCount \in Nat  \* FIXME: tighten bound if needed
 
 \* ── Initial state ─────────────────────────────────────────────────────────────
@@ -48,6 +50,7 @@ Init ==
     /\ deliberationRounds = 0
     /\ maxDeliberation = 9
     /\ maxSize = 3
+    /\ minLiveVoters = 2
     /\ polledCount = 0
 
 \* ── Actions ────────────────────────────────────────────────────────────────────
@@ -58,33 +61,34 @@ IdleQuorumStart(a) ==
     /\ state' = "COLLECTING_VOTES"
     /\ slotsAvailable' = a  \* param from event
     /\ polledCount' = polledCount  \* FIXME: XState assign for polledCount
-    /\ UNCHANGED <<successCount, deliberationRounds, maxDeliberation, maxSize>>
+    /\ UNCHANGED <<successCount, deliberationRounds, maxDeliberation, maxSize, minLiveVoters>>
 
 \* IDLE -[CIRCUIT_BREAK]-> IDLE
 IdleCircuitBreak ==
     /\ state = "IDLE"
     /\ state' = "IDLE"
-    /\ UNCHANGED <<slotsAvailable, successCount, deliberationRounds, maxDeliberation, maxSize, polledCount>>
+    /\ UNCHANGED <<slotsAvailable, successCount, deliberationRounds, maxDeliberation, maxSize, minLiveVoters, polledCount>>
 
 \* IDLE -[DECIDE]-> IDLE
 IdleDecide ==
     /\ state = "IDLE"
     /\ state' = "IDLE"
-    /\ UNCHANGED <<slotsAvailable, successCount, deliberationRounds, maxDeliberation, maxSize, polledCount>>
+    /\ UNCHANGED <<slotsAvailable, successCount, deliberationRounds, maxDeliberation, maxSize, minLiveVoters, polledCount>>
 
 \* IDLE -[VOTES_COLLECTED]-> IDLE
 IdleVotesCollected ==
     /\ state = "IDLE"
     /\ state' = "IDLE"
-    /\ UNCHANGED <<slotsAvailable, successCount, deliberationRounds, maxDeliberation, maxSize, polledCount>>
+    /\ UNCHANGED <<slotsAvailable, successCount, deliberationRounds, maxDeliberation, maxSize, minLiveVoters, polledCount>>
 
-\* COLLECTING_VOTES -[VOTES_COLLECTED / unanimityMet]-> DECIDED
+\* COLLECTING_VOTES -[VOTES_COLLECTED / unanimityMet AND floorMet]-> DECIDED
 CollectingVotesVotesCollectedToDECIDED(c) ==
     /\ state = "COLLECTING_VOTES"
     /\ c = polledCount
+    /\ c >= minLiveVoters
     /\ state' = "DECIDED"
     /\ successCount' = c  \* param from event
-    /\ UNCHANGED <<slotsAvailable, deliberationRounds, maxDeliberation, maxSize, polledCount>>
+    /\ UNCHANGED <<slotsAvailable, deliberationRounds, maxDeliberation, maxSize, minLiveVoters, polledCount>>
 
 \* COLLECTING_VOTES -[VOTES_COLLECTED]-> DELIBERATING
 CollectingVotesVotesCollectedToDELIBERATING(c) ==
@@ -92,33 +96,34 @@ CollectingVotesVotesCollectedToDELIBERATING(c) ==
     /\ state' = "DELIBERATING"
     /\ successCount' = c  \* param from event
     /\ deliberationRounds' = deliberationRounds + 1
-    /\ UNCHANGED <<slotsAvailable, maxDeliberation, maxSize, polledCount>>
+    /\ UNCHANGED <<slotsAvailable, maxDeliberation, maxSize, minLiveVoters, polledCount>>
 
 \* COLLECTING_VOTES -[QUORUM_START]-> COLLECTING_VOTES
 CollectingVotesQuorumStart ==
     /\ state = "COLLECTING_VOTES"
     /\ state' = "COLLECTING_VOTES"
-    /\ UNCHANGED <<slotsAvailable, successCount, deliberationRounds, maxDeliberation, maxSize, polledCount>>
+    /\ UNCHANGED <<slotsAvailable, successCount, deliberationRounds, maxDeliberation, maxSize, minLiveVoters, polledCount>>
 
 \* COLLECTING_VOTES -[CIRCUIT_BREAK]-> COLLECTING_VOTES
 CollectingVotesCircuitBreak ==
     /\ state = "COLLECTING_VOTES"
     /\ state' = "COLLECTING_VOTES"
-    /\ UNCHANGED <<slotsAvailable, successCount, deliberationRounds, maxDeliberation, maxSize, polledCount>>
+    /\ UNCHANGED <<slotsAvailable, successCount, deliberationRounds, maxDeliberation, maxSize, minLiveVoters, polledCount>>
 
 \* COLLECTING_VOTES -[DECIDE]-> COLLECTING_VOTES
 CollectingVotesDecide ==
     /\ state = "COLLECTING_VOTES"
     /\ state' = "COLLECTING_VOTES"
-    /\ UNCHANGED <<slotsAvailable, successCount, deliberationRounds, maxDeliberation, maxSize, polledCount>>
+    /\ UNCHANGED <<slotsAvailable, successCount, deliberationRounds, maxDeliberation, maxSize, minLiveVoters, polledCount>>
 
-\* DELIBERATING -[VOTES_COLLECTED / unanimityMet]-> DECIDED
+\* DELIBERATING -[VOTES_COLLECTED / unanimityMet AND floorMet]-> DECIDED
 DeliberatingVotesCollectedToDECIDED(c) ==
     /\ state = "DELIBERATING"
     /\ c = polledCount
+    /\ c >= minLiveVoters
     /\ state' = "DECIDED"
     /\ successCount' = c  \* param from event
-    /\ UNCHANGED <<slotsAvailable, deliberationRounds, maxDeliberation, maxSize, polledCount>>
+    /\ UNCHANGED <<slotsAvailable, deliberationRounds, maxDeliberation, maxSize, minLiveVoters, polledCount>>
 
 \* DELIBERATING -[VOTES_COLLECTED / noInfiniteDeliberation]-> DELIBERATING
 DeliberatingVotesCollectedToDELIBERATING ==
@@ -126,61 +131,63 @@ DeliberatingVotesCollectedToDELIBERATING ==
     /\ deliberationRounds < maxDeliberation
     /\ state' = "DELIBERATING"
     /\ deliberationRounds' = deliberationRounds + 1
-    /\ UNCHANGED <<slotsAvailable, successCount, maxDeliberation, maxSize, polledCount>>
+    /\ UNCHANGED <<slotsAvailable, successCount, maxDeliberation, maxSize, minLiveVoters, polledCount>>
 
-\* DELIBERATING -[VOTES_COLLECTED]-> DECIDED
+\* DELIBERATING -[VOTES_COLLECTED / floorMet]-> DECIDED (max rounds exhausted, but floor still met)
 DeliberatingVotesCollectedFallbackToDECIDED ==
     /\ state = "DELIBERATING"
+    /\ successCount >= minLiveVoters
     /\ state' = "DECIDED"
-    /\ UNCHANGED <<slotsAvailable, successCount, deliberationRounds, maxDeliberation, maxSize, polledCount>>
+    /\ UNCHANGED <<slotsAvailable, successCount, deliberationRounds, maxDeliberation, maxSize, minLiveVoters, polledCount>>
 
-\* DELIBERATING -[DECIDE]-> DECIDED
+\* DELIBERATING -[DECIDE / floorMet]-> DECIDED
 DeliberatingDecide ==
     /\ state = "DELIBERATING"
+    /\ successCount >= minLiveVoters
     /\ state' = "DECIDED"
-    /\ UNCHANGED <<slotsAvailable, successCount, deliberationRounds, maxDeliberation, maxSize, polledCount>>
+    /\ UNCHANGED <<slotsAvailable, successCount, deliberationRounds, maxDeliberation, maxSize, minLiveVoters, polledCount>>
 
 \* DELIBERATING -[QUORUM_START]-> DELIBERATING
 DeliberatingQuorumStart ==
     /\ state = "DELIBERATING"
     /\ state' = "DELIBERATING"
-    /\ UNCHANGED <<slotsAvailable, successCount, deliberationRounds, maxDeliberation, maxSize, polledCount>>
+    /\ UNCHANGED <<slotsAvailable, successCount, deliberationRounds, maxDeliberation, maxSize, minLiveVoters, polledCount>>
 
 \* DELIBERATING -[CIRCUIT_BREAK]-> DELIBERATING
 DeliberatingCircuitBreak ==
     /\ state = "DELIBERATING"
     /\ state' = "DELIBERATING"
-    /\ UNCHANGED <<slotsAvailable, successCount, deliberationRounds, maxDeliberation, maxSize, polledCount>>
+    /\ UNCHANGED <<slotsAvailable, successCount, deliberationRounds, maxDeliberation, maxSize, minLiveVoters, polledCount>>
 
 \* DECIDED -[DECIDE]-> DECIDED (self-loop in final state)
 DecidedDecide ==
     /\ state = "DECIDED"
     /\ state' = "DECIDED"
-    /\ UNCHANGED <<slotsAvailable, successCount, deliberationRounds, maxDeliberation, maxSize, polledCount>>
+    /\ UNCHANGED <<slotsAvailable, successCount, deliberationRounds, maxDeliberation, maxSize, minLiveVoters, polledCount>>
 
 \* DECIDED -[CIRCUIT_BREAK]-> DECIDED (self-loop in final state)
 DecidedCircuitBreak ==
     /\ state = "DECIDED"
     /\ state' = "DECIDED"
-    /\ UNCHANGED <<slotsAvailable, successCount, deliberationRounds, maxDeliberation, maxSize, polledCount>>
+    /\ UNCHANGED <<slotsAvailable, successCount, deliberationRounds, maxDeliberation, maxSize, minLiveVoters, polledCount>>
 
 \* DECIDED -[QUORUM_START]-> DECIDED (self-loop in final state)
 DecidedQuorumStart ==
     /\ state = "DECIDED"
     /\ state' = "DECIDED"
-    /\ UNCHANGED <<slotsAvailable, successCount, deliberationRounds, maxDeliberation, maxSize, polledCount>>
+    /\ UNCHANGED <<slotsAvailable, successCount, deliberationRounds, maxDeliberation, maxSize, minLiveVoters, polledCount>>
 
 \* DECIDED -[VOTES_COLLECTED]-> DECIDED (self-loop in final state)
 DecidedVotesCollected ==
     /\ state = "DECIDED"
     /\ state' = "DECIDED"
-    /\ UNCHANGED <<slotsAvailable, successCount, deliberationRounds, maxDeliberation, maxSize, polledCount>>
+    /\ UNCHANGED <<slotsAvailable, successCount, deliberationRounds, maxDeliberation, maxSize, minLiveVoters, polledCount>>
 
 \* DECIDED is a final (absorbing) state
 StayDECIDED ==
     /\ state = "DECIDED"
     /\ state' = "DECIDED"
-    /\ UNCHANGED <<slotsAvailable, successCount, deliberationRounds, maxDeliberation, maxSize, polledCount>>
+    /\ UNCHANGED <<slotsAvailable, successCount, deliberationRounds, maxDeliberation, maxSize, minLiveVoters, polledCount>>
 
 \* ── Next ──────────────────────────────────────────────────────────────────────
 Next ==
@@ -210,5 +217,11 @@ Spec == Init /\ [][Next]_vars
 
 \* ── Invariants (add domain-specific properties here) ──────────────────────────
 \* TypeOK is the structural baseline. Add semantic invariants below.
+
+\* @requirement QUORUM-170
+\* FloorSafety: reaching DECIDED requires successCount >= minLiveVoters.
+\* Prevents thin consensus where a single surviving voter declares unanimity.
+FloorSafety ==
+    state = "DECIDED" => successCount >= minLiveVoters
 
 ====

--- a/.planning/formal/tla/NFStopHook.tla
+++ b/.planning/formal/tla/NFStopHook.tla
@@ -27,15 +27,17 @@
 EXTENDS Naturals, FiniteSets, TLC
 
 CONSTANTS
-  MaxTurnLines   \* Maximum transcript lines considered (model: 500)
+  MaxTurnLines,  \* Maximum transcript lines considered (model: 500)
+  MinLiveVoters  \* Minimum live voters for valid consensus (issue #170, default: 2)
 
 VARIABLES
   hasCommand,        \* TRUE if a planning command (e.g. /qgsd:plan-phase) was found in current turn
   hasQuorumEvidence, \* TRUE if quorum evidence (slot-worker calls or successful MCP responses) present
+  liveVoterCount,    \* Number of live (non-UNAVAIL) voters detected
   decision,          \* "UNDECIDED" | "BLOCK" | "PASS"
   algorithmDone      \* TRUE when MakeDecision has fired
 
-vars == <<hasCommand, hasQuorumEvidence, decision, algorithmDone>>
+vars == <<hasCommand, hasQuorumEvidence, liveVoterCount, decision, algorithmDone>>
 
 (*
  * TypeOK — type invariant for all variables.
@@ -44,6 +46,7 @@ vars == <<hasCommand, hasQuorumEvidence, decision, algorithmDone>>
 TypeOK ==
   /\ hasCommand        \in BOOLEAN
   /\ hasQuorumEvidence \in BOOLEAN
+  /\ liveVoterCount    \in Nat
   /\ decision          \in {"UNDECIDED", "BLOCK", "PASS"}
   /\ algorithmDone     \in BOOLEAN
 
@@ -54,6 +57,7 @@ TypeOK ==
 Init ==
   /\ hasCommand        = FALSE
   /\ hasQuorumEvidence = FALSE
+  /\ liveVoterCount    = 0
   /\ decision          = "UNDECIDED"
   /\ algorithmDone     = FALSE
 
@@ -68,7 +72,7 @@ DetectCommand ==
   /\ ~algorithmDone
   /\ hasCommand = FALSE
   /\ hasCommand' \in BOOLEAN
-  /\ UNCHANGED <<hasQuorumEvidence, decision, algorithmDone>>
+  /\ UNCHANGED <<hasQuorumEvidence, liveVoterCount, decision, algorithmDone>>
 
 (*
  * DetectQuorumEvidence — nondeterministic: the hook either finds or does not find
@@ -81,7 +85,17 @@ DetectQuorumEvidence ==
   /\ ~algorithmDone
   /\ hasQuorumEvidence = FALSE
   /\ hasQuorumEvidence' \in BOOLEAN
-  /\ UNCHANGED <<hasCommand, decision, algorithmDone>>
+  /\ UNCHANGED <<hasCommand, liveVoterCount, decision, algorithmDone>>
+
+(*
+ * DetectLiveVoters — nondeterministic: the hook detects N live (non-UNAVAIL) voters.
+ * Models: countLiveSlotWorkers() or successCount from MCP call counting.
+ *)
+DetectLiveVoters ==
+  /\ ~algorithmDone
+  /\ liveVoterCount = 0
+  /\ liveVoterCount' \in 0..MaxTurnLines
+  /\ UNCHANGED <<hasCommand, hasQuorumEvidence, decision, algorithmDone>>
 
 (*
  * MakeDecision — applies the Stop hook gate logic once detection is complete.
@@ -98,10 +112,10 @@ MakeDecision ==
   /\ decision = "UNDECIDED"
   /\ decision' =
        IF ~hasCommand THEN "PASS"
-       ELSE IF hasCommand /\ hasQuorumEvidence THEN "PASS"
+       ELSE IF hasCommand /\ hasQuorumEvidence /\ liveVoterCount >= MinLiveVoters THEN "PASS"
        ELSE "BLOCK"
   /\ algorithmDone' = TRUE
-  /\ UNCHANGED <<hasCommand, hasQuorumEvidence>>
+  /\ UNCHANGED <<hasCommand, hasQuorumEvidence, liveVoterCount>>
 
 (*
  * Next — step relation: detection steps or the decision step.
@@ -110,6 +124,7 @@ MakeDecision ==
 Next ==
   \/ DetectCommand
   \/ DetectQuorumEvidence
+  \/ DetectLiveVoters
   \/ MakeDecision
   \/ (algorithmDone /\ UNCHANGED vars)  \* Stuttering in terminal state
 
@@ -127,6 +142,7 @@ Spec ==
   /\ WF_vars(MakeDecision)
   /\ WF_vars(DetectCommand)
   /\ WF_vars(DetectQuorumEvidence)
+  /\ WF_vars(DetectLiveVoters)
 
 \* ── Safety Invariants ──────────────────────────────────────────────────────
 
@@ -140,20 +156,29 @@ SafetyInvariant1 ==
   decision = "BLOCK" => hasCommand
 
 (*
- * SafetyInvariant2: BLOCK can only be decided if quorum evidence is absent.
- * Prevents blocking a turn that already satisfied the quorum requirement.
+ * SafetyInvariant2: BLOCK can only be decided if quorum evidence is absent
+ * OR live voters are below the floor. Allows floor-block even with evidence.
  *)
 \* @requirement STOP-03
 SafetyInvariant2 ==
-  decision = "BLOCK" => ~hasQuorumEvidence
+  decision = "BLOCK" => ~hasQuorumEvidence \/ liveVoterCount < MinLiveVoters
 
 (*
- * SafetyInvariant3: PASS can only be decided on a planning turn if quorum evidence is present.
+ * SafetyInvariant3: PASS can only be decided on a planning turn if quorum evidence is present
+ * AND live voter count meets the floor.
  * (When hasCommand=FALSE, PASS is trivially correct — not a planning turn.)
  *)
 \* @requirement STOP-04
 SafetyInvariant3 ==
   (decision = "PASS" /\ hasCommand) => hasQuorumEvidence
+
+(*
+ * FloorSafety: PASS on a planning turn requires live voters >= MinLiveVoters.
+ * Prevents thin consensus where a single surviving voter declares unanimity.
+ *)
+\* @requirement QUORUM-170
+FloorSafety ==
+  (decision = "PASS" /\ hasCommand) => liveVoterCount >= MinLiveVoters
 
 \* ── Liveness Properties ────────────────────────────────────────────────────
 
@@ -165,17 +190,18 @@ SafetyInvariant3 ==
 LivenessProperty1 == <>algorithmDone
 
 (*
- * LivenessProperty2: If quorum evidence is present, the decision eventually reaches PASS.
- * Ensures the hook doesn't block when quorum is satisfied.
+ * LivenessProperty2: If quorum evidence is present AND live voters meet the floor,
+ * the decision eventually reaches PASS.
+ * Ensures the hook doesn't block when quorum is satisfied with adequate voters.
  *)
 \* @requirement STOP-06
-LivenessProperty2 == hasQuorumEvidence => <>(decision = "PASS")
+LivenessProperty2 == (hasQuorumEvidence /\ liveVoterCount >= MinLiveVoters) => <>(decision = "PASS")
 
 (*
- * LivenessProperty3: If a command is detected with no quorum evidence, the decision
- * eventually reaches BLOCK. Ensures the hook always enforces quorum.
+ * LivenessProperty3: If a command is detected with no quorum evidence OR below-floor
+ * live voters, the decision eventually reaches BLOCK.
  *)
 \* @requirement STOP-07
-LivenessProperty3 == (hasCommand /\ ~hasQuorumEvidence) => <>(decision = "BLOCK")
+LivenessProperty3 == (hasCommand /\ (~hasQuorumEvidence \/ liveVoterCount < MinLiveVoters)) => <>(decision = "BLOCK")
 
 ====

--- a/.planning/formal/tla/NFStopHook.tla
+++ b/.planning/formal/tla/NFStopHook.tla
@@ -164,8 +164,8 @@ SafetyInvariant2 ==
   decision = "BLOCK" => ~hasQuorumEvidence \/ liveVoterCount < MinLiveVoters
 
 (*
- * SafetyInvariant3: PASS can only be decided on a planning turn if quorum evidence is present
- * AND live voter count meets the floor.
+ * SafetyInvariant3: PASS can only be decided on a planning turn if quorum evidence is present.
+ * The live-voter floor is enforced separately by the FloorSafety invariant (below).
  * (When hasCommand=FALSE, PASS is trivially correct — not a planning turn.)
  *)
 \* @requirement STOP-04

--- a/.planning/formal/tla/guards/nf-workflow.json
+++ b/.planning/formal/tla/guards/nf-workflow.json
@@ -2,6 +2,8 @@
   "guards": {
     "minQuorumMet":            "successCount * 2 >= N",
     "unanimityMet":            "successCount = polledCount",
+    "floorMet":                "successCount >= minLiveVoters",
+    "unanimityAndFloorMet":    "successCount = polledCount /\\ successCount >= minLiveVoters",
     "noInfiniteDeliberation":  "deliberationRounds < maxDeliberation",
     "phaseMonotonicallyAdvances": "TRUE"
   },

--- a/commands/nf/quorum.md
+++ b/commands/nf/quorum.md
@@ -60,7 +60,15 @@ These three rules govern ALL consensus determination in both Mode A and Mode B. 
 - Consensus means 100% of valid (non-UNAVAIL) external voters agree on the same verdict.
 - There is NO majority-based approval. 2-out-of-3 APPROVE with 1 BLOCK is NOT consensus — it is a disagreement requiring deliberation.
 - UNAVAIL voters are excluded from the denominator (they are not valid voters for this round).
-- If only 1 external voter is valid and they APPROVE, that is consensus (1/1 = 100%).
+- If only 1 external voter is valid and they APPROVE, that is consensus (1/1 = 100%) — provided `min_live_voters` is satisfied (see CE-4).
+
+**RULE CE-4: Minimum Live Voters Floor**
+- After tier fallback, if the number of live (non-UNAVAIL) external voters is below `min_live_voters` (default: 2), consensus MUST NOT be declared — even if all remaining voters agree.
+- `min_live_voters` is read from `quorum.min_live_voters` in config (default: 2). The floor prevents thin consensus where a single surviving voter satisfies unanimity after mass UNAVAIL.
+- The orchestrator must either:
+  1. Re-dispatch with extended timeouts to recover UNAVAIL slots, OR
+  2. Surface the degraded-roster state to the user for an explicit waiver via `--force-quorum`
+- Below-floor consensus is BLOCKED by `nf-stop.js` with a clear error — it does not silently pass.
 
 ---
 

--- a/hooks/config-loader.js
+++ b/hooks/config-loader.js
@@ -135,6 +135,7 @@ const DEFAULT_CONFIG = {
   quorum: {
     maxSize: 4,
     preferSub: false,
+    min_live_voters: 2,  // minimum live voters for valid consensus (issue #170)
   },
   // agent_config: per-slot metadata.
   //   auth_type: "sub" (subscription, flat-fee) | "api" (pay-per-token)

--- a/hooks/dist/config-loader.js
+++ b/hooks/dist/config-loader.js
@@ -135,6 +135,7 @@ const DEFAULT_CONFIG = {
   quorum: {
     maxSize: 4,
     preferSub: false,
+    min_live_voters: 2,  // minimum live voters for valid consensus (issue #170)
   },
   // agent_config: per-slot metadata.
   //   auth_type: "sub" (subscription, flat-fee) | "api" (pay-per-token)

--- a/hooks/dist/nf-stop.js
+++ b/hooks/dist/nf-stop.js
@@ -664,6 +664,82 @@ function detectUnavailWithoutFallback(currentTurnLines, cwd) {
   return { violated: false };
 }
 
+// Counts the number of live slot-worker voters in the current turn. Walks assistant
+// messages for Task(nf-quorum-slot-worker) dispatches, then inspects the matching
+// tool_result blocks. A result counts as a live voter only if it carries an explicit
+// APPROVE or BLOCK verdict — UNAVAIL, FLAG_TRUNCATED, error, and empty results are
+// non-votes and excluded. Returns the count of valid votes in the last dispatch round.
+function countLiveSlotWorkers(currentTurnLines) {
+  // Track dispatch rounds (groups of parallel slot-worker Tasks per assistant message)
+  const roundIds = [];       // Array of Sets, one per dispatch round
+  const taskResults = new Map(); // tool_use_id → result text
+
+  let currentRoundIds = null;
+
+  for (const line of currentTurnLines) {
+    try {
+      const entry = JSON.parse(line);
+
+      if (entry.type === 'assistant') {
+        const content = entry.message && entry.message.content;
+        if (!Array.isArray(content)) continue;
+        let hasSlotWorker = false;
+        for (const block of content) {
+          if (block.type === 'tool_use' && block.name === 'Task') {
+            const inputStr = JSON.stringify(block.input || {});
+            if (inputStr.includes('nf-quorum-slot-worker') && block.id) {
+              if (!currentRoundIds) currentRoundIds = new Set();
+              currentRoundIds.add(block.id);
+              hasSlotWorker = true;
+            }
+          }
+        }
+        // End of assistant message — if it had slot-workers, close the round
+        if (hasSlotWorker && currentRoundIds) {
+          roundIds.push(currentRoundIds);
+          currentRoundIds = null;
+        }
+      }
+
+      // Collect tool_result text keyed by tool_use_id
+      if (entry.type === 'user') {
+        const content = entry.message && entry.message.content;
+        if (!Array.isArray(content)) continue;
+        for (const block of content) {
+          if (block.type === 'tool_result' && block.tool_use_id) {
+            const resultText = Array.isArray(block.content)
+              ? block.content.map(c => c.text || '').join('')
+              : (typeof block.content === 'string' ? block.content : '');
+            taskResults.set(block.tool_use_id, resultText);
+          }
+        }
+      }
+    } catch { /* skip malformed */ }
+  }
+
+  // Only count live voters from the LAST dispatch round (the consensus round)
+  if (roundIds.length === 0) return 0;
+  const lastRound = roundIds[roundIds.length - 1];
+
+  let liveCount = 0;
+  for (const id of lastRound) {
+    const result = taskResults.get(id) || '';
+    // A live voter carries an explicit APPROVE/BLOCK verdict. Matching the verdict
+    // positively (rather than excluding UNAVAIL/FLAG_TRUNCATED) avoids counting error
+    // results as votes, and avoids dropping a valid vote whose reasoning text merely
+    // mentions the word "UNAVAIL". Fails safe: an unrecognized result is not a vote.
+    if (/verdict:\s*(?:APPROVE|BLOCK)\b/i.test(result)) liveCount++;
+  }
+  return liveCount;
+}
+
+// Extracts min_live_voters from config with safe default.
+function getMinLiveVoters(config) {
+  return (config.quorum && Number.isInteger(config.quorum.min_live_voters) && config.quorum.min_live_voters >= 1)
+    ? config.quorum.min_live_voters
+    : 2;
+}
+
 // The exact token Claude must include in its final output to mark a decision turn.
 // Used by hasDecisionMarker (Stop hook) and injected into Claude's context (Prompt hook).
 const DECISION_MARKER = '<!-- NF_DECISION -->';
@@ -843,6 +919,7 @@ function main() {
       // Extract --n N flag from current-turn user prompt (if present)
       const promptText = extractPromptText(currentTurnLines);
       const quorumSizeOverride = parseQuorumSizeFlag(promptText);
+      const hasForceQuorum = /\b--force-quorum\b/.test(promptText);
       const soloMode = quorumSizeOverride === 1;
 
       // GUARD 6: Solo mode (--n 1) — Claude-only quorum, no external models required
@@ -903,6 +980,28 @@ function main() {
           }));
           process.exit(0);
         }
+
+        // MIN_LIVE_VOTERS floor (issue #170)
+        const minLiveVoters = getMinLiveVoters(config);
+        const liveSlotWorkers = countLiveSlotWorkers(currentTurnLines);
+        if (liveSlotWorkers < minLiveVoters && !hasForceQuorum) {
+          appendConformanceEvent({
+            ts:              new Date().toISOString(),
+            phase:           'DECIDING',
+            action:          'floor_block',
+            live_voters:     liveSlotWorkers,
+            min_live_voters: minLiveVoters,
+            outcome:         'BLOCK',
+            schema_version,
+          });
+          process.stdout.write(JSON.stringify({
+            decision: 'block',
+            reason: 'QUORUM FLOOR NOT MET: Only ' + liveSlotWorkers + ' live voter(s) (min_live_voters = ' + minLiveVoters + '). ' +
+              'Too many slots are UNAVAIL for reliable consensus. Re-dispatch with extended timeouts, or re-run with --force-quorum to waive.'
+          }));
+          process.exit(0);
+        }
+
         process.exit(0);
       }
 
@@ -938,6 +1037,26 @@ function main() {
           }
           missingAgents.push(toolName);
         }
+      }
+
+      // MIN_LIVE_VOTERS floor — checked when ceiling is met but live voters are too few
+      const minLiveVoters = getMinLiveVoters(config);
+      if (successCount >= maxSize && successCount < minLiveVoters && !hasForceQuorum) {
+        appendConformanceEvent({
+          ts:              new Date().toISOString(),
+          phase:           'DECIDING',
+          action:          'floor_block',
+          live_voters:     successCount,
+          min_live_voters: minLiveVoters,
+          outcome:         'BLOCK',
+          schema_version,
+        });
+        process.stdout.write(JSON.stringify({
+          decision: 'block',
+          reason: 'QUORUM FLOOR NOT MET: ' + successCount + ' live voter(s) (min_live_voters = ' + minLiveVoters + '). ' +
+            'Too few live voters for reliable consensus. Re-run with --force-quorum to waive.'
+        }));
+        process.exit(0);
       }
 
       if (successCount < maxSize) {

--- a/hooks/dist/nf-stop.js
+++ b/hooks/dist/nf-stop.js
@@ -158,6 +158,39 @@ function extractCommandTag(entry) {
   return m ? m[1].trim() : null;
 }
 
+// Extracts the value of the <command-args> XML tag injected by Claude Code for real slash
+// command invocations. Slash-command flags (e.g. --force-quorum, --n N) land here — NOT in
+// <command-name>. Returns the trimmed args content, or null if the tag is absent.
+function extractCommandArgs(entry) {
+  let text = '';
+  const content = entry.message?.content;
+  if (typeof content === 'string') {
+    text = content;
+  } else if (Array.isArray(content)) {
+    const first = content.find(c => c?.type === 'text');
+    text = first ? (first.text || '') : '';
+  }
+  const m = text.match(/<command-args>([\s\S]*?)<\/command-args>/);
+  return m ? m[1].trim() : null;
+}
+
+// Detects the --force-quorum waiver flag. Checks the extracted prompt text AND every
+// <command-args> tag in the turn — for a tagged slash command, extractPromptText returns
+// only the command name, so flags live in <command-args>. Scoped to user command args
+// (never hook-injected text) so a prior block reason mentioning the flag cannot self-waive.
+function hasForceQuorumFlag(currentTurnLines, promptText) {
+  if (/\b--force-quorum\b/.test(promptText)) return true;
+  for (const line of currentTurnLines) {
+    try {
+      const entry = JSON.parse(line);
+      if (entry.type !== 'user') continue;
+      const args = extractCommandArgs(entry);
+      if (args !== null && /\b--force-quorum\b/.test(args)) return true;
+    } catch { /* skip malformed lines */ }
+  }
+  return false;
+}
+
 // Returns true if any user entry in currentTurnLines contains an NF quorum command.
 // Uses XML-tag-first strategy: if a <command-name> tag is present, only that tag is tested
 // against cmdPattern (never the full body). Falls back to first 300 chars of message text
@@ -685,9 +718,13 @@ function countLiveSlotWorkers(currentTurnLines) {
         if (!Array.isArray(content)) continue;
         let hasSlotWorker = false;
         for (const block of content) {
-          if (block.type === 'tool_use' && block.name === 'Task') {
-            const inputStr = JSON.stringify(block.input || {});
-            if (inputStr.includes('nf-quorum-slot-worker') && block.id) {
+          if (block.type === 'tool_use' && block.name === 'Task' && block.id) {
+            // Match the structured subagent_type field — consistent with
+            // wasSlotWorkerUsed / detectUnavailWithoutFallback, and avoids matching
+            // the string in an unrelated Task's prompt/description.
+            const input = block.input || {};
+            const subagentType = input.subagent_type || input.subagentType || '';
+            if (subagentType === 'nf-quorum-slot-worker') {
               if (!currentRoundIds) currentRoundIds = new Set();
               currentRoundIds.add(block.id);
               hasSlotWorker = true;
@@ -707,6 +744,9 @@ function countLiveSlotWorkers(currentTurnLines) {
         if (!Array.isArray(content)) continue;
         for (const block of content) {
           if (block.type === 'tool_result' && block.tool_use_id) {
+            // Errored tool results are non-votes — leave them unrecorded so they
+            // are not counted toward the live-voter total.
+            if (block.is_error === true) continue;
             const resultText = Array.isArray(block.content)
               ? block.content.map(c => c.text || '').join('')
               : (typeof block.content === 'string' ? block.content : '');
@@ -919,7 +959,7 @@ function main() {
       // Extract --n N flag from current-turn user prompt (if present)
       const promptText = extractPromptText(currentTurnLines);
       const quorumSizeOverride = parseQuorumSizeFlag(promptText);
-      const hasForceQuorum = /\b--force-quorum\b/.test(promptText);
+      const hasForceQuorum = hasForceQuorumFlag(currentTurnLines, promptText);
       const soloMode = quorumSizeOverride === 1;
 
       // GUARD 6: Solo mode (--n 1) — Claude-only quorum, no external models required

--- a/hooks/nf-stop.js
+++ b/hooks/nf-stop.js
@@ -664,6 +664,82 @@ function detectUnavailWithoutFallback(currentTurnLines, cwd) {
   return { violated: false };
 }
 
+// Counts the number of live slot-worker voters in the current turn. Walks assistant
+// messages for Task(nf-quorum-slot-worker) dispatches, then inspects the matching
+// tool_result blocks. A result counts as a live voter only if it carries an explicit
+// APPROVE or BLOCK verdict — UNAVAIL, FLAG_TRUNCATED, error, and empty results are
+// non-votes and excluded. Returns the count of valid votes in the last dispatch round.
+function countLiveSlotWorkers(currentTurnLines) {
+  // Track dispatch rounds (groups of parallel slot-worker Tasks per assistant message)
+  const roundIds = [];       // Array of Sets, one per dispatch round
+  const taskResults = new Map(); // tool_use_id → result text
+
+  let currentRoundIds = null;
+
+  for (const line of currentTurnLines) {
+    try {
+      const entry = JSON.parse(line);
+
+      if (entry.type === 'assistant') {
+        const content = entry.message && entry.message.content;
+        if (!Array.isArray(content)) continue;
+        let hasSlotWorker = false;
+        for (const block of content) {
+          if (block.type === 'tool_use' && block.name === 'Task') {
+            const inputStr = JSON.stringify(block.input || {});
+            if (inputStr.includes('nf-quorum-slot-worker') && block.id) {
+              if (!currentRoundIds) currentRoundIds = new Set();
+              currentRoundIds.add(block.id);
+              hasSlotWorker = true;
+            }
+          }
+        }
+        // End of assistant message — if it had slot-workers, close the round
+        if (hasSlotWorker && currentRoundIds) {
+          roundIds.push(currentRoundIds);
+          currentRoundIds = null;
+        }
+      }
+
+      // Collect tool_result text keyed by tool_use_id
+      if (entry.type === 'user') {
+        const content = entry.message && entry.message.content;
+        if (!Array.isArray(content)) continue;
+        for (const block of content) {
+          if (block.type === 'tool_result' && block.tool_use_id) {
+            const resultText = Array.isArray(block.content)
+              ? block.content.map(c => c.text || '').join('')
+              : (typeof block.content === 'string' ? block.content : '');
+            taskResults.set(block.tool_use_id, resultText);
+          }
+        }
+      }
+    } catch { /* skip malformed */ }
+  }
+
+  // Only count live voters from the LAST dispatch round (the consensus round)
+  if (roundIds.length === 0) return 0;
+  const lastRound = roundIds[roundIds.length - 1];
+
+  let liveCount = 0;
+  for (const id of lastRound) {
+    const result = taskResults.get(id) || '';
+    // A live voter carries an explicit APPROVE/BLOCK verdict. Matching the verdict
+    // positively (rather than excluding UNAVAIL/FLAG_TRUNCATED) avoids counting error
+    // results as votes, and avoids dropping a valid vote whose reasoning text merely
+    // mentions the word "UNAVAIL". Fails safe: an unrecognized result is not a vote.
+    if (/verdict:\s*(?:APPROVE|BLOCK)\b/i.test(result)) liveCount++;
+  }
+  return liveCount;
+}
+
+// Extracts min_live_voters from config with safe default.
+function getMinLiveVoters(config) {
+  return (config.quorum && Number.isInteger(config.quorum.min_live_voters) && config.quorum.min_live_voters >= 1)
+    ? config.quorum.min_live_voters
+    : 2;
+}
+
 // The exact token Claude must include in its final output to mark a decision turn.
 // Used by hasDecisionMarker (Stop hook) and injected into Claude's context (Prompt hook).
 const DECISION_MARKER = '<!-- NF_DECISION -->';
@@ -843,6 +919,7 @@ function main() {
       // Extract --n N flag from current-turn user prompt (if present)
       const promptText = extractPromptText(currentTurnLines);
       const quorumSizeOverride = parseQuorumSizeFlag(promptText);
+      const hasForceQuorum = /\b--force-quorum\b/.test(promptText);
       const soloMode = quorumSizeOverride === 1;
 
       // GUARD 6: Solo mode (--n 1) — Claude-only quorum, no external models required
@@ -903,6 +980,28 @@ function main() {
           }));
           process.exit(0);
         }
+
+        // MIN_LIVE_VOTERS floor (issue #170)
+        const minLiveVoters = getMinLiveVoters(config);
+        const liveSlotWorkers = countLiveSlotWorkers(currentTurnLines);
+        if (liveSlotWorkers < minLiveVoters && !hasForceQuorum) {
+          appendConformanceEvent({
+            ts:              new Date().toISOString(),
+            phase:           'DECIDING',
+            action:          'floor_block',
+            live_voters:     liveSlotWorkers,
+            min_live_voters: minLiveVoters,
+            outcome:         'BLOCK',
+            schema_version,
+          });
+          process.stdout.write(JSON.stringify({
+            decision: 'block',
+            reason: 'QUORUM FLOOR NOT MET: Only ' + liveSlotWorkers + ' live voter(s) (min_live_voters = ' + minLiveVoters + '). ' +
+              'Too many slots are UNAVAIL for reliable consensus. Re-dispatch with extended timeouts, or re-run with --force-quorum to waive.'
+          }));
+          process.exit(0);
+        }
+
         process.exit(0);
       }
 
@@ -938,6 +1037,26 @@ function main() {
           }
           missingAgents.push(toolName);
         }
+      }
+
+      // MIN_LIVE_VOTERS floor — checked when ceiling is met but live voters are too few
+      const minLiveVoters = getMinLiveVoters(config);
+      if (successCount >= maxSize && successCount < minLiveVoters && !hasForceQuorum) {
+        appendConformanceEvent({
+          ts:              new Date().toISOString(),
+          phase:           'DECIDING',
+          action:          'floor_block',
+          live_voters:     successCount,
+          min_live_voters: minLiveVoters,
+          outcome:         'BLOCK',
+          schema_version,
+        });
+        process.stdout.write(JSON.stringify({
+          decision: 'block',
+          reason: 'QUORUM FLOOR NOT MET: ' + successCount + ' live voter(s) (min_live_voters = ' + minLiveVoters + '). ' +
+            'Too few live voters for reliable consensus. Re-run with --force-quorum to waive.'
+        }));
+        process.exit(0);
       }
 
       if (successCount < maxSize) {

--- a/hooks/nf-stop.js
+++ b/hooks/nf-stop.js
@@ -158,6 +158,39 @@ function extractCommandTag(entry) {
   return m ? m[1].trim() : null;
 }
 
+// Extracts the value of the <command-args> XML tag injected by Claude Code for real slash
+// command invocations. Slash-command flags (e.g. --force-quorum, --n N) land here — NOT in
+// <command-name>. Returns the trimmed args content, or null if the tag is absent.
+function extractCommandArgs(entry) {
+  let text = '';
+  const content = entry.message?.content;
+  if (typeof content === 'string') {
+    text = content;
+  } else if (Array.isArray(content)) {
+    const first = content.find(c => c?.type === 'text');
+    text = first ? (first.text || '') : '';
+  }
+  const m = text.match(/<command-args>([\s\S]*?)<\/command-args>/);
+  return m ? m[1].trim() : null;
+}
+
+// Detects the --force-quorum waiver flag. Checks the extracted prompt text AND every
+// <command-args> tag in the turn — for a tagged slash command, extractPromptText returns
+// only the command name, so flags live in <command-args>. Scoped to user command args
+// (never hook-injected text) so a prior block reason mentioning the flag cannot self-waive.
+function hasForceQuorumFlag(currentTurnLines, promptText) {
+  if (/\b--force-quorum\b/.test(promptText)) return true;
+  for (const line of currentTurnLines) {
+    try {
+      const entry = JSON.parse(line);
+      if (entry.type !== 'user') continue;
+      const args = extractCommandArgs(entry);
+      if (args !== null && /\b--force-quorum\b/.test(args)) return true;
+    } catch { /* skip malformed lines */ }
+  }
+  return false;
+}
+
 // Returns true if any user entry in currentTurnLines contains an NF quorum command.
 // Uses XML-tag-first strategy: if a <command-name> tag is present, only that tag is tested
 // against cmdPattern (never the full body). Falls back to first 300 chars of message text
@@ -685,9 +718,13 @@ function countLiveSlotWorkers(currentTurnLines) {
         if (!Array.isArray(content)) continue;
         let hasSlotWorker = false;
         for (const block of content) {
-          if (block.type === 'tool_use' && block.name === 'Task') {
-            const inputStr = JSON.stringify(block.input || {});
-            if (inputStr.includes('nf-quorum-slot-worker') && block.id) {
+          if (block.type === 'tool_use' && block.name === 'Task' && block.id) {
+            // Match the structured subagent_type field — consistent with
+            // wasSlotWorkerUsed / detectUnavailWithoutFallback, and avoids matching
+            // the string in an unrelated Task's prompt/description.
+            const input = block.input || {};
+            const subagentType = input.subagent_type || input.subagentType || '';
+            if (subagentType === 'nf-quorum-slot-worker') {
               if (!currentRoundIds) currentRoundIds = new Set();
               currentRoundIds.add(block.id);
               hasSlotWorker = true;
@@ -707,6 +744,9 @@ function countLiveSlotWorkers(currentTurnLines) {
         if (!Array.isArray(content)) continue;
         for (const block of content) {
           if (block.type === 'tool_result' && block.tool_use_id) {
+            // Errored tool results are non-votes — leave them unrecorded so they
+            // are not counted toward the live-voter total.
+            if (block.is_error === true) continue;
             const resultText = Array.isArray(block.content)
               ? block.content.map(c => c.text || '').join('')
               : (typeof block.content === 'string' ? block.content : '');
@@ -919,7 +959,7 @@ function main() {
       // Extract --n N flag from current-turn user prompt (if present)
       const promptText = extractPromptText(currentTurnLines);
       const quorumSizeOverride = parseQuorumSizeFlag(promptText);
-      const hasForceQuorum = /\b--force-quorum\b/.test(promptText);
+      const hasForceQuorum = hasForceQuorumFlag(currentTurnLines, promptText);
       const soloMode = quorumSizeOverride === 1;
 
       // GUARD 6: Solo mode (--n 1) — Claude-only quorum, no external models required

--- a/hooks/nf-stop.test.js
+++ b/hooks/nf-stop.test.js
@@ -1638,6 +1638,318 @@ test('TC-STANDARD-NON-QUORUM-NOT-ENFORCED: standard mode does NOT enforce /nf:ex
   }
 });
 
+// ── TC-FLOOR-*: Minimum live voters floor (issue #170) ──────────────────────────
+//
+// TC-FLOOR-1: Slot-worker path — 1 live voter, floor=2 → BLOCK (thin consensus)
+// TC-FLOOR-2: Slot-worker path — 2 live voters, floor=2 → PASS
+// TC-FLOOR-3: Non-slot-worker path — successCount=1, maxSize=1, floor=2 → BLOCK
+// TC-FLOOR-4: Non-slot-worker path — successCount=2, maxSize=2, floor=2 → PASS
+// TC-FLOOR-5: Floor disabled (min_live_voters=1), 1 live voter → PASS (backward compat)
+
+// Helper: build a slot-worker Task dispatch assistant line
+function slotWorkerTaskLine(slotName, taskId) {
+  return JSON.stringify({
+    type: 'assistant',
+    message: {
+      role: 'assistant',
+      content: [{
+        type: 'tool_use',
+        id: taskId,
+        name: 'Task',
+        input: {
+          subagent_type: 'nf-quorum-slot-worker',
+          model: 'haiku',
+          description: `${slotName} quorum R1`,
+          prompt: 'node quorum-slot-dispatch.cjs --slot ' + slotName,
+        },
+      }],
+      stop_reason: 'tool_use',
+    },
+    timestamp: '2026-02-20T00:05:00Z',
+    uuid: `assistant-sw-${slotName}`,
+  });
+}
+
+// Helper: build a tool_result line for a slot-worker Task
+function slotWorkerResultLine(taskId, resultText, uuid) {
+  return JSON.stringify({
+    type: 'user',
+    message: {
+      role: 'user',
+      content: [{
+        type: 'tool_result',
+        tool_use_id: taskId,
+        content: [{ type: 'text', text: resultText }],
+      }],
+    },
+    timestamp: '2026-02-20T00:05:30Z',
+    uuid: uuid || `tr-sw-${taskId}`,
+  });
+}
+
+// TC-FLOOR-1: Slot-worker path — only 1 live voter out of 2 dispatched, floor=2 → BLOCK
+// Simulates the thin-consensus scenario from issue #170: one slot returns APPROVE,
+// the other returns UNAVAIL. With floor=2, this must BLOCK.
+test('TC-FLOOR-1: slot-worker thin consensus — 1 live voter, floor=2 → BLOCK', () => {
+  const slots = ['slot-a', 'slot-b'];
+  const configPayload = JSON.stringify({
+    quorum_commands: ['quick'],
+    quorum_active: slots,
+    agent_config: {},
+    quorum: { maxSize: 2, min_live_voters: 2 },
+  });
+  const homeDir = path.join(os.tmpdir(), `nf-home-floor1-${Date.now()}`);
+  const claudeDir = path.join(homeDir, '.claude');
+  fs.mkdirSync(claudeDir, { recursive: true });
+  fs.writeFileSync(path.join(claudeDir, 'nf.json'), configPayload);
+
+  const claudeJsonTmp = path.join(os.tmpdir(), `nf-claude-floor1-${Date.now()}.json`);
+  const mcpServers = {};
+  for (const s of slots) mcpServers[s] = {};
+  fs.writeFileSync(claudeJsonTmp, JSON.stringify({ mcpServers }));
+
+  // Write a checkpoint file signaling all_tiers_exhausted=true so FALLBACK-01 gate passes
+  const cpDir = path.join(homeDir, '.planning', 'quorum', 'checkpoints');
+  fs.mkdirSync(cpDir, { recursive: true });
+  fs.writeFileSync(path.join(cpDir, 'round-1.json'), JSON.stringify({
+    round: 1,
+    unavail_primaries: ['slot-b'],
+    fallback_dispatched: false,
+    t1_slots_tried: [],
+    t2_slots_tried: [],
+    all_tiers_exhausted: true,
+    proceed_reason: 'all tiers exhausted, only 1 live voter',
+    timestamp: '2026-02-20T00:00:01Z',
+    schema_version: 1,
+  }));
+
+  // Transcript: slot-worker dispatch with 1 APPROVE and 1 UNAVAIL + checkpoint Bash call
+  const transcriptLines = [
+    userLine('/qnf:quick add something', 'human-floor1'),
+    assistantLine([bashCommitBlock('node /path/nf-tools.cjs commit "docs: plan" --files quick-115-PLAN.md')], 'assistant-commit'),
+    JSON.stringify({
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'task-a', name: 'Task', input: { subagent_type: 'nf-quorum-slot-worker', model: 'haiku', description: 'slot-a quorum R1', prompt: 'node "$HOME/.claude/nf-bin/quorum-slot-dispatch.cjs" --slot slot-a --mode A --round 1 --question "test"' } },
+          { type: 'tool_use', id: 'task-b', name: 'Task', input: { subagent_type: 'nf-quorum-slot-worker', model: 'haiku', description: 'slot-b quorum R1', prompt: 'node "$HOME/.claude/nf-bin/quorum-slot-dispatch.cjs" --slot slot-b --mode A --round 1 --question "test"' } },
+        ],
+        stop_reason: 'tool_use',
+      },
+      timestamp: '2026-02-20T00:05:00Z',
+      uuid: 'assistant-sw-dispatch',
+    }),
+    toolResultSuccessLine('task-a', 'verdict: APPROVE\nreasoning: looks good\ndispatch_nonce: a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6'),
+    toolResultSuccessLine('task-b', 'verdict: UNAVAIL\nreasoning: provider down'),
+    assistantLine([{
+      type: 'tool_use', id: 'toolu_ckpt', name: 'Bash',
+      input: { command: 'node "$HOME/.claude/nf-bin/quorum-checkpoint.cjs" --round 1 --unavail-primaries "slot-b" --fallback-dispatched false --t1-slots "none" --t2-slots "none" --all-tiers-exhausted true --proceed-reason "all tiers exhausted"' },
+    }], 'a-ckpt'),
+    toolResultSuccessLine('toolu_ckpt', 'FALLBACK-01 checkpoint written: round-1.json'),
+    assistantLine([{ type: 'text', text: 'Quorum complete.\n\n<!-- NF_DECISION -->' }], 'assistant-final'),
+  ];
+  const tmpFile = writeTempTranscript(transcriptLines);
+  try {
+    const { stdout, exitCode } = runHookWithEnv(
+      { stop_hook_active: false, hook_event_name: 'Stop', transcript_path: tmpFile, last_assistant_message: 'Done.' },
+      { HOME: homeDir, NF_CLAUDE_JSON: claudeJsonTmp },
+      homeDir
+    );
+    assert.strictEqual(exitCode, 0);
+    assert.ok(stdout.length > 0, 'must block — only 1 live voter below floor of 2');
+    const parsed = JSON.parse(stdout);
+    assert.strictEqual(parsed.decision, 'block', 'decision must be block — thin consensus');
+    assert.ok(parsed.reason.includes('QUORUM FLOOR NOT MET'), 'reason must mention floor');
+    assert.ok(parsed.reason.includes('1 live voter'), 'reason must mention 1 live voter');
+    assert.ok(parsed.reason.includes('min_live_voters = 2'), 'reason must mention floor value');
+  } finally {
+    fs.unlinkSync(tmpFile);
+    fs.unlinkSync(claudeJsonTmp);
+  }
+});
+
+// TC-FLOOR-2: Slot-worker path — 2 live voters, floor=2 → PASS
+test('TC-FLOOR-2: slot-worker adequate consensus — 2 live voters, floor=2 → PASS', () => {
+  const slots = ['slot-a', 'slot-b'];
+  const configPayload = JSON.stringify({
+    quorum_commands: ['quick'],
+    quorum_active: slots,
+    agent_config: {},
+    quorum: { maxSize: 2, min_live_voters: 2 },
+  });
+  const homeDir = path.join(os.tmpdir(), `nf-home-floor2-${Date.now()}`);
+  const claudeDir = path.join(homeDir, '.claude');
+  fs.mkdirSync(claudeDir, { recursive: true });
+  fs.writeFileSync(path.join(claudeDir, 'nf.json'), configPayload);
+
+  const claudeJsonTmp = path.join(os.tmpdir(), `nf-claude-floor2-${Date.now()}.json`);
+  const mcpServers = {};
+  for (const s of slots) mcpServers[s] = {};
+  fs.writeFileSync(claudeJsonTmp, JSON.stringify({ mcpServers }));
+
+  // Transcript: both slot-workers return APPROVE (dispatched as sibling Tasks in one message)
+  const transcriptLines = [
+    userLine('/qnf:quick add something', 'human-floor2'),
+    assistantLine([bashCommitBlock('node /path/nf-tools.cjs commit "docs: plan" --files quick-115-PLAN.md')], 'assistant-commit'),
+    JSON.stringify({
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'task-a', name: 'Task', input: { subagent_type: 'nf-quorum-slot-worker', prompt: 'node quorum-slot-dispatch.cjs --slot slot-a --mode A --round 1 --question "test"' } },
+          { type: 'tool_use', id: 'task-b', name: 'Task', input: { subagent_type: 'nf-quorum-slot-worker', prompt: 'node quorum-slot-dispatch.cjs --slot slot-b --mode A --round 1 --question "test"' } },
+        ],
+        stop_reason: 'tool_use',
+      },
+      timestamp: '2026-02-20T00:05:00Z',
+      uuid: 'assistant-sw-dispatch',
+    }),
+    toolResultSuccessLine('task-a', 'verdict: APPROVE\nreasoning: looks good\ndispatch_nonce: a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6'),
+    toolResultSuccessLine('task-b', 'verdict: APPROVE\nreasoning: solid plan\ndispatch_nonce: f1e2d3c4b5a6978869504132435a6b7c'),
+    assistantLine([{ type: 'text', text: 'Done.' }], 'assistant-final'),
+  ];
+  const tmpFile = writeTempTranscript(transcriptLines);
+  try {
+    const { stdout, exitCode } = runHookWithEnv(
+      { stop_hook_active: false, hook_event_name: 'Stop', transcript_path: tmpFile, last_assistant_message: 'Done.' },
+      { HOME: homeDir, NF_CLAUDE_JSON: claudeJsonTmp },
+      homeDir
+    );
+    assert.strictEqual(exitCode, 0);
+    assert.strictEqual(stdout, '', '2 live voters meets floor=2 — must not block');
+  } finally {
+    fs.unlinkSync(tmpFile);
+    fs.unlinkSync(claudeJsonTmp);
+  }
+});
+
+// TC-FLOOR-3: Non-slot-worker path — successCount=1, maxSize=1, floor=2 → BLOCK
+// Ceiling is met (1 >= 1) but floor is not (1 < 2).
+test('TC-FLOOR-3: non-slot-worker — ceiling met but floor not met → BLOCK', () => {
+  const slots = ['slot-a'];
+  const configPayload = JSON.stringify({
+    quorum_commands: ['quick'],
+    quorum_active: slots,
+    agent_config: { 'slot-a': { auth_type: 'api' } },
+    quorum: { maxSize: 1, min_live_voters: 2 },
+  });
+  const homeDir = path.join(os.tmpdir(), `nf-home-floor3-${Date.now()}`);
+  const claudeDir = path.join(homeDir, '.claude');
+  fs.mkdirSync(claudeDir, { recursive: true });
+  fs.writeFileSync(path.join(claudeDir, 'nf.json'), configPayload);
+
+  const claudeJsonTmp = path.join(os.tmpdir(), `nf-claude-floor3-${Date.now()}.json`);
+  fs.writeFileSync(claudeJsonTmp, JSON.stringify({ mcpServers: { 'slot-a': {} } }));
+
+  // Transcript: 1 successful call meets maxSize=1 but not floor=2
+  const transcriptLines = [
+    userLine('/qnf:quick add something', 'human-floor3'),
+    assistantLine([bashCommitBlock('node /path/nf-tools.cjs commit "docs: plan" --files quick-115-PLAN.md')], 'assistant-commit'),
+    assistantLine([toolUseBlock('mcp__slot-a__review')], 'assistant-a'),
+    toolResultSuccessLine('toolu_mcp__slot-a__review', 'slot-a review OK'),
+    assistantLine([{ type: 'text', text: 'Done.' }], 'assistant-final'),
+  ];
+  const tmpFile = writeTempTranscript(transcriptLines);
+  try {
+    const { stdout, exitCode } = runHookWithEnv(
+      { stop_hook_active: false, hook_event_name: 'Stop', transcript_path: tmpFile, last_assistant_message: 'Done.' },
+      { HOME: homeDir, NF_CLAUDE_JSON: claudeJsonTmp },
+      homeDir
+    );
+    assert.strictEqual(exitCode, 0);
+    assert.ok(stdout.length > 0, 'must block — ceiling met but floor not met');
+    const parsed = JSON.parse(stdout);
+    assert.strictEqual(parsed.decision, 'block', 'decision must be block — below floor');
+    assert.ok(parsed.reason.includes('QUORUM FLOOR NOT MET'), 'reason must mention floor');
+  } finally {
+    fs.unlinkSync(tmpFile);
+    fs.unlinkSync(claudeJsonTmp);
+  }
+});
+
+// TC-FLOOR-4: Non-slot-worker path — successCount=2, maxSize=2, floor=2 → PASS
+test('TC-FLOOR-4: non-slot-worker — ceiling and floor both met → PASS', () => {
+  const slots = ['slot-a', 'slot-b'];
+  const configPayload = JSON.stringify({
+    quorum_commands: ['quick'],
+    quorum_active: slots,
+    agent_config: { 'slot-a': { auth_type: 'api' }, 'slot-b': { auth_type: 'api' } },
+    quorum: { maxSize: 2, min_live_voters: 2 },
+  });
+  const homeDir = path.join(os.tmpdir(), `nf-home-floor4-${Date.now()}`);
+  const claudeDir = path.join(homeDir, '.claude');
+  fs.mkdirSync(claudeDir, { recursive: true });
+  fs.writeFileSync(path.join(claudeDir, 'nf.json'), configPayload);
+
+  const claudeJsonTmp = path.join(os.tmpdir(), `nf-claude-floor4-${Date.now()}.json`);
+  const mcpServers = {};
+  for (const s of slots) mcpServers[s] = {};
+  fs.writeFileSync(claudeJsonTmp, JSON.stringify({ mcpServers }));
+
+  const transcriptLines = [
+    userLine('/qnf:quick add something', 'human-floor4'),
+    assistantLine([bashCommitBlock('node /path/nf-tools.cjs commit "docs: plan" --files quick-115-PLAN.md')], 'assistant-commit'),
+    assistantLine([toolUseBlock('mcp__slot-a__review')], 'assistant-a'),
+    toolResultSuccessLine('toolu_mcp__slot-a__review', 'slot-a OK'),
+    assistantLine([toolUseBlock('mcp__slot-b__review')], 'assistant-b'),
+    toolResultSuccessLine('toolu_mcp__slot-b__review', 'slot-b OK'),
+    assistantLine([{ type: 'text', text: 'Done.' }], 'assistant-final'),
+  ];
+  const tmpFile = writeTempTranscript(transcriptLines);
+  try {
+    const { stdout, exitCode } = runHookWithEnv(
+      { stop_hook_active: false, hook_event_name: 'Stop', transcript_path: tmpFile, last_assistant_message: 'Done.' },
+      { HOME: homeDir, NF_CLAUDE_JSON: claudeJsonTmp },
+      homeDir
+    );
+    assert.strictEqual(exitCode, 0);
+    assert.strictEqual(stdout, '', '2 live voters meets both ceiling=2 and floor=2 — must not block');
+  } finally {
+    fs.unlinkSync(tmpFile);
+    fs.unlinkSync(claudeJsonTmp);
+  }
+});
+
+// TC-FLOOR-5: Floor disabled (min_live_voters=1), 1 live voter → PASS (backward compat)
+test('TC-FLOOR-5: floor=1 with 1 live voter → PASS (backward compat)', () => {
+  const slots = ['slot-a'];
+  const configPayload = JSON.stringify({
+    quorum_commands: ['quick'],
+    quorum_active: slots,
+    agent_config: { 'slot-a': { auth_type: 'api' } },
+    quorum: { maxSize: 1, min_live_voters: 1 },
+  });
+  const homeDir = path.join(os.tmpdir(), `nf-home-floor5-${Date.now()}`);
+  const claudeDir = path.join(homeDir, '.claude');
+  fs.mkdirSync(claudeDir, { recursive: true });
+  fs.writeFileSync(path.join(claudeDir, 'nf.json'), configPayload);
+
+  const claudeJsonTmp = path.join(os.tmpdir(), `nf-claude-floor5-${Date.now()}.json`);
+  fs.writeFileSync(claudeJsonTmp, JSON.stringify({ mcpServers: { 'slot-a': {} } }));
+
+  const transcriptLines = [
+    userLine('/qnf:quick add something', 'human-floor5'),
+    assistantLine([bashCommitBlock('node /path/nf-tools.cjs commit "docs: plan" --files quick-115-PLAN.md')], 'assistant-commit'),
+    assistantLine([toolUseBlock('mcp__slot-a__review')], 'assistant-a'),
+    toolResultSuccessLine('toolu_mcp__slot-a__review', 'slot-a OK'),
+    assistantLine([{ type: 'text', text: 'Done.' }], 'assistant-final'),
+  ];
+  const tmpFile = writeTempTranscript(transcriptLines);
+  try {
+    const { stdout, exitCode } = runHookWithEnv(
+      { stop_hook_active: false, hook_event_name: 'Stop', transcript_path: tmpFile, last_assistant_message: 'Done.' },
+      { HOME: homeDir, NF_CLAUDE_JSON: claudeJsonTmp },
+      homeDir
+    );
+    assert.strictEqual(exitCode, 0);
+    assert.strictEqual(stdout, '', 'floor=1 with 1 live voter must pass — backward compat');
+  } finally {
+    fs.unlinkSync(tmpFile);
+    fs.unlinkSync(claudeJsonTmp);
+  }
+});
+
 // ── FALLBACK-01 Structured Checkpoint Tests (issue #172) ────────────────────
 //
 // The FALLBACK-01 gate now reads a schema-validated JSON file at
@@ -1683,7 +1995,7 @@ function setupFallbackDir(label) {
   fs.mkdirSync(claudeDir, { recursive: true });
   fs.writeFileSync(
     path.join(claudeDir, 'nf.json'),
-    JSON.stringify({ hook_profile: 'standard', quorum_commands: ['plan-phase'] }),
+    JSON.stringify({ hook_profile: 'standard', quorum_commands: ['plan-phase'], quorum: { min_live_voters: 1 } }),
     'utf8'
   );
   return dir;

--- a/hooks/nf-stop.test.js
+++ b/hooks/nf-stop.test.js
@@ -1646,47 +1646,6 @@ test('TC-STANDARD-NON-QUORUM-NOT-ENFORCED: standard mode does NOT enforce /nf:ex
 // TC-FLOOR-4: Non-slot-worker path — successCount=2, maxSize=2, floor=2 → PASS
 // TC-FLOOR-5: Floor disabled (min_live_voters=1), 1 live voter → PASS (backward compat)
 
-// Helper: build a slot-worker Task dispatch assistant line
-function slotWorkerTaskLine(slotName, taskId) {
-  return JSON.stringify({
-    type: 'assistant',
-    message: {
-      role: 'assistant',
-      content: [{
-        type: 'tool_use',
-        id: taskId,
-        name: 'Task',
-        input: {
-          subagent_type: 'nf-quorum-slot-worker',
-          model: 'haiku',
-          description: `${slotName} quorum R1`,
-          prompt: 'node quorum-slot-dispatch.cjs --slot ' + slotName,
-        },
-      }],
-      stop_reason: 'tool_use',
-    },
-    timestamp: '2026-02-20T00:05:00Z',
-    uuid: `assistant-sw-${slotName}`,
-  });
-}
-
-// Helper: build a tool_result line for a slot-worker Task
-function slotWorkerResultLine(taskId, resultText, uuid) {
-  return JSON.stringify({
-    type: 'user',
-    message: {
-      role: 'user',
-      content: [{
-        type: 'tool_result',
-        tool_use_id: taskId,
-        content: [{ type: 'text', text: resultText }],
-      }],
-    },
-    timestamp: '2026-02-20T00:05:30Z',
-    uuid: uuid || `tr-sw-${taskId}`,
-  });
-}
-
 // TC-FLOOR-1: Slot-worker path — only 1 live voter out of 2 dispatched, floor=2 → BLOCK
 // Simulates the thin-consensus scenario from issue #170: one slot returns APPROVE,
 // the other returns UNAVAIL. With floor=2, this must BLOCK.

--- a/src/machines/nf-workflow.machine.ts
+++ b/src/machines/nf-workflow.machine.ts
@@ -31,12 +31,14 @@ export const nfWorkflowMachine = setup({
     unanimityMet: ({ context }) =>
       context.successCount === context.polledCount,
 
-    floorMet: ({ context }) =>
-      context.successCount >= context.minLiveVoters,
+    floorMet: ({ context, event }) =>
+      event.type === 'VOTES_COLLECTED' &&
+      event.successCount >= context.minLiveVoters,
 
-    unanimityAndFloorMet: ({ context }) =>
-      context.successCount === context.polledCount &&
-      context.successCount >= context.minLiveVoters,
+    unanimityAndFloorMet: ({ context, event }) =>
+      event.type === 'VOTES_COLLECTED' &&
+      event.successCount === context.polledCount &&
+      event.successCount >= context.minLiveVoters,
 
     noInfiniteDeliberation: ({ context }) =>
       context.deliberationRounds < context.maxDeliberation,

--- a/src/machines/nf-workflow.machine.ts
+++ b/src/machines/nf-workflow.machine.ts
@@ -8,6 +8,7 @@ export interface NFContext {
   currentPhase:       string;
   maxDeliberation:    number;
   maxSize:            number;   // cap on voters polled per round (--n N - 1 ceiling)
+  minLiveVoters:      number;   // floor: minimum live voters for valid consensus (issue #170)
   polledCount:        number;   // agents actually recruited this round
 }
 
@@ -30,6 +31,13 @@ export const nfWorkflowMachine = setup({
     unanimityMet: ({ context }) =>
       context.successCount === context.polledCount,
 
+    floorMet: ({ context }) =>
+      context.successCount >= context.minLiveVoters,
+
+    unanimityAndFloorMet: ({ context }) =>
+      context.successCount === context.polledCount &&
+      context.successCount >= context.minLiveVoters,
+
     noInfiniteDeliberation: ({ context }) =>
       context.deliberationRounds < context.maxDeliberation,
 
@@ -45,6 +53,7 @@ export const nfWorkflowMachine = setup({
     currentPhase:       'IDLE',
     maxDeliberation:    9,
     maxSize:            3,
+    minLiveVoters:      2,
     polledCount:        0,
   },
   states: {
@@ -73,7 +82,7 @@ export const nfWorkflowMachine = setup({
       on: {
         VOTES_COLLECTED: [
           {
-            guard:   'unanimityMet',
+            guard:   'unanimityAndFloorMet',
             target:  'DECIDED',
             actions: assign({
               successCount:  ({ event }) => event.successCount,
@@ -104,7 +113,7 @@ export const nfWorkflowMachine = setup({
       on: {
         VOTES_COLLECTED: [
           {
-            guard:   'unanimityMet',
+            guard:   'unanimityAndFloorMet',
             target:  'DECIDED',
             actions: assign({
               successCount:  ({ event }) => event.successCount,
@@ -119,6 +128,7 @@ export const nfWorkflowMachine = setup({
             }),
           },
           {
+            guard:   'floorMet',
             target:  'DECIDED',
             actions: assign({ currentPhase: () => 'DECIDED' }),
           },


### PR DESCRIPTION
## Summary

Adds a configurable `min_live_voters` floor (default: 2) that blocks consensus when the number of live (non-UNAVAIL) voters falls below the threshold. Prevents thin consensus where a single surviving voter declares unanimity after mass UNAVAIL — surfaced during the 2026-05-13 quorum runs with 60–80% slot failures.

> **Note:** This is a clean, rebased-on-`main` replacement for #191. That branch had drifted behind `main` (its diff was polluted with unrelated deletions) and CI was red due to a missing TLC constant. This PR carries only the issue #170 work, on top of current `main`, with the review fixes folded in. The unrelated `@hpcc-js/wasm-graphviz` dependency bump from #191 is intentionally **not** included.

## Changes

- **Enforcement** (`nf-stop.js`): floor checked in both the slot-worker and non-slot-worker paths. Below-floor consensus blocks with a clear error; `--force-quorum` waives it.
- **Live-voter counting**: `countLiveSlotWorkers` counts only results carrying an explicit `APPROVE`/`BLOCK` verdict — errors and `UNAVAIL`/`FLAG_TRUNCATED` are non-votes. Positive-match logic fails safe (an unrecognized result is not a vote) and avoids dropping a valid vote whose reasoning text merely mentions "UNAVAIL".
- **XState machine**: adds `minLiveVoters` context + `floorMet` / `unanimityAndFloorMet` guards; DECIDED transitions now require unanimity **and** floor.
- **Formal**: `NFStopHook.tla` models the floor as the `FloorSafety` invariant. `MCStopHook.cfg` assigns the new `MinLiveVoters` constant and adds `INVARIANT FloorSafety` so it is actually model-checked — verified locally with TLC (`No error has been found`).
- **Config**: `config-loader` defaults `quorum.min_live_voters = 2`.
- **Docs**: RULE CE-4 added to `commands/nf/quorum.md`.

## Acceptance criteria (#170)

- [x] `min_live_voters` configurable (flat config value + quorum.md risk-level guidance)
- [x] CE-3 evaluation in `nf-stop.js` checks the floor (both paths)
- [x] Below-floor consensus blocks with a clear error, not silently
- [x] TLA+ spec models the floor as a safety invariant — and `MCStopHook.cfg` checks it

## Verification

- `node --test hooks/nf-stop.test.js` — 54/54 pass (incl. 5 new `TC-FLOOR-*` cases)
- `node bin/run-stop-hook-tlc.cjs MCStopHook` — TypeOK, SafetyInvariant1-3, **FloorSafety**, LivenessProperty1-3 — no error
- `check-spec-sync`, `verify-hooks-sync`, `lint:isolation` — all pass

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enforced minimum live voters floor (default: 2) for consensus approval; bypass with `--force-quorum` when necessary.
  * Configurable via `quorum.min_live_voters` setting.

* **Documentation**
  * Updated consensus rules detailing minimum voter floor requirements and resolution pathways.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nForma-AI/nForma/pull/192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->