### PR TITLE
chore(release): 0.44.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,36 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.44.0] - 2026-05-21 — Quorum reliability & provider resolution hardening
+
+### Added
+- feat(skills): `/nf:pr-resolve` skill — evaluates bot review comments (CodeRabbit, Copilot, gitar) for validity before resolving threads, then polls CI and squash-merges when ready. Includes a worktree cleanliness pre-flight check before skill execution (#160, #181)
+- feat(quorum): `min_live_voters` floor for thin-consensus safety — a verdict is trusted only once a minimum number of slots have returned live votes, so a lone surviving voter can no longer carry consensus (#192)
+- feat(quorum): empirical score-delta calibration — consensus scoring thresholds are derived from observed score distributions rather than fixed constants (#175)
+- feat(install): auto-install `uv` when missing, gated by an availability pre-check, before the River ML install step (#155)
+
 ### Changed
-- fix(quorum): replace the fragile HTML-comment `FALLBACK_CHECKPOINT` transcript marker with a schema-validated structured checkpoint file (`.planning/quorum/checkpoints/round-<N>.json`). `/nf:quorum` now runs `quorum-checkpoint.cjs` to write the checkpoint; `nf-stop.js` reads and JSON-schema-validates that file instead of regex-parsing the transcript, so LLM stylistic variation in the comment can no longer bypass or trigger the FALLBACK-01 gate. The human-readable HTML comment is still emitted for the transcript but is no longer the gating mechanism. (#172)
+- fix(quorum): replace the fragile HTML-comment `FALLBACK_CHECKPOINT` transcript marker with a schema-validated structured checkpoint file (`.planning/quorum/checkpoints/round-<N>.json`). `/nf:quorum` now runs `quorum-checkpoint.cjs` to write the checkpoint; `nf-stop.js` reads and JSON-schema-validates that file instead of regex-parsing the transcript, so LLM stylistic variation in the comment can no longer bypass or trigger the FALLBACK-01 gate. The human-readable HTML comment is still emitted for the transcript but is no longer the gating mechanism. (#188)
+- fix: consolidate `providers.json` onto the canonical `~/.claude/nf-bin/` path — installer, MCP server, and quorum dispatch now all read the same location, ending divergence between the legacy `nf/bin/` and `nf-bin/` copies (#186, closes #167)
 
 ### Fixed
-- fix(mcp): `unified-mcp-server.mjs` now resolves the spawn executable through the same 3-tier fallback as `call-quorum-slot.cjs` (`resolvedCli → cli → mainTool`) via a shared `resolveSpawnTarget` helper. The previous `provider.resolvedCli ?? provider.cli` expression could hand `null` to `child_process.spawn` for `mainTool`-only slots (`providers.json` carries `cli: null`), throwing the opaque `TypeError: The "file" argument must be of type string. Received null`. An unresolvable provider now fails with a named `[spawn error: provider <name> has no resolvable CLI ...]` instead. The deep health check binary lookup uses the same fallback (#161/#164 follow-up)
-- fix(provider-concurrency): PID-based file semaphores no longer leave stale locks after a crash or `SIGKILL` — stale-lock reclamation (dead PID, previous-boot detection, TTL backstop) now runs on every pass of the acquire retry loop, so a slot freed by a holder that dies while another caller is waiting becomes available within one backoff cycle instead of blocking until timeout; `process.kill(pid,0)` `EPERM` is now treated as alive and a boot-time field guards against post-reboot PID reuse (#176)
+- fix(mcp): `unified-mcp-server.mjs` now resolves the spawn executable through the same 3-tier fallback as `call-quorum-slot.cjs` (`resolvedCli → cli → mainTool`) via a shared `resolveSpawnTarget` helper. The previous `provider.resolvedCli ?? provider.cli` expression could hand `null` to `child_process.spawn` for `mainTool`-only slots (`providers.json` carries `cli: null`), throwing the opaque `TypeError: The "file" argument must be of type string. Received null`. An unresolvable provider now fails with a named `[spawn error: provider <name> has no resolvable CLI ...]` instead. The deep health check binary lookup uses the same fallback (#193, follows #161/#164)
+- fix(mcp/install): resolve a provider's CLI from `mainTool` when the `cli` field is null, and self-heal a missing `mainTool` — without this the resolved CLI stayed unset and spawn received `null`, taking the whole quorum offline (#161, #164)
+- fix(quorum): backport the `mainTool` CLI fallback to `probe-quorum-slots` so slot health probes resolve binaries the same way dispatch does (#180)
+- fix(quorum): replace a truthy gate in `detectInstalledProviders` that excluded validly-configured slots (#183)
+- fix(mcp): auto-fall-back to the user-installed `providers.json`, and backfill `UNIFIED_PROVIDERS_CONFIG` when the repo-shipped source is empty (#162, #163)
+- fix(quorum): prefer the slash-path `providers.json` so Daintree-registered slots are visible to the quorum (#165)
+- fix(provider-concurrency): PID-based file semaphores no longer leave stale locks after a crash or `SIGKILL` — stale-lock reclamation (dead PID, previous-boot detection, TTL backstop) now runs on every pass of the acquire retry loop, so a slot freed by a holder that dies while another caller is waiting becomes available within one backoff cycle instead of blocking until timeout; `process.kill(pid,0)` `EPERM` is now treated as alive and a boot-time field guards against post-reboot PID reuse (#187, addresses #176)
 - fix(call-quorum-slot): HTTP provider slots are now held for the full request lifetime — the slot was previously released in a synchronous `finally` the instant `req.end()` returned, before the response arrived, which defeated the per-provider concurrency cap (#176)
+- fix(quorum): model correlated provider failures in the early-escalation gate so a shared-upstream outage no longer reads as independent slot failures (#190)
+- fix(quorum/link-daintree): attribute fan-out slots to their actual upstream provider, make fan-out idempotent across installs, persist fan-out preset metadata to an install-immune store, and always register `health_check` plus smoke-probe for newly created slots (#158, #159, #179, #184)
+- fix(quorum/link-daintree): store API tokens as `${VAR}` placeholders instead of plaintext (#182)
+- fix(mcp-status): read the quorum scoreboard from the correct path (#166)
+- fix(autopilot): trust GitHub server merge state over the `gh` CLI exit code when deciding whether a merge succeeded (#185)
+- fix(statusline): River status cyan now means "has visits" (reward data exists), not merely "has arms" (#155)
+
+### Removed
+- chore(quorum): remove dead CCR code paths after the `ccr-*` fleet retirement (#177)
 
 ## [0.43.1] - 2026-05-03
 

--- a/docs/assets/terminal.svg
+++ b/docs/assets/terminal.svg
@@ -80,7 +80,7 @@
     <path d="M100.8,143.0 H96.6 V132.0" stroke="#7dcfff" stroke-width="1.5" stroke-linecap="square" fill="none"/>
     <line x1="100.8" y1="143.0" x2="109.2" y2="143.0" stroke="#7dcfff" stroke-width="1.5" stroke-linecap="square" fill="none"/>
     <path d="M109.2,143.0 H113.4 V132.0" stroke="#7dcfff" stroke-width="1.5" stroke-linecap="square" fill="none"/>
-    <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="198" xml:space="preserve"><tspan fill="#c0caf5">  nForma </tspan><tspan fill="#c0caf5">— Consensus before code. Proof before production. </tspan><tspan fill="#565f89">v0.43.1</tspan></text>
+    <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="198" xml:space="preserve"><tspan fill="#c0caf5">  nForma </tspan><tspan fill="#c0caf5">— Consensus before code. Proof before production. </tspan><tspan fill="#565f89">v0.44.0</tspan></text>
     <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="220" xml:space="preserve"><tspan fill="#565f89">  Built on GSD-CC by TÂCHES.</tspan></text>
     <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="264" xml:space="preserve"><tspan fill="#7dcfff">  The task of leadership is to create an alignment of strengths</tspan></text>
     <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="286" xml:space="preserve"><tspan fill="#7dcfff">   so strong that it makes the system’s weaknesses irrelevant.</tspan></text>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nforma.ai/nforma",
-  "version": "0.43.1",
+  "version": "0.44.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nforma.ai/nforma",
-      "version": "0.43.1",
+      "version": "0.44.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nforma.ai/nforma",
-  "version": "0.43.1",
+  "version": "0.44.0",
   "description": "nForma — Multi-agent coding orchestrator with quorum consensus and formal verification (TLA+, Alloy, PRISM). Consensus before code, proof before production.",
   "bin": {
     "nforma": "bin/nforma-cli.js",


### PR DESCRIPTION
## Release 0.44.0 — Quorum reliability & provider resolution hardening

Stable release prepared manually (CHANGELOG required reconstruction — ~26 PRs merged since 0.43.1, only 4 previously logged).

### Verified locally before push
- [x] `package.json` bumped to 0.44.0
- [x] `package-lock.json` synced (`npm install --package-lock-only`) — version matches
- [x] CHANGELOG `## [0.44.0]` entry — full reconstruction across Added/Changed/Fixed/Removed
- [x] `terminal.svg` regenerated (embeds v0.44.0)
- [x] `npm ci --ignore-scripts` — lockfile integrity OK
- [x] `build:hooks` && `build:machines`
- [x] `check:assets`
- [x] `lint:isolation`
- [x] `test:ci` — **1668/1668 pass, 0 fail**

### Highlights
- `/nf:pr-resolve` skill — bot-thread evaluation + autonomous merge (#160, #181)
- Quorum thin-consensus safety: `min_live_voters` floor (#192), empirical score-delta calibration (#175)
- Provider/CLI resolution hardening: `mainTool` fallback across `call-quorum-slot`, `unified-mcp-server`, `probe-quorum-slots` (#161, #164, #180, #183, #193)
- `providers.json` path consolidation onto canonical `~/.claude/nf-bin/` (#186, closes #167)
- Provider-concurrency semaphore stale-lock self-healing (#187), correlated-failure modeling in the early-escalation gate (#190)

### After merge
CI (`release.yml`) will: test → tag `v0.44.0` → create GitHub Release → publish to npm `@latest` → align `@next` dist-tag to 0.44.0 (both tags land on 0.44.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release v0.44.0

* **New Features**
  * New skills and quorum reliability/scoring capabilities
  * JSON checkpoint mechanism for enhanced validation
  * Auto-installation of `uv` for simplified setup

* **Improvements**
  * Enhanced reliability across provider resolution and quorum dispatch
  * Consolidated provider configuration path
  * Better autopilot merge-state handling

* **Bug Fixes**
  * CLI resolution and MCP status path corrections
  * Provider concurrency and lifetime handling fixes
  * Daintree linking behavior improvements
  * Statusline color semantics update

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nForma-AI/nForma/pull/194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->