### PR TITLE
feat(statusline): line-1 quorum indicator + background self-refresh

### DIFF
--- a/hooks/dist/nf-statusline.js
+++ b/hooks/dist/nf-statusline.js
@@ -5,7 +5,7 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { spawnSync } = require('child_process');
+const { spawnSync, spawn } = require('child_process');
 const { loadConfig, shouldRunHook, validateHookInput } = require('./config-loader');
 
 // Detect context window size from data
@@ -161,6 +161,71 @@ function buildSlotsLine(homeDir) {
   return parts.join(' \x1b[2m│\x1b[0m ');
 }
 
+// Compact one-line quorum indicator for line 1 of the statusline, so quorum
+// health is visible even when the terminal only paints the first status row
+// (multi-line status lines depend on vertical space). Reuses the same cache +
+// freshness logic as buildSlotsLine.
+//   N● quorum   (green)  — all N MCP-registered slots healthy & fresh
+//   H/N⊘ quorum (red)    — H of N healthy (some down)
+//   N○ quorum   (dim)    — no fresh probe data yet (cache stale/missing)
+function buildQuorumSummary(homeDir) {
+  const providersPath = path.join(homeDir, '.claude', 'nf-bin', 'providers.json');
+  const claudeJsonPath = path.join(homeDir, '.claude.json');
+  const cachePath = path.join(homeDir, '.claude', 'nf', 'slot-health.json');
+
+  let providers, mcpServers, cache;
+  try { providers = JSON.parse(fs.readFileSync(providersPath, 'utf8')).providers; } catch (_) { return null; }
+  if (!Array.isArray(providers) || providers.length === 0) return null;
+  try { mcpServers = JSON.parse(fs.readFileSync(claudeJsonPath, 'utf8')).mcpServers || {}; } catch (_) { mcpServers = {}; }
+  try { cache = JSON.parse(fs.readFileSync(cachePath, 'utf8')); } catch (_) { cache = null; }
+
+  const FRESH_MS = 5 * 60 * 1000;
+  const checkedAt = cache && cache.checked_at ? Date.parse(cache.checked_at) : 0;
+  const fresh = checkedAt && (Date.now() - checkedAt) < FRESH_MS;
+
+  const mcpSlots = providers.filter(p => mcpServers[p.name]);
+  const total = mcpSlots.length;
+  if (total === 0) return null;
+
+  if (!fresh) return `\x1b[2m${total}○ quorum\x1b[0m`;
+  const healthy = mcpSlots.filter(p => { const e = cache.slots && cache.slots[p.name]; return e && e.ok; }).length;
+  if (healthy === total) return `\x1b[32m${total}● quorum\x1b[0m`;
+  return `\x1b[31m${healthy}/${total}⊘ quorum\x1b[0m`;
+}
+
+// Fire-and-forget: if the slot-health cache is stale/missing, kick off the
+// probe in a DETACHED background process so the NEXT render is fresh. The
+// statusline itself must stay instant — this never blocks. Throttled so a slow
+// probe can't cause spawn storms across frequent statusline renders.
+function maybeRefreshSlotCache(homeDir) {
+  try {
+    const nfDir = path.join(homeDir, '.claude', 'nf');
+    const cachePath = path.join(nfDir, 'slot-health.json');
+    const markerPath = path.join(nfDir, '.slot-probe-spawned');
+    const FRESH_MS = 5 * 60 * 1000;
+    const THROTTLE_MS = 60 * 1000;
+
+    // Still fresh → nothing to do.
+    try {
+      const c = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
+      if (c.checked_at && (Date.now() - Date.parse(c.checked_at)) < FRESH_MS) return;
+    } catch (_) { /* missing/unreadable → refresh */ }
+
+    // Don't spawn again if we spawned a probe recently.
+    try {
+      const m = fs.statSync(markerPath);
+      if (Date.now() - m.mtimeMs < THROTTLE_MS) return;
+    } catch (_) { /* no marker yet → ok to spawn */ }
+
+    const probe = path.join(homeDir, '.claude', 'hooks', 'nf-slot-health-probe.js');
+    if (!fs.existsSync(probe)) return;
+    try { fs.mkdirSync(nfDir, { recursive: true }); } catch (_) {}
+    try { fs.writeFileSync(markerPath, String(Date.now())); } catch (_) {}
+    const child = spawn(process.execPath, [probe], { detached: true, stdio: 'ignore' });
+    child.unref();
+  } catch (_) { /* never block the statusline */ }
+}
+
 // Read JSON from stdin
 let input = '';
 process.stdin.setEncoding('utf8');
@@ -305,12 +370,23 @@ process.stdin.on('end', () => {
       } catch (e) {}
     }
 
