### PR TITLE
feat(statusline): actionable quorum indicator — show the fix command when slots are down

### DIFF
--- a/hooks/dist/nf-statusline.js
+++ b/hooks/dist/nf-statusline.js
@@ -179,9 +179,11 @@ function buildSlotsLine(homeDir, ctx) {
 // Compact one-line quorum indicator for line 1, so quorum health is visible even
 // when the terminal only paints the first status row (multi-line status lines
 // depend on vertical space). `ctx` is the shared readSlotHealth() result.
-//   N● quorum   (green)  — all N MCP-registered slots healthy & fresh
-//   H/N⊘ quorum (red)    — H of N healthy (some down)
-//   N○ quorum   (dim)    — no fresh probe data yet (cache stale/missing)
+//   N● quorum                  (green)  — all N MCP slots healthy & fresh
+//   H/N⊘ /nf:mcp-restart <slot> (red+CTA) — one slot probed FAILED → restart it
+//   H/N⊘ /nf:mcp-repair         (red+CTA) — several slots failed → repair the fleet
+//   H/N○ quorum                (dim)    — fresh, but some slots not yet probed (no failure)
+//   N○ quorum                  (dim)    — no fresh probe data yet (cache stale/missing)
 function buildQuorumSummary(homeDir, ctx) {
   const h = ctx || readSlotHealth(homeDir);
   if (!h) return null;
@@ -194,9 +196,15 @@ function buildQuorumSummary(homeDir, ctx) {
   if (!fresh) return `\x1b[2m${total}○ quorum\x1b[0m`;
   const healthy = mcpSlots.filter(p => { const e = cache && cache.slots && cache.slots[p.name]; return e && e.ok; }).length;
   if (healthy === total) return `\x1b[32m${total}● quorum\x1b[0m`;
-  // Some slots down → make it a call-to-action, not just a status (like ⬆ /nf:update).
-  // One identifiable failed slot → restart just it; otherwise repair the fleet.
+
+  // A slot counts as DOWN only if it was actually probed and FAILED (ok === false).
+  // Slots merely MISSING from the cache (added since the last probe) are unknown,
+  // not failures — don't raise a repair CTA for them, just show a dim count.
   const down = mcpSlots.filter(p => { const e = cache && cache.slots && cache.slots[p.name]; return e && e.ok === false; });
+  if (down.length === 0) return `\x1b[2m${healthy}/${total}○ quorum\x1b[0m`;
+
+  // Real failure → make it a call-to-action, not just a status (like ⬆ /nf:update).
+  // One identifiable failed slot → restart just it; otherwise repair the fleet.
   const cmd = down.length === 1 ? `/nf:mcp-restart ${down[0].name}` : '/nf:mcp-repair';
   return `\x1b[31m${healthy}/${total}⊘\x1b[0m \x1b[33m${cmd}\x1b[0m`;
 }

--- a/hooks/dist/nf-statusline.js
+++ b/hooks/dist/nf-statusline.js
@@ -194,7 +194,11 @@ function buildQuorumSummary(homeDir, ctx) {
   if (!fresh) return `\x1b[2m${total}○ quorum\x1b[0m`;
   const healthy = mcpSlots.filter(p => { const e = cache && cache.slots && cache.slots[p.name]; return e && e.ok; }).length;
   if (healthy === total) return `\x1b[32m${total}● quorum\x1b[0m`;
-  return `\x1b[31m${healthy}/${total}⊘ quorum\x1b[0m`;
+  // Some slots down → make it a call-to-action, not just a status (like ⬆ /nf:update).
+  // One identifiable failed slot → restart just it; otherwise repair the fleet.
+  const down = mcpSlots.filter(p => { const e = cache && cache.slots && cache.slots[p.name]; return e && e.ok === false; });
+  const cmd = down.length === 1 ? `/nf:mcp-restart ${down[0].name}` : '/nf:mcp-repair';
+  return `\x1b[31m${healthy}/${total}⊘\x1b[0m \x1b[33m${cmd}\x1b[0m`;
 }
 
 // Fire-and-forget: when the slot-health cache is NOT fresh, kick off the probe in

--- a/hooks/nf-statusline.js
+++ b/hooks/nf-statusline.js
@@ -179,9 +179,11 @@ function buildSlotsLine(homeDir, ctx) {
 // Compact one-line quorum indicator for line 1, so quorum health is visible even
 // when the terminal only paints the first status row (multi-line status lines
 // depend on vertical space). `ctx` is the shared readSlotHealth() result.
-//   N● quorum   (green)  — all N MCP-registered slots healthy & fresh
-//   H/N⊘ quorum (red)    — H of N healthy (some down)
-//   N○ quorum   (dim)    — no fresh probe data yet (cache stale/missing)
+//   N● quorum                  (green)  — all N MCP slots healthy & fresh
+//   H/N⊘ /nf:mcp-restart <slot> (red+CTA) — one slot probed FAILED → restart it
+//   H/N⊘ /nf:mcp-repair         (red+CTA) — several slots failed → repair the fleet
+//   H/N○ quorum                (dim)    — fresh, but some slots not yet probed (no failure)
+//   N○ quorum                  (dim)    — no fresh probe data yet (cache stale/missing)
 function buildQuorumSummary(homeDir, ctx) {
   const h = ctx || readSlotHealth(homeDir);
   if (!h) return null;
@@ -194,9 +196,15 @@ function buildQuorumSummary(homeDir, ctx) {
   if (!fresh) return `\x1b[2m${total}○ quorum\x1b[0m`;
   const healthy = mcpSlots.filter(p => { const e = cache && cache.slots && cache.slots[p.name]; return e && e.ok; }).length;
   if (healthy === total) return `\x1b[32m${total}● quorum\x1b[0m`;
-  // Some slots down → make it a call-to-action, not just a status (like ⬆ /nf:update).
-  // One identifiable failed slot → restart just it; otherwise repair the fleet.
+
+  // A slot counts as DOWN only if it was actually probed and FAILED (ok === false).
+  // Slots merely MISSING from the cache (added since the last probe) are unknown,
+  // not failures — don't raise a repair CTA for them, just show a dim count.
   const down = mcpSlots.filter(p => { const e = cache && cache.slots && cache.slots[p.name]; return e && e.ok === false; });
+  if (down.length === 0) return `\x1b[2m${healthy}/${total}○ quorum\x1b[0m`;
+
+  // Real failure → make it a call-to-action, not just a status (like ⬆ /nf:update).
+  // One identifiable failed slot → restart just it; otherwise repair the fleet.
   const cmd = down.length === 1 ? `/nf:mcp-restart ${down[0].name}` : '/nf:mcp-repair';
   return `\x1b[31m${healthy}/${total}⊘\x1b[0m \x1b[33m${cmd}\x1b[0m`;
 }

--- a/hooks/nf-statusline.js
+++ b/hooks/nf-statusline.js
@@ -194,7 +194,11 @@ function buildQuorumSummary(homeDir, ctx) {
   if (!fresh) return `\x1b[2m${total}○ quorum\x1b[0m`;
   const healthy = mcpSlots.filter(p => { const e = cache && cache.slots && cache.slots[p.name]; return e && e.ok; }).length;
   if (healthy === total) return `\x1b[32m${total}● quorum\x1b[0m`;
-  return `\x1b[31m${healthy}/${total}⊘ quorum\x1b[0m`;
+  // Some slots down → make it a call-to-action, not just a status (like ⬆ /nf:update).
+  // One identifiable failed slot → restart just it; otherwise repair the fleet.
+  const down = mcpSlots.filter(p => { const e = cache && cache.slots && cache.slots[p.name]; return e && e.ok === false; });
+  const cmd = down.length === 1 ? `/nf:mcp-restart ${down[0].name}` : '/nf:mcp-repair';
+  return `\x1b[31m${healthy}/${total}⊘\x1b[0m \x1b[33m${cmd}\x1b[0m`;
 }
 
 // Fire-and-forget: when the slot-health cache is NOT fresh, kick off the probe in

--- a/hooks/nf-statusline.test.js
+++ b/hooks/nf-statusline.test.js
@@ -984,3 +984,19 @@ test('QS7: no provider inventory -> no probe spawn / no marker (no churn)', () =
     assert.ok(!fs.existsSync(markerPath), 'no probe marker when there is no provider inventory (readSlotHealth null)');
   } finally { fs.rmSync(tempHome, { recursive: true, force: true }); fs.rmSync(tempDir, { recursive: true, force: true }); }
 });
+
+test('QS2c: fresh cache but a slot is MISSING its entry -> dim count, NO false repair CTA', () => {
+  const tempHome = setupSlotsHome('qs2c', {
+    providers: [{ name: 'codex-1' }, { name: 'gemini-1' }, { name: 'claude-1' }],
+    mcpServers: { 'codex-1': {}, 'gemini-1': {}, 'claude-1': {} },
+    // claude-1 added since last probe → no cache entry; codex-1/gemini-1 healthy. None FAILED.
+    health: { checked_at: qsFreshIso(), slots: { 'codex-1': { ok: true }, 'gemini-1': { ok: true } } },
+  });
+  const tempDir = makeTempDir('qs2c-dir');
+  try {
+    const { stdout } = runHook({ model: { display_name: 'M' }, workspace: { current_dir: tempDir } }, { HOME: tempHome });
+    assert.ok(line1(stdout).includes('2/3○ quorum'), `expected dim 2/3○ quorum (no failure); got: ${JSON.stringify(line1(stdout))}`);
+    assert.ok(!line1(stdout).includes('/nf:mcp-repair') && !line1(stdout).includes('/nf:mcp-restart'),
+      `must NOT show a repair/restart CTA when slots are merely unprobed; got: ${JSON.stringify(line1(stdout))}`);
+  } finally { fs.rmSync(tempHome, { recursive: true, force: true }); fs.rmSync(tempDir, { recursive: true, force: true }); }
+});

--- a/hooks/nf-statusline.test.js
+++ b/hooks/nf-statusline.test.js
@@ -881,7 +881,7 @@ test('QS1: all MCP slots healthy + fresh -> green N dot quorum on line 1', () =>
   } finally { fs.rmSync(tempHome, { recursive: true, force: true }); fs.rmSync(tempDir, { recursive: true, force: true }); }
 });
 
