### PR TITLE
fix(install): migrate mcpServers args→nf-bin in the empty-source branch (#200 regression)

### DIFF
--- a/bin/install-helpers.cjs
+++ b/bin/install-helpers.cjs
@@ -54,6 +54,15 @@ function synthesizeMcpEntry(providerName, claudeHomeDir) {
   };
 }
 
+// True when an mcpServers entry's args[0] points at unified-mcp-server.mjs but is
+// NOT under the installed nf-bin dir — i.e. it's still bound to the repo working
+// tree or an npx cache and must be repointed at the installed copy (issue #200).
+function mcpArgsNeedMigration(args0, nfBinDir) {
+  return typeof args0 === 'string'
+    && args0.endsWith('unified-mcp-server.mjs')
+    && !isUnderInstallDir(args0, nfBinDir);
+}
+
 /**
  * Merge the repo's providers.json into the user's installed copy, preserving user-added
  * entries. The repo source (`bin/providers.json`) ships the canonical default fleet; users
@@ -202,5 +211,6 @@ module.exports = {
   shouldCopyToNfBin,
   installedUnifiedMcpPath,
   isUnderInstallDir,
+  mcpArgsNeedMigration,
   synthesizeMcpEntry,
 };

--- a/bin/install.js
+++ b/bin/install.js
@@ -540,6 +540,7 @@ const {
   shouldCopyToNfBin,
   installedUnifiedMcpPath,
   isUnderInstallDir,
+  mcpArgsNeedMigration,
   synthesizeMcpEntry,
 } = require('./install-helpers.cjs');
 
@@ -683,6 +684,8 @@ function ensureMcpSlotsFromProviders() {
             if (claudeJsonForBackfill?.mcpServers) {
               let backfilled = 0;
               const legacyProvidersJson = path.join(os.homedir(), '.claude', 'nf', 'bin', 'providers.json');
+              const nfBinDir = path.join(os.homedir(), '.claude', 'nf-bin');
+              const installedMcp = path.join(nfBinDir, 'unified-mcp-server.mjs');
               for (const slotName of mcpSlots) {
                 const entry = claudeJsonForBackfill.mcpServers[slotName];
                 if (!entry) continue;
@@ -692,12 +695,25 @@ function ensureMcpSlotsFromProviders() {
                   entry.env.UNIFIED_PROVIDERS_CONFIG = globalProvidersJson;
                   backfilled++;
                 }
+                // Args migration (issue #200): the early `return` above means the
+                // main Step-4 args migration never runs when the repo source
+                // providers.json is empty (the typical case after install). So a slot
+                // whose args[0] points at the repo working tree (<repo>/bin/...mjs) or
+                // an npx cache would never be repointed at the installed nf-bin copy,
+                // leaving the whole fleet coupled to the repo tree. Self-heal it here.
+                if (fs.existsSync(installedMcp)) {
+                  const a0 = Array.isArray(entry.args) ? entry.args[0] : undefined;
+                  if (mcpArgsNeedMigration(a0, nfBinDir)) {
+                    entry.args = [installedMcp, ...entry.args.slice(1)];
+                    backfilled++;
+                  }
+                }
               }
               if (backfilled > 0) {
                 const tmpPath = claudeJsonPath + '.tmp';
                 fs.writeFileSync(tmpPath, JSON.stringify(claudeJsonForBackfill, null, 2) + '\n', 'utf8');
                 fs.renameSync(tmpPath, claudeJsonPath);
-                console.log(`  ${green}✓${reset} Backfilled UNIFIED_PROVIDERS_CONFIG on ${backfilled} mcpServers entry/entries`);
+                console.log(`  ${green}✓${reset} Self-healed ${backfilled} mcpServers entry/entries (UNIFIED_PROVIDERS_CONFIG + args → nf-bin)`);
               }
             }
           } catch (e) {

--- a/test/install-mcp-nfbin.test.cjs
+++ b/test/install-mcp-nfbin.test.cjs
@@ -20,8 +20,27 @@ const {
   isUnderInstallDir,
   synthesizeMcpEntry,
   installedUnifiedMcpPath,
+  mcpArgsNeedMigration,
   NF_BIN_RUNTIME_MJS,
 } = require('../bin/install-helpers.cjs');
+
+describe('mcpArgsNeedMigration — repo-tree → nf-bin args migration (issue #200)', () => {
+  const nfBin = '/home/u/.claude/nf-bin';
+  it('flags a repo-tree args[0] for migration (the bug: slots ran from the repo)', () => {
+    assert.equal(mcpArgsNeedMigration('/home/u/code/QGSD/bin/unified-mcp-server.mjs', nfBin), true);
+  });
+  it('flags an npx-cache args[0] for migration', () => {
+    assert.equal(mcpArgsNeedMigration('/home/u/.npm/_npx/abc/node_modules/@nforma.ai/nforma/bin/unified-mcp-server.mjs', nfBin), true);
+  });
+  it('does NOT flag an already-installed nf-bin path', () => {
+    assert.equal(mcpArgsNeedMigration('/home/u/.claude/nf-bin/unified-mcp-server.mjs', nfBin), false);
+  });
+  it('ignores non-unified args and non-string input', () => {
+    assert.equal(mcpArgsNeedMigration('/home/u/code/QGSD/bin/some-other.mjs', nfBin), false);
+    assert.equal(mcpArgsNeedMigration(undefined, nfBin), false);
+    assert.equal(mcpArgsNeedMigration(null, nfBin), false);
+  });
+});
 
 describe('shouldCopyToNfBin — nf-bin copy filter (issue #200)', () => {
   it('selects unified-mcp-server.mjs (the bug: .mjs was skipped)', () => {


### PR DESCRIPTION
## The bug (found by running the installer and checking the logs)
`#200`/#211 was supposed to stop MCP slots running from the repo working tree. But on a **real install it never migrated existing slots' `args[0]`** — they kept pointing at `<repo>/bin/unified-mcp-server.mjs`, so a repo edit / `git stash` / branch-switch could still take the whole fleet down (the exact failure #200 set out to prevent).

**Root cause:** `ensureMcpSlotsFromProviders` reads providers.json from `__dirname` = the repo `bin/providers.json`, which ships **empty** (the intentional stub since the config consolidation). With an empty source it enters the "sync from `~/.claude.json`" branch and **`return`s before Step 4** (`install.js:710`) — so Step 4's args migration, env backfill, and the `#200` assertion are all unreachable on every real install. The `.mjs` copy worked (separate loop), which masked it; only the args migration was dead.

## Fix
Add the args migration to the empty-branch self-heal loop (right next to the `UNIFIED_PROVIDERS_CONFIG` backfill that someone already had to add there for the same early-return reason). Extracted the predicate into a pure, unit-tested `mcpArgsNeedMigration(args0, nfBinDir)` in `install-helpers.cjs`. Also made the self-heal log line accurate (it now mentions args, not just the env var).

## Verified
- **End-to-end:** set a slot's `args[0]` back to the repo tree → ran install → it was rewritten to `~/.claude/nf-bin/unified-mcp-server.mjs`. All 7 live slots now resolve under nf-bin.
- New `mcpArgsNeedMigration` unit tests (repo-tree / npx-cache → migrate; already-nf-bin / non-unified / null → don't): green. `install-mcp-nfbin` suite 14/0; `lint:isolation` clean; lockfile in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)