### PR TITLE
fix(quorum): fail-closed on malformed --remaining-rounds (#204)

### DIFF
--- a/bin/parse-int-strict.cjs
+++ b/bin/parse-int-strict.cjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+'use strict';
+// bin/parse-int-strict.cjs
+// Shared strict integer parser for numeric bin/ CLI arguments.
+// Issue #204 / class #183 — guards against fail-open NaN math when an
+// orchestrator passes a placeholder or malformed value for a numeric flag.
+//
+// Unlike parseInt(), this rejects:
+//   - non-string / null / undefined input
+//   - empty / whitespace-only strings
+//   - values with trailing non-digit garbage ("12abc", "2.5", "0x10")
+//   - NaN / Infinity
+// Returns the parsed integer, or null when the input is not a clean integer.
+
+/**
+ * parseIntStrict(value) — parse a string into an integer, strictly.
+ *
+ * @param {unknown} value - the raw flag value (e.g. from `--flag=VALUE`.split('=')[1])
+ * @returns {number|null} the integer, or null if `value` is not a clean integer
+ */
+function parseIntStrict(value) {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (trimmed === '') return null;
+  // Accept an optional leading sign followed by digits only.
+  if (!/^[+-]?\d+$/.test(trimmed)) return null;
+  const n = Number(trimmed);
+  if (!Number.isInteger(n)) return null;
+  return n;
+}
+
+module.exports = { parseIntStrict };

--- a/bin/quorum-consensus-gate.cjs
+++ b/bin/quorum-consensus-gate.cjs
@@ -17,6 +17,7 @@ const fs   = require('fs');
 const os   = require('os');
 const path = require('path');
 const { loadProviders } = require('./resolve-providers.cjs');
+const { parseIntStrict } = require('./parse-int-strict.cjs');
 
 /**
  * poissonBinomialCDF(probabilities, k) — computes P(X >= k) for heterogeneous trials.
@@ -241,32 +242,46 @@ function computeEarlyEscalation(slotRates, minQuorum, remainingRounds, threshold
 
   const probability = 1 - Math.pow(1 - pPerRound, remainingRounds);
   const rounded = Math.round(probability * 1e6) / 1e6;
-  const result = {
+  return {
     shouldEscalate: rounded < threshold,
     probability: rounded,
     threshold,
     remainingRounds,
     pPerRound: Math.round(pPerRound * 1e6) / 1e6,
   };
-
-  if (clusterOutages.length > 0) {
-    result.clusterOutages = clusterOutages;
-  }
-
-  return result;
 }
 
 // ── CLI entrypoint ───────────────────────────────────────────────────────────
 if (require.main === module) {
   const args = process.argv.slice(2);
   const minQuorumArg = args.find(a => a.startsWith('--min-quorum='));
-  const minQuorum = minQuorumArg ? parseInt(minQuorumArg.split('=')[1], 10) : undefined;
+  let minQuorum;
+  if (minQuorumArg) {
+    minQuorum = parseIntStrict(minQuorumArg.split('=')[1]);
+    if (minQuorum === null || minQuorum < 1) {
+      process.stderr.write(
+        'Usage: quorum-consensus-gate --min-quorum=<positive integer>\n' +
+        `Invalid --min-quorum value: ${JSON.stringify(minQuorumArg.split('=')[1])}\n`,
+      );
+      process.exit(2);
+    }
+  }
 
   const remainingRoundsArg = args.find(a => a.startsWith('--remaining-rounds='));
 
   if (remainingRoundsArg) {
     // HEAL-01: Early escalation mode -- compute P(consensus | remaining rounds)
-    const remainingRounds = parseInt(remainingRoundsArg.split('=')[1], 10);
+    // Fail CLOSED on malformed input (#204): an unvalidated NaN propagated
+    // through Math.pow(...) and produced shouldEscalate:false / probability:null,
+    // silently disabling the early-escalation net. Exit 2 so callers SEE the misuse.
+    const remainingRounds = parseIntStrict(remainingRoundsArg.split('=')[1]);
+    if (remainingRounds === null || remainingRounds < 0) {
+      process.stderr.write(
+        'Usage: quorum-consensus-gate --remaining-rounds=<non-negative integer>\n' +
+        `Invalid --remaining-rounds value: ${JSON.stringify(remainingRoundsArg.split('=')[1])}\n`,
+      );
+      process.exit(2);
+    }
     const pp2 = require('./planning-paths.cjs');
     const scoreboardPath = pp2.resolveWithFallback(process.cwd(), 'quorum-scoreboard');
     let slotRates = null;

--- a/bin/quorum-consensus-gate.test.cjs
+++ b/bin/quorum-consensus-gate.test.cjs
@@ -9,8 +9,31 @@ const assert = require('node:assert');
 const fs     = require('fs');
 const path   = require('path');
 const os     = require('os');
+const { execFileSync } = require('node:child_process');
 
 const { checkConsensusGate, computeConsensusProbability, poissonBinomialCDF } = require('./quorum-consensus-gate.cjs');
+const { parseIntStrict } = require('./parse-int-strict.cjs');
+
+const GATE_CLI = path.join(__dirname, 'quorum-consensus-gate.cjs');
+
+// Run the gate CLI in a clean cwd (so it falls back to prior rates) and capture
+// exit code + stdout + stderr.
+function runGate(args, cwd) {
+  try {
+    const stdout = execFileSync(process.execPath, [GATE_CLI, ...args], {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { code: 0, stdout, stderr: '' };
+  } catch (err) {
+    return {
+      code: typeof err.status === 'number' ? err.status : 1,
+      stdout: err.stdout ? err.stdout.toString() : '',
+      stderr: err.stderr ? err.stderr.toString() : '',
+    };
+  }
+}
 
 let tmpDir;
 
@@ -173,5 +196,73 @@ describe('checkConsensusGate', () => {
     });
     const elapsed = performance.now() - start;
     assert.ok(elapsed < 10, 'Should complete in under 10ms, took: ' + elapsed.toFixed(2) + 'ms');
+  });
+});
+
+// ── parseIntStrict tests (Issue #204) ────────────────────────────────────────
+
+describe('parseIntStrict', () => {
+  test('parses clean non-negative integers', () => {
+    assert.strictEqual(parseIntStrict('0'), 0);
+    assert.strictEqual(parseIntStrict('3'), 3);
+    assert.strictEqual(parseIntStrict('42'), 42);
+    assert.strictEqual(parseIntStrict('  7 '), 7);
+  });
+
+  test('parses signed integers', () => {
+    assert.strictEqual(parseIntStrict('-1'), -1);
+    assert.strictEqual(parseIntStrict('+5'), 5);
+  });
+
+  test('returns null for non-integer / malformed input (no fail-open NaN)', () => {
+    for (const bad of ['', '  ', 'abc', '2.5', '12abc', '0x10', 'NaN', 'Infinity', undefined, null, 3]) {
+      assert.strictEqual(parseIntStrict(bad), null, `expected null for ${JSON.stringify(bad)}`);
+    }
+  });
+});
+
+// ── CLI early-escalation: fail CLOSED on malformed --remaining-rounds (#204) ──
+
+describe('early-escalation CLI --remaining-rounds validation', () => {
+  test('non-numeric --remaining-rounds exits 2 and does NOT emit shouldEscalate:false / probability:null', () => {
+    const res = runGate(['--remaining-rounds=foo'], tmpDir);
+    assert.strictEqual(res.code, 2, 'should exit 2 on malformed input, got ' + res.code);
+    assert.ok(!/shouldEscalate/.test(res.stdout), 'must not emit a result object on stdout');
+    assert.ok(!/probability/.test(res.stdout), 'must not emit probability on stdout');
+    assert.match(res.stderr, /Usage:/, 'should print a usage message to stderr');
+    assert.match(res.stderr, /remaining-rounds/, 'usage should reference the flag');
+  });
+
+  test('empty --remaining-rounds value exits 2', () => {
+    const res = runGate(['--remaining-rounds='], tmpDir);
+    assert.strictEqual(res.code, 2);
+    assert.ok(!/shouldEscalate/.test(res.stdout));
+  });
+
+  test('negative --remaining-rounds exits 2', () => {
+    const res = runGate(['--remaining-rounds=-1'], tmpDir);
+    assert.strictEqual(res.code, 2);
+  });
+
+  test('valid --remaining-rounds still works and emits a result', () => {
+    // Priors (0.85 x4, minQuorum 2) over several rounds -> high P -> continue (exit 0).
+    const res = runGate(['--remaining-rounds=3'], tmpDir);
+    assert.ok(res.code === 0 || res.code === 1, 'valid input should exit 0 or 1, got ' + res.code);
+    // stdout may be prefixed by run-prism diagnostic lines; the result JSON is the
+    // trailing {...} object. Extract from the first '{' to the last '}'.
+    const start = res.stdout.indexOf('{');
+    const end = res.stdout.lastIndexOf('}');
+    assert.ok(start !== -1 && end !== -1, 'expected a JSON result object on stdout');
+    const parsed = JSON.parse(res.stdout.slice(start, end + 1));
+    assert.strictEqual(typeof parsed.probability, 'number', 'probability must be a number, not null');
+    assert.ok(!Number.isNaN(parsed.probability), 'probability must not be NaN');
+    assert.strictEqual(parsed.remainingRounds, 3);
+    assert.strictEqual(typeof parsed.shouldEscalate, 'boolean');
+  });
+
+  test('malformed --min-quorum exits 2', () => {
+    const res = runGate(['--remaining-rounds=3', '--min-quorum=foo'], tmpDir);
+    assert.strictEqual(res.code, 2);
+    assert.match(res.stderr, /min-quorum/);
   });
 });


### PR DESCRIPTION
Closes #204.

## Problem
The HEAL-01 early-escalation gate (`bin/quorum-consensus-gate.cjs`) parsed `--remaining-rounds` with an unvalidated `parseInt(...)`. On a non-numeric value the result was `NaN`, which propagated fail-OPEN through the escalation math:

- `:208` `remainingRounds <= 0` → false (`NaN <= 0` is false)
- `:238` `Math.pow(1 - pPerRound, NaN)` → `NaN`
- `:241` `NaN < threshold` → false

So the CLI emitted `shouldEscalate:false` / `probability:null` and exited `0` ('continue deliberating'). An orchestrator passing a placeholder got a confident 'continue' instead of an error — the early-escalation net silently never fired on malformed input. The trailing `clusterOutages` branch at the end of `computeEarlyEscalation` was also dead (the cluster-outage case returns earlier in the function).

## Changes
- Add shared `bin/parse-int-strict.cjs` (`parseIntStrict`) that rejects non-string, empty, fractional, and trailing-garbage input by returning `null`, instead of `parseInt`'s lenient/`NaN` behavior (numeric-CLI-arg class #183).
- Validate `--remaining-rounds` (`>= 0`) and `--min-quorum` (`>= 1`) in the CLI entrypoint; on misuse, print a usage message to **stderr** and `process.exit(2)` so callers SEE the misuse instead of a fail-open continue.
- Remove the dead `clusterOutages` branch in `computeEarlyEscalation`.

## Tests
Appended to `bin/quorum-consensus-gate.test.cjs` (already in `test:ci`):
- `parseIntStrict` unit coverage (valid ints, signed, and the null cases).
- Non-numeric `--remaining-rounds` exits `2` and emits **no** `shouldEscalate` / `probability` on stdout; empty and negative values also exit `2`; malformed `--min-quorum` exits `2`.
- A valid `--remaining-rounds` still produces a numeric (non-null, non-NaN) `probability`.

`node --test bin/quorum-consensus-gate.test.cjs test/quorum-consensus-gate-cluster.test.cjs` → 49 pass / 0 fail. `node scripts/lint-isolation.js` → pass.

Part of the 2026-06 quorum-hardening series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)