-test('QS2: some slots down + fresh -> red H/N quorum', () => {
+test('QS2: exactly one slot down -> red count + /nf:mcp-restart <slot> CTA', () => {
   const tempHome = setupSlotsHome('qs2', {
     providers: [{ name: 'codex-1' }, { name: 'gemini-1' }, { name: 'claude-1' }],
     mcpServers: { 'codex-1': {}, 'gemini-1': {}, 'claude-1': {} },
@@ -890,7 +890,22 @@ test('QS2: some slots down + fresh -> red H/N quorum', () => {
   const tempDir = makeTempDir('qs2-dir');
   try {
     const { stdout } = runHook({ model: { display_name: 'M' }, workspace: { current_dir: tempDir } }, { HOME: tempHome });
-    assert.ok(line1(stdout).includes('\x1b[31m2/3⊘ quorum\x1b[0m'), `expected red 2/3 quorum; got: ${JSON.stringify(line1(stdout))}`);
+    assert.ok(line1(stdout).includes('\x1b[31m2/3⊘\x1b[0m'), `expected red 2/3 count; got: ${JSON.stringify(line1(stdout))}`);
+    assert.ok(line1(stdout).includes('\x1b[33m/nf:mcp-restart gemini-1\x1b[0m'), `expected restart CTA for the single down slot; got: ${JSON.stringify(line1(stdout))}`);
+  } finally { fs.rmSync(tempHome, { recursive: true, force: true }); fs.rmSync(tempDir, { recursive: true, force: true }); }
+});
+
+test('QS2b: multiple slots down -> /nf:mcp-repair CTA', () => {
+  const tempHome = setupSlotsHome('qs2b', {
+    providers: [{ name: 'codex-1' }, { name: 'gemini-1' }, { name: 'claude-1' }],
+    mcpServers: { 'codex-1': {}, 'gemini-1': {}, 'claude-1': {} },
+    health: { checked_at: qsFreshIso(), slots: { 'codex-1': { ok: true }, 'gemini-1': { ok: false }, 'claude-1': { ok: false } } },
+  });
+  const tempDir = makeTempDir('qs2b-dir');
+  try {
+    const { stdout } = runHook({ model: { display_name: 'M' }, workspace: { current_dir: tempDir } }, { HOME: tempHome });
+    assert.ok(line1(stdout).includes('\x1b[31m1/3⊘\x1b[0m'), `expected red 1/3 count; got: ${JSON.stringify(line1(stdout))}`);
+    assert.ok(line1(stdout).includes('\x1b[33m/nf:mcp-repair\x1b[0m'), `expected repair CTA for multiple down; got: ${JSON.stringify(line1(stdout))}`);
   } finally { fs.rmSync(tempHome, { recursive: true, force: true }); fs.rmSync(tempDir, { recursive: true, force: true }); }
 });
 


### PR DESCRIPTION
## Why
Following the `⬆ /nf:update` pattern, the statusline should tell you *what to run*, not just report a problem. When a quorum slot is down, you now see the command to fix it.

## What
The line-1 quorum tag becomes a call-to-action when slots are down:
- All healthy → `7● quorum` (green, unchanged)
- **One** slot failed → `5/7⊘ /nf:mcp-restart <slot>` (red count + yellow command — restart just that slot)
- **Several** down → `5/7⊘ /nf:mcp-repair` (yellow command — repair the fleet)
- Stale/no data → `7○ quorum` (dim, unchanged — auto-refreshes)

Both commands are real (`mcp-restart <agent>` / `mcp-repair`), and the colour/format mirrors `⬆ /nf:update`.

## Tools (coderlm/River/embed) — deliberately no CTA
Their `○` is the **normal on-demand idle state** (coderlm auto-starts in `/nf:solve`, River idles until trained, embed until its cache warms) — not a fault. A constant "start it" command there would be noise, not a fix. If you want an explicit start/activate CTA for a specific tool, that's a quick follow-up.

## Tests
`QS2` (one down → restart CTA) and `QS2b` (several down → repair CTA) added; full statusline suite 45/0; verified the live render: `… │ 1/2⊘ /nf:mcp-restart gemini-1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quorum status display with health count indicators when slots are down.
  * Added suggested repair commands based on number of failed slots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->