+    // Kick off a background slot-health refresh if the cache is stale (non-blocking).
+    try { maybeRefreshSlotCache(homeDir); } catch (_e) {}
+
+    // Compact quorum indicator for line 1 — always visible even when the terminal
+    // only paints the first status row.
+    let quorumTag = '';
+    try {
+      const q = buildQuorumSummary(homeDir);
+      if (q) quorumTag = ` \x1b[2m│\x1b[0m ${q}`;
+    } catch (_e) {}
+
     // Output (tools line is assembled and written after the main line)
     const dirname = path.basename(dir);
     if (task) {
-      process.stdout.write(`${nfUpdate}\x1b[2m${model}\x1b[0m │ \x1b[1m${task}\x1b[0m │ \x1b[2m${dirname}\x1b[0m${ctx}`);
+      process.stdout.write(`${nfUpdate}\x1b[2m${model}\x1b[0m │ \x1b[1m${task}\x1b[0m │ \x1b[2m${dirname}\x1b[0m${ctx}${quorumTag}`);
     } else {
-      process.stdout.write(`${nfUpdate}\x1b[2m${model}\x1b[0m │ \x1b[2m${dirname}\x1b[0m${ctx}`);
+      process.stdout.write(`${nfUpdate}\x1b[2m${model}\x1b[0m │ \x1b[2m${dirname}\x1b[0m${ctx}${quorumTag}`);
     }
 
     // Quorum slots line (above the tools line)

--- a/hooks/dist/nf-statusline.js
+++ b/hooks/dist/nf-statusline.js
@@ -123,24 +123,39 @@ function buildToolsLine(homeDir, dir) {
   return parts.join(' \x1b[2m│\x1b[0m ');
 }
 
-// Build the quorum-slots line. Reads providers.json (the configured slot inventory),
-// ~/.claude.json mcpServers (which slots are MCP-registered), and the slot-health
-// cache written by nf-slot-health-probe.js. Statusline rendering must stay fast,
-// so this is purely cache-read — the probe runs out-of-band (e.g. SessionStart).
-function buildSlotsLine(homeDir) {
+const SLOT_FRESH_MS = 5 * 60 * 1000;
+
+// Read the slot-health context ONCE per render: providers.json (configured slot
+// inventory), ~/.claude.json mcpServers (which slots are MCP-registered), and the
+// slot-health cache written by nf-slot-health-probe.js. Returns null when there is
+// no usable provider inventory. Null/invalid provider entries are dropped here so
+// every consumer can assume `{ name }`. Statusline rendering must stay fast, so
+// this is a pure cache-read — the probe runs out-of-band (SessionStart / the
+// background refresh below).
+function readSlotHealth(homeDir) {
   const providersPath = path.join(homeDir, '.claude', 'nf-bin', 'providers.json');
   const claudeJsonPath = path.join(homeDir, '.claude.json');
   const cachePath = path.join(homeDir, '.claude', 'nf', 'slot-health.json');
 
   let providers, mcpServers, cache;
-  try { providers = JSON.parse(fs.readFileSync(providersPath, 'utf8')).providers; } catch (_) { return null; }
-  if (!Array.isArray(providers) || providers.length === 0) return null;
+  try { providers = JSON.parse(fs.readFileSync(providersPath, 'utf8')).providers; } catch (_) { providers = null; }
+  if (!Array.isArray(providers)) return null;
+  providers = providers.filter(p => p && typeof p.name === 'string' && p.name);
+  if (providers.length === 0) return null;
   try { mcpServers = JSON.parse(fs.readFileSync(claudeJsonPath, 'utf8')).mcpServers || {}; } catch (_) { mcpServers = {}; }
   try { cache = JSON.parse(fs.readFileSync(cachePath, 'utf8')); } catch (_) { cache = null; }
 
-  const FRESH_MS = 5 * 60 * 1000;
   const checkedAt = cache && cache.checked_at ? Date.parse(cache.checked_at) : 0;
-  const fresh = checkedAt && (Date.now() - checkedAt) < FRESH_MS;
+  const fresh = !!(checkedAt && (Date.now() - checkedAt) < SLOT_FRESH_MS);
+  return { providers, mcpServers, cache, fresh };
+}
+
+// Build the detailed per-slot row (line 2). `ctx` is the shared readSlotHealth()
+// result so a render doesn't re-read the same files three times.
+function buildSlotsLine(homeDir, ctx) {
+  const h = ctx || readSlotHealth(homeDir);
+  if (!h) return null;
+  const { providers, mcpServers, cache, fresh } = h;
 
   const parts = [];
   for (const p of providers) {
@@ -161,55 +176,38 @@ function buildSlotsLine(homeDir) {
   return parts.join(' \x1b[2m│\x1b[0m ');
 }
 
-// Compact one-line quorum indicator for line 1 of the statusline, so quorum
-// health is visible even when the terminal only paints the first status row
-// (multi-line status lines depend on vertical space). Reuses the same cache +
-// freshness logic as buildSlotsLine.
+// Compact one-line quorum indicator for line 1, so quorum health is visible even
+// when the terminal only paints the first status row (multi-line status lines
+// depend on vertical space). `ctx` is the shared readSlotHealth() result.
 //   N● quorum   (green)  — all N MCP-registered slots healthy & fresh
 //   H/N⊘ quorum (red)    — H of N healthy (some down)
 //   N○ quorum   (dim)    — no fresh probe data yet (cache stale/missing)
-function buildQuorumSummary(homeDir) {
-  const providersPath = path.join(homeDir, '.claude', 'nf-bin', 'providers.json');
-  const claudeJsonPath = path.join(homeDir, '.claude.json');
-  const cachePath = path.join(homeDir, '.claude', 'nf', 'slot-health.json');
-
-  let providers, mcpServers, cache;
-  try { providers = JSON.parse(fs.readFileSync(providersPath, 'utf8')).providers; } catch (_) { return null; }
-  if (!Array.isArray(providers) || providers.length === 0) return null;
-  try { mcpServers = JSON.parse(fs.readFileSync(claudeJsonPath, 'utf8')).mcpServers || {}; } catch (_) { mcpServers = {}; }
-  try { cache = JSON.parse(fs.readFileSync(cachePath, 'utf8')); } catch (_) { cache = null; }
-
-  const FRESH_MS = 5 * 60 * 1000;
-  const checkedAt = cache && cache.checked_at ? Date.parse(cache.checked_at) : 0;
-  const fresh = checkedAt && (Date.now() - checkedAt) < FRESH_MS;
+function buildQuorumSummary(homeDir, ctx) {
+  const h = ctx || readSlotHealth(homeDir);
+  if (!h) return null;
+  const { providers, mcpServers, cache, fresh } = h;
 
   const mcpSlots = providers.filter(p => mcpServers[p.name]);
   const total = mcpSlots.length;
   if (total === 0) return null;
 
   if (!fresh) return `\x1b[2m${total}○ quorum\x1b[0m`;
-  const healthy = mcpSlots.filter(p => { const e = cache.slots && cache.slots[p.name]; return e && e.ok; }).length;
+  const healthy = mcpSlots.filter(p => { const e = cache && cache.slots && cache.slots[p.name]; return e && e.ok; }).length;
   if (healthy === total) return `\x1b[32m${total}● quorum\x1b[0m`;
   return `\x1b[31m${healthy}/${total}⊘ quorum\x1b[0m`;
 }
 
-// Fire-and-forget: if the slot-health cache is stale/missing, kick off the
-// probe in a DETACHED background process so the NEXT render is fresh. The
-// statusline itself must stay instant — this never blocks. Throttled so a slow
-// probe can't cause spawn storms across frequent statusline renders.
-function maybeRefreshSlotCache(homeDir) {
+// Fire-and-forget: when the slot-health cache is NOT fresh, kick off the probe in
+// a DETACHED background process so the NEXT render reads fresh. The statusline
+// itself must stay instant — this never blocks. Throttled (1/min) so a slow probe
+// can't cause spawn storms across frequent renders. `fresh` comes from the shared
+// readSlotHealth() result so we don't re-read the cache here.
+function maybeRefreshSlotCache(homeDir, fresh) {
   try {
+    if (fresh) return; // already fresh — nothing to do
     const nfDir = path.join(homeDir, '.claude', 'nf');
-    const cachePath = path.join(nfDir, 'slot-health.json');
     const markerPath = path.join(nfDir, '.slot-probe-spawned');
-    const FRESH_MS = 5 * 60 * 1000;
     const THROTTLE_MS = 60 * 1000;
-
-    // Still fresh → nothing to do.
-    try {
-      const c = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
-      if (c.checked_at && (Date.now() - Date.parse(c.checked_at)) < FRESH_MS) return;
-    } catch (_) { /* missing/unreadable → refresh */ }
 
     // Don't spawn again if we spawned a probe recently.
     try {
@@ -370,14 +368,20 @@ process.stdin.on('end', () => {
       } catch (e) {}
     }
 
+    // Read the slot-health context ONCE and share it across the quorum tag,
+    // the slots row, and the background-refresh decision (avoids re-reading the
+    // same HOME-scoped JSON files three times per render).
+    let slotHealth = null;
+    try { slotHealth = readSlotHealth(homeDir); } catch (_e) {}
+
     // Kick off a background slot-health refresh if the cache is stale (non-blocking).
-    try { maybeRefreshSlotCache(homeDir); } catch (_e) {}
+    try { maybeRefreshSlotCache(homeDir, slotHealth ? slotHealth.fresh : false); } catch (_e) {}
 
     // Compact quorum indicator for line 1 — always visible even when the terminal
     // only paints the first status row.
     let quorumTag = '';
     try {
-      const q = buildQuorumSummary(homeDir);
+      const q = buildQuorumSummary(homeDir, slotHealth);
       if (q) quorumTag = ` \x1b[2m│\x1b[0m ${q}`;
     } catch (_e) {}
 
@@ -391,7 +395,7 @@ process.stdin.on('end', () => {
 
     // Quorum slots line (above the tools line)
     try {
-      const slotsLine = buildSlotsLine(homeDir);
+      const slotsLine = buildSlotsLine(homeDir, slotHealth);
       if (slotsLine) {
         process.stdout.write('\n' + slotsLine);
       }

--- a/hooks/dist/nf-statusline.js
+++ b/hooks/dist/nf-statusline.js
@@ -375,7 +375,10 @@ process.stdin.on('end', () => {
     try { slotHealth = readSlotHealth(homeDir); } catch (_e) {}
 
     // Kick off a background slot-health refresh if the cache is stale (non-blocking).
-    try { maybeRefreshSlotCache(homeDir, slotHealth ? slotHealth.fresh : false); } catch (_e) {}
+    // Only when there's a provider inventory to probe — if readSlotHealth returned
+    // null (providers.json missing/unreadable), spawning the probe every render
+    // would be pointless churn.
+    if (slotHealth) { try { maybeRefreshSlotCache(homeDir, slotHealth.fresh); } catch (_e) {} }
 
     // Compact quorum indicator for line 1 — always visible even when the terminal
     // only paints the first status row.

--- a/hooks/nf-statusline.js
+++ b/hooks/nf-statusline.js
@@ -5,7 +5,7 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { spawnSync } = require('child_process');
+const { spawnSync, spawn } = require('child_process');
 const { loadConfig, shouldRunHook, validateHookInput } = require('./config-loader');
 
 // Detect context window size from data
@@ -161,6 +161,71 @@ function buildSlotsLine(homeDir) {
   return parts.join(' \x1b[2m│\x1b[0m ');
 }
 
+// Compact one-line quorum indicator for line 1 of the statusline, so quorum
+// health is visible even when the terminal only paints the first status row
+// (multi-line status lines depend on vertical space). Reuses the same cache +
+// freshness logic as buildSlotsLine.
+//   N● quorum   (green)  — all N MCP-registered slots healthy & fresh
+//   H/N⊘ quorum (red)    — H of N healthy (some down)
+//   N○ quorum   (dim)    — no fresh probe data yet (cache stale/missing)
+function buildQuorumSummary(homeDir) {
+  const providersPath = path.join(homeDir, '.claude', 'nf-bin', 'providers.json');
+  const claudeJsonPath = path.join(homeDir, '.claude.json');
+  const cachePath = path.join(homeDir, '.claude', 'nf', 'slot-health.json');
+
+  let providers, mcpServers, cache;
+  try { providers = JSON.parse(fs.readFileSync(providersPath, 'utf8')).providers; } catch (_) { return null; }
+  if (!Array.isArray(providers) || providers.length === 0) return null;
+  try { mcpServers = JSON.parse(fs.readFileSync(claudeJsonPath, 'utf8')).mcpServers || {}; } catch (_) { mcpServers = {}; }
+  try { cache = JSON.parse(fs.readFileSync(cachePath, 'utf8')); } catch (_) { cache = null; }
+
+  const FRESH_MS = 5 * 60 * 1000;
+  const checkedAt = cache && cache.checked_at ? Date.parse(cache.checked_at) : 0;
+  const fresh = checkedAt && (Date.now() - checkedAt) < FRESH_MS;
+
+  const mcpSlots = providers.filter(p => mcpServers[p.name]);
+  const total = mcpSlots.length;
+  if (total === 0) return null;
+
+  if (!fresh) return `\x1b[2m${total}○ quorum\x1b[0m`;
+  const healthy = mcpSlots.filter(p => { const e = cache.slots && cache.slots[p.name]; return e && e.ok; }).length;
+  if (healthy === total) return `\x1b[32m${total}● quorum\x1b[0m`;
+  return `\x1b[31m${healthy}/${total}⊘ quorum\x1b[0m`;
+}
+
+// Fire-and-forget: if the slot-health cache is stale/missing, kick off the
+// probe in a DETACHED background process so the NEXT render is fresh. The
+// statusline itself must stay instant — this never blocks. Throttled so a slow
+// probe can't cause spawn storms across frequent statusline renders.
+function maybeRefreshSlotCache(homeDir) {
+  try {
+    const nfDir = path.join(homeDir, '.claude', 'nf');
+    const cachePath = path.join(nfDir, 'slot-health.json');
+    const markerPath = path.join(nfDir, '.slot-probe-spawned');
+    const FRESH_MS = 5 * 60 * 1000;
+    const THROTTLE_MS = 60 * 1000;
+
+    // Still fresh → nothing to do.
+    try {
+      const c = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
+      if (c.checked_at && (Date.now() - Date.parse(c.checked_at)) < FRESH_MS) return;
+    } catch (_) { /* missing/unreadable → refresh */ }
+
+    // Don't spawn again if we spawned a probe recently.
+    try {
+      const m = fs.statSync(markerPath);
+      if (Date.now() - m.mtimeMs < THROTTLE_MS) return;
+    } catch (_) { /* no marker yet → ok to spawn */ }
+
+    const probe = path.join(homeDir, '.claude', 'hooks', 'nf-slot-health-probe.js');
+    if (!fs.existsSync(probe)) return;
+    try { fs.mkdirSync(nfDir, { recursive: true }); } catch (_) {}
+    try { fs.writeFileSync(markerPath, String(Date.now())); } catch (_) {}
+    const child = spawn(process.execPath, [probe], { detached: true, stdio: 'ignore' });
+    child.unref();
+  } catch (_) { /* never block the statusline */ }
+}
+
 // Read JSON from stdin
 let input = '';
 process.stdin.setEncoding('utf8');
@@ -305,12 +370,23 @@ process.stdin.on('end', () => {
       } catch (e) {}
     }
 
+    // Kick off a background slot-health refresh if the cache is stale (non-blocking).
+    try { maybeRefreshSlotCache(homeDir); } catch (_e) {}
+
+    // Compact quorum indicator for line 1 — always visible even when the terminal
+    // only paints the first status row.
+    let quorumTag = '';
+    try {
+      const q = buildQuorumSummary(homeDir);
+      if (q) quorumTag = ` \x1b[2m│\x1b[0m ${q}`;
+    } catch (_e) {}
+
     // Output (tools line is assembled and written after the main line)
     const dirname = path.basename(dir);
     if (task) {
-      process.stdout.write(`${nfUpdate}\x1b[2m${model}\x1b[0m │ \x1b[1m${task}\x1b[0m │ \x1b[2m${dirname}\x1b[0m${ctx}`);
+      process.stdout.write(`${nfUpdate}\x1b[2m${model}\x1b[0m │ \x1b[1m${task}\x1b[0m │ \x1b[2m${dirname}\x1b[0m${ctx}${quorumTag}`);
     } else {
-      process.stdout.write(`${nfUpdate}\x1b[2m${model}\x1b[0m │ \x1b[2m${dirname}\x1b[0m${ctx}`);
+      process.stdout.write(`${nfUpdate}\x1b[2m${model}\x1b[0m │ \x1b[2m${dirname}\x1b[0m${ctx}${quorumTag}`);
     }
 
     // Quorum slots line (above the tools line)

--- a/hooks/nf-statusline.js
+++ b/hooks/nf-statusline.js
@@ -123,24 +123,39 @@ function buildToolsLine(homeDir, dir) {
   return parts.join(' \x1b[2m│\x1b[0m ');
 }
 
-// Build the quorum-slots line. Reads providers.json (the configured slot inventory),
-// ~/.claude.json mcpServers (which slots are MCP-registered), and the slot-health
-// cache written by nf-slot-health-probe.js. Statusline rendering must stay fast,
-// so this is purely cache-read — the probe runs out-of-band (e.g. SessionStart).
-function buildSlotsLine(homeDir) {
+const SLOT_FRESH_MS = 5 * 60 * 1000;
+
+// Read the slot-health context ONCE per render: providers.json (configured slot
+// inventory), ~/.claude.json mcpServers (which slots are MCP-registered), and the
+// slot-health cache written by nf-slot-health-probe.js. Returns null when there is
+// no usable provider inventory. Null/invalid provider entries are dropped here so
+// every consumer can assume `{ name }`. Statusline rendering must stay fast, so
+// this is a pure cache-read — the probe runs out-of-band (SessionStart / the
+// background refresh below).
+function readSlotHealth(homeDir) {
   const providersPath = path.join(homeDir, '.claude', 'nf-bin', 'providers.json');
   const claudeJsonPath = path.join(homeDir, '.claude.json');
   const cachePath = path.join(homeDir, '.claude', 'nf', 'slot-health.json');
 
   let providers, mcpServers, cache;
-  try { providers = JSON.parse(fs.readFileSync(providersPath, 'utf8')).providers; } catch (_) { return null; }
-  if (!Array.isArray(providers) || providers.length === 0) return null;
+  try { providers = JSON.parse(fs.readFileSync(providersPath, 'utf8')).providers; } catch (_) { providers = null; }
+  if (!Array.isArray(providers)) return null;
+  providers = providers.filter(p => p && typeof p.name === 'string' && p.name);
+  if (providers.length === 0) return null;
   try { mcpServers = JSON.parse(fs.readFileSync(claudeJsonPath, 'utf8')).mcpServers || {}; } catch (_) { mcpServers = {}; }
   try { cache = JSON.parse(fs.readFileSync(cachePath, 'utf8')); } catch (_) { cache = null; }
 
-  const FRESH_MS = 5 * 60 * 1000;
   const checkedAt = cache && cache.checked_at ? Date.parse(cache.checked_at) : 0;
-  const fresh = checkedAt && (Date.now() - checkedAt) < FRESH_MS;
+  const fresh = !!(checkedAt && (Date.now() - checkedAt) < SLOT_FRESH_MS);
+  return { providers, mcpServers, cache, fresh };
+}
+
+// Build the detailed per-slot row (line 2). `ctx` is the shared readSlotHealth()
+// result so a render doesn't re-read the same files three times.
+function buildSlotsLine(homeDir, ctx) {
+  const h = ctx || readSlotHealth(homeDir);
+  if (!h) return null;
+  const { providers, mcpServers, cache, fresh } = h;
 
   const parts = [];
   for (const p of providers) {
@@ -161,55 +176,38 @@ function buildSlotsLine(homeDir) {
   return parts.join(' \x1b[2m│\x1b[0m ');
 }
 
-// Compact one-line quorum indicator for line 1 of the statusline, so quorum
-// health is visible even when the terminal only paints the first status row
-// (multi-line status lines depend on vertical space). Reuses the same cache +
-// freshness logic as buildSlotsLine.
+// Compact one-line quorum indicator for line 1, so quorum health is visible even
+// when the terminal only paints the first status row (multi-line status lines
+// depend on vertical space). `ctx` is the shared readSlotHealth() result.
 //   N● quorum   (green)  — all N MCP-registered slots healthy & fresh
 //   H/N⊘ quorum (red)    — H of N healthy (some down)
 //   N○ quorum   (dim)    — no fresh probe data yet (cache stale/missing)
-function buildQuorumSummary(homeDir) {
-  const providersPath = path.join(homeDir, '.claude', 'nf-bin', 'providers.json');
-  const claudeJsonPath = path.join(homeDir, '.claude.json');
-  const cachePath = path.join(homeDir, '.claude', 'nf', 'slot-health.json');
-
-  let providers, mcpServers, cache;
-  try { providers = JSON.parse(fs.readFileSync(providersPath, 'utf8')).providers; } catch (_) { return null; }
-  if (!Array.isArray(providers) || providers.length === 0) return null;
-  try { mcpServers = JSON.parse(fs.readFileSync(claudeJsonPath, 'utf8')).mcpServers || {}; } catch (_) { mcpServers = {}; }
-  try { cache = JSON.parse(fs.readFileSync(cachePath, 'utf8')); } catch (_) { cache = null; }
-
-  const FRESH_MS = 5 * 60 * 1000;
-  const checkedAt = cache && cache.checked_at ? Date.parse(cache.checked_at) : 0;
-  const fresh = checkedAt && (Date.now() - checkedAt) < FRESH_MS;
+function buildQuorumSummary(homeDir, ctx) {
+  const h = ctx || readSlotHealth(homeDir);
+  if (!h) return null;
+  const { providers, mcpServers, cache, fresh } = h;
 
   const mcpSlots = providers.filter(p => mcpServers[p.name]);
   const total = mcpSlots.length;
   if (total === 0) return null;
 
   if (!fresh) return `\x1b[2m${total}○ quorum\x1b[0m`;
-  const healthy = mcpSlots.filter(p => { const e = cache.slots && cache.slots[p.name]; return e && e.ok; }).length;
+  const healthy = mcpSlots.filter(p => { const e = cache && cache.slots && cache.slots[p.name]; return e && e.ok; }).length;
   if (healthy === total) return `\x1b[32m${total}● quorum\x1b[0m`;
   return `\x1b[31m${healthy}/${total}⊘ quorum\x1b[0m`;
 }
 
-// Fire-and-forget: if the slot-health cache is stale/missing, kick off the
-// probe in a DETACHED background process so the NEXT render is fresh. The
-// statusline itself must stay instant — this never blocks. Throttled so a slow
-// probe can't cause spawn storms across frequent statusline renders.
-function maybeRefreshSlotCache(homeDir) {
+// Fire-and-forget: when the slot-health cache is NOT fresh, kick off the probe in
+// a DETACHED background process so the NEXT render reads fresh. The statusline
+// itself must stay instant — this never blocks. Throttled (1/min) so a slow probe
+// can't cause spawn storms across frequent renders. `fresh` comes from the shared
+// readSlotHealth() result so we don't re-read the cache here.
+function maybeRefreshSlotCache(homeDir, fresh) {
   try {
+    if (fresh) return; // already fresh — nothing to do
     const nfDir = path.join(homeDir, '.claude', 'nf');
-    const cachePath = path.join(nfDir, 'slot-health.json');
     const markerPath = path.join(nfDir, '.slot-probe-spawned');
-    const FRESH_MS = 5 * 60 * 1000;
     const THROTTLE_MS = 60 * 1000;
-
-    // Still fresh → nothing to do.
-    try {
-      const c = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
-      if (c.checked_at && (Date.now() - Date.parse(c.checked_at)) < FRESH_MS) return;
-    } catch (_) { /* missing/unreadable → refresh */ }
 
     // Don't spawn again if we spawned a probe recently.
     try {
@@ -370,14 +368,20 @@ process.stdin.on('end', () => {
       } catch (e) {}
     }
 
+    // Read the slot-health context ONCE and share it across the quorum tag,
+    // the slots row, and the background-refresh decision (avoids re-reading the
+    // same HOME-scoped JSON files three times per render).
+    let slotHealth = null;
+    try { slotHealth = readSlotHealth(homeDir); } catch (_e) {}
+
     // Kick off a background slot-health refresh if the cache is stale (non-blocking).
-    try { maybeRefreshSlotCache(homeDir); } catch (_e) {}
+    try { maybeRefreshSlotCache(homeDir, slotHealth ? slotHealth.fresh : false); } catch (_e) {}
 
     // Compact quorum indicator for line 1 — always visible even when the terminal
     // only paints the first status row.
     let quorumTag = '';
     try {
-      const q = buildQuorumSummary(homeDir);
+      const q = buildQuorumSummary(homeDir, slotHealth);
       if (q) quorumTag = ` \x1b[2m│\x1b[0m ${q}`;
     } catch (_e) {}
 
@@ -391,7 +395,7 @@ process.stdin.on('end', () => {
 
     // Quorum slots line (above the tools line)
     try {
-      const slotsLine = buildSlotsLine(homeDir);
+      const slotsLine = buildSlotsLine(homeDir, slotHealth);
       if (slotsLine) {
         process.stdout.write('\n' + slotsLine);
       }

--- a/hooks/nf-statusline.js
+++ b/hooks/nf-statusline.js
@@ -375,7 +375,10 @@ process.stdin.on('end', () => {
     try { slotHealth = readSlotHealth(homeDir); } catch (_e) {}
 
     // Kick off a background slot-health refresh if the cache is stale (non-blocking).
-    try { maybeRefreshSlotCache(homeDir, slotHealth ? slotHealth.fresh : false); } catch (_e) {}
+    // Only when there's a provider inventory to probe — if readSlotHealth returned
+    // null (providers.json missing/unreadable), spawning the probe every render
+    // would be pointless churn.
+    if (slotHealth) { try { maybeRefreshSlotCache(homeDir, slotHealth.fresh); } catch (_e) {} }
 
     // Compact quorum indicator for line 1 — always visible even when the terminal
     // only paints the first status row.

--- a/hooks/nf-statusline.test.js
+++ b/hooks/nf-statusline.test.js
@@ -860,3 +860,76 @@ test('TC38: slots line renders above tools line', () => {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
 });
+
+// ── Line-1 compact quorum indicator (buildQuorumSummary) ────────────────────
+// Reuses setupSlotsHome(); the indicator is the LAST element of stdout line 1.
+function line1(stdout) { return (stdout.split('\n')[0] || ''); }
+const qsFreshIso = () => new Date(Date.now() - 1000).toISOString();
+const qsStaleIso = () => new Date(Date.now() - 10 * 60 * 1000).toISOString();
+
+test('QS1: all MCP slots healthy + fresh -> green N dot quorum on line 1', () => {
+  const tempHome = setupSlotsHome('qs1', {
+    providers: [{ name: 'codex-1' }, { name: 'gemini-1' }, { name: 'claude-1' }],
+    mcpServers: { 'codex-1': {}, 'gemini-1': {}, 'claude-1': {} },
+    health: { checked_at: qsFreshIso(), slots: { 'codex-1': { ok: true }, 'gemini-1': { ok: true }, 'claude-1': { ok: true } } },
+  });
+  const tempDir = makeTempDir('qs1-dir');
+  try {
+    const { stdout, exitCode } = runHook({ model: { display_name: 'M' }, workspace: { current_dir: tempDir } }, { HOME: tempHome });
+    assert.strictEqual(exitCode, 0);
+    assert.ok(line1(stdout).includes('\x1b[32m3● quorum\x1b[0m'), `expected green 3 dot quorum; got: ${JSON.stringify(line1(stdout))}`);
+  } finally { fs.rmSync(tempHome, { recursive: true, force: true }); fs.rmSync(tempDir, { recursive: true, force: true }); }
+});
+
+test('QS2: some slots down + fresh -> red H/N quorum', () => {
+  const tempHome = setupSlotsHome('qs2', {
+    providers: [{ name: 'codex-1' }, { name: 'gemini-1' }, { name: 'claude-1' }],
+    mcpServers: { 'codex-1': {}, 'gemini-1': {}, 'claude-1': {} },
+    health: { checked_at: qsFreshIso(), slots: { 'codex-1': { ok: true }, 'gemini-1': { ok: false }, 'claude-1': { ok: true } } },
+  });
+  const tempDir = makeTempDir('qs2-dir');
+  try {
+    const { stdout } = runHook({ model: { display_name: 'M' }, workspace: { current_dir: tempDir } }, { HOME: tempHome });
+    assert.ok(line1(stdout).includes('\x1b[31m2/3⊘ quorum\x1b[0m'), `expected red 2/3 quorum; got: ${JSON.stringify(line1(stdout))}`);
+  } finally { fs.rmSync(tempHome, { recursive: true, force: true }); fs.rmSync(tempDir, { recursive: true, force: true }); }
+});
+
+test('QS3: stale cache -> dim N circle quorum', () => {
+  const tempHome = setupSlotsHome('qs3', {
+    providers: [{ name: 'codex-1' }, { name: 'gemini-1' }],
+    mcpServers: { 'codex-1': {}, 'gemini-1': {} },
+    health: { checked_at: qsStaleIso(), slots: { 'codex-1': { ok: true }, 'gemini-1': { ok: true } } },
+  });
+  const tempDir = makeTempDir('qs3-dir');
+  try {
+    const { stdout } = runHook({ model: { display_name: 'M' }, workspace: { current_dir: tempDir } }, { HOME: tempHome });
+    assert.ok(line1(stdout).includes('2○ quorum'), `expected dim 2 circle quorum; got: ${JSON.stringify(line1(stdout))}`);
+  } finally { fs.rmSync(tempHome, { recursive: true, force: true }); fs.rmSync(tempDir, { recursive: true, force: true }); }
+});
+
+test('QS4: missing cache -> dim N circle quorum (no crash)', () => {
+  const tempHome = setupSlotsHome('qs4', {
+    providers: [{ name: 'codex-1' }],
+    mcpServers: { 'codex-1': {} },
+  });
+  const tempDir = makeTempDir('qs4-dir');
+  try {
+    const { stdout, exitCode } = runHook({ model: { display_name: 'M' }, workspace: { current_dir: tempDir } }, { HOME: tempHome });
+    assert.strictEqual(exitCode, 0);
+    assert.ok(line1(stdout).includes('1○ quorum'), `expected dim 1 circle quorum; got: ${JSON.stringify(line1(stdout))}`);
+  } finally { fs.rmSync(tempHome, { recursive: true, force: true }); fs.rmSync(tempDir, { recursive: true, force: true }); }
+});
+
+test('QS5: null/invalid provider entries are dropped, not crashed (robustness)', () => {
+  const tempHome = setupSlotsHome('qs5', {
+    providers: [null, { name: 'codex-1' }, { foo: 'bar' }],
+    mcpServers: { 'codex-1': {} },
+    health: { checked_at: qsFreshIso(), slots: { 'codex-1': { ok: true } } },
+  });
+  const tempDir = makeTempDir('qs5-dir');
+  try {
+    const { stdout, exitCode } = runHook({ model: { display_name: 'M' }, workspace: { current_dir: tempDir } }, { HOME: tempHome });
+    assert.strictEqual(exitCode, 0);
+    assert.ok(line1(stdout).includes('\x1b[32m1● quorum\x1b[0m'), `expected green 1 dot quorum; got: ${JSON.stringify(line1(stdout))}`);
+  } finally { fs.rmSync(tempHome, { recursive: true, force: true }); fs.rmSync(tempDir, { recursive: true, force: true }); }
+});

--- a/hooks/nf-statusline.test.js
+++ b/hooks/nf-statusline.test.js
@@ -933,3 +933,39 @@ test('QS5: null/invalid provider entries are dropped, not crashed (robustness)',
     assert.ok(line1(stdout).includes('\x1b[32m1● quorum\x1b[0m'), `expected green 1 dot quorum; got: ${JSON.stringify(line1(stdout))}`);
   } finally { fs.rmSync(tempHome, { recursive: true, force: true }); fs.rmSync(tempDir, { recursive: true, force: true }); }
 });
+
+// ── Background self-refresh (maybeRefreshSlotCache) ─────────────────────────
+test('QS6: stale/missing cache + probe present -> creates throttle marker, throttled on 2nd render', () => {
+  const tempHome = setupSlotsHome('qs6', {
+    providers: [{ name: 'codex-1' }],
+    mcpServers: { 'codex-1': {} },
+    // no health file -> not fresh -> should kick a refresh
+  });
+  const hooksDir = path.join(tempHome, '.claude', 'hooks');
+  fs.mkdirSync(hooksDir, { recursive: true });
+  fs.writeFileSync(path.join(hooksDir, 'nf-slot-health-probe.js'), 'process.exit(0)\n', 'utf8');
+  const markerPath = path.join(tempHome, '.claude', 'nf', '.slot-probe-spawned');
+  const tempDir = makeTempDir('qs6-dir');
+  try {
+    runHook({ model: { display_name: 'M' }, workspace: { current_dir: tempDir } }, { HOME: tempHome });
+    assert.ok(fs.existsSync(markerPath), 'throttle marker must be created on stale/missing cache');
+    const m1 = fs.statSync(markerPath).mtimeMs;
+    runHook({ model: { display_name: 'M' }, workspace: { current_dir: tempDir } }, { HOME: tempHome });
+    const m2 = fs.statSync(markerPath).mtimeMs;
+    assert.strictEqual(m1, m2, 'marker must not be rewritten within the throttle window (no re-spawn)');
+  } finally { fs.rmSync(tempHome, { recursive: true, force: true }); fs.rmSync(tempDir, { recursive: true, force: true }); }
+});
+
+test('QS7: no provider inventory -> no probe spawn / no marker (no churn)', () => {
+  const tempHome = makeTempDir('qs7-home');
+  const hooksDir = path.join(tempHome, '.claude', 'hooks');
+  fs.mkdirSync(hooksDir, { recursive: true });
+  fs.writeFileSync(path.join(hooksDir, 'nf-slot-health-probe.js'), 'process.exit(0)\n', 'utf8');
+  const markerPath = path.join(tempHome, '.claude', 'nf', '.slot-probe-spawned');
+  const tempDir = makeTempDir('qs7-dir');
+  try {
+    const { exitCode } = runHook({ model: { display_name: 'M' }, workspace: { current_dir: tempDir } }, { HOME: tempHome });
+    assert.strictEqual(exitCode, 0);
+    assert.ok(!fs.existsSync(markerPath), 'no probe marker when there is no provider inventory (readSlotHealth null)');
+  } finally { fs.rmSync(tempHome, { recursive: true, force: true }); fs.rmSync(tempDir, { recursive: true, force: true }); }
+});


### PR DESCRIPTION
## Why
The per-slot quorum row is line 2 of the statusline, so it only shows when the terminal has vertical room to paint a second status row — on short windows users see only line 1 and think quorum status is missing. Separately, the slot-health cache is refreshed **only at SessionStart** and expires after 5 min, so even when the row shows, the dots are usually hollow `○` (stale) rather than green.

## What
- **Line-1 compact quorum indicator** (always visible): `7● quorum` (green, all healthy) · `5/7⊘ quorum` (red, some down) · `7○ quorum` (dim, no fresh data). The detailed per-slot row (line 2) is unchanged.
- **Background self-refresh**: when the cache is stale/missing, the statusline kicks off `nf-slot-health-probe.js` in a **detached, throttled (1/min), fail-open** background process, so the next render reads fresh. The statusline itself stays instant (never blocks on the probe).

## Verified
- Stale render → `7○ quorum` (dim) and spawns the probe; after it lands → `7● quorum` (green `\x1b[32m`). Confirmed against the live installed copy.
- `npm run build:hooks` regenerated `hooks/dist/nf-statusline.js`; `verify-hooks-sync` ✓, `lint:isolation` ✓, `nf-statusline.test.js` 37/0.

Addresses the "why can't I see / why is it always stale" statusline questions from this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a quorum health indicator to the status display, showing "all healthy" or individual healthy counts.

* **Performance**
  * Optimized health data refresh to run in the background without blocking the interface; stale data displays as unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->