### PR TITLE
feat(statusline): tools on line 1 + honest River recency indicator

### DIFF
--- a/hooks/dist/nf-statusline.js
+++ b/hooks/dist/nf-statusline.js
@@ -105,9 +105,17 @@ function buildToolsLine(homeDir, dir) {
                 ? '\x1b[32m● River\x1b[0m'   // trained & recently active
                 : '\x1b[36m● River\x1b[0m';   // exploring (recent learning, not all trained)
             }
-            // A live shadow recommendation is by definition current → always active.
+            // A shadow recommendation counts as active only when it's RECENT —
+            // routing-policy stamps lastShadow.timestamp on every write, so an old
+            // recommendation lingering in the state file must not keep River green
+            // forever (same staleness trap as the visit counters above). A missing
+            // timestamp is treated as recent for backward compat with pre-stamp state.
             if (riverState.lastShadow && typeof riverState.lastShadow.recommendation === 'string' && riverState.lastShadow.recommendation) {
-              toolsRiver = `\x1b[33m● River: ${riverState.lastShadow.recommendation}\x1b[0m`;
+              const sts = Date.parse(riverState.lastShadow.timestamp);
+              const shadowRecent = Number.isNaN(sts) || (Date.now() - sts) < RIVER_ACTIVE_MS;
+              if (shadowRecent) {
+                toolsRiver = `\x1b[33m● River: ${riverState.lastShadow.recommendation}\x1b[0m`;
+              }
             }
           }
         }

--- a/hooks/dist/nf-statusline.js
+++ b/hooks/dist/nf-statusline.js
@@ -76,11 +76,16 @@ function buildToolsLine(homeDir, dir) {
           const riverState = JSON.parse(fs.readFileSync(riverPath, 'utf8'));
           const qTable = riverState && riverState.qTable;
           if (qTable && typeof qTable === 'object') {
-            // Check if ANY arm has been visited — means "ready to start learning"
+            // The bandit learns slowly (only during Mode C coding-task delegation),
+            // so "active" must mean RECENTLY active — otherwise a bandit that learned
+            // months ago would show green forever. Require a qTable update within the
+            // window below (or a live lastShadow). Stale visits → ○ idle, not ●.
             const RIVER_MIN_EXPLORE = 20;
+            const RIVER_ACTIVE_MS = 24 * 60 * 60 * 1000; // learned within the last day
             let hasArms = false;
             let hasVisits = false;
             let allAbove = true;
+            let recentlyActive = false;
             for (const taskType of Object.keys(qTable)) {
               const arms = qTable[taskType];
               if (arms && typeof arms === 'object') {
@@ -89,14 +94,18 @@ function buildToolsLine(homeDir, dir) {
                   const visits = arms[armName].visits || 0;
                   if (visits > 0) hasVisits = true;
                   if (visits < RIVER_MIN_EXPLORE) allAbove = false;
+                  const lu = Date.parse(arms[armName].lastUpdate);
+                  if (!Number.isNaN(lu) && (Date.now() - lu) < RIVER_ACTIVE_MS) recentlyActive = true;
                 }
               }
             }
-            if (hasArms && hasVisits) {
+            // Has learned but not recently → idle (honest: River isn't doing anything now).
+            if (hasArms && hasVisits && recentlyActive) {
               toolsRiver = allAbove
-                ? '\x1b[32m● River\x1b[0m'   // trained
-                : '\x1b[36m● River\x1b[0m';   // exploring (has learning data, not all trained)
+                ? '\x1b[32m● River\x1b[0m'   // trained & recently active
+                : '\x1b[36m● River\x1b[0m';   // exploring (recent learning, not all trained)
             }
+            // A live shadow recommendation is by definition current → always active.
             if (riverState.lastShadow && typeof riverState.lastShadow.recommendation === 'string' && riverState.lastShadow.recommendation) {
               toolsRiver = `\x1b[33m● River: ${riverState.lastShadow.recommendation}\x1b[0m`;
             }
@@ -400,27 +409,28 @@ process.stdin.on('end', () => {
       if (q) quorumTag = ` \x1b[2m│\x1b[0m ${q}`;
     } catch (_e) {}
 
-    // Output (tools line is assembled and written after the main line)
+    // Tools (coderlm/River/embed) on LINE 1 too — they used to live on a separate
+    // bottom row that terminals with little vertical space never paint, so they were
+    // effectively invisible. Surface them next to the quorum indicator instead.
+    let toolsTag = '';
+    try {
+      const t = buildToolsLine(homeDir, dir);
+      if (t) toolsTag = ` \x1b[2m│\x1b[0m ${t}`;
+    } catch (_e) {}
+
+    // Output: everything actionable on line 1; per-slot quorum detail on line 2.
     const dirname = path.basename(dir);
     if (task) {
-      process.stdout.write(`${nfUpdate}\x1b[2m${model}\x1b[0m │ \x1b[1m${task}\x1b[0m │ \x1b[2m${dirname}\x1b[0m${ctx}${quorumTag}`);
+      process.stdout.write(`${nfUpdate}\x1b[2m${model}\x1b[0m │ \x1b[1m${task}\x1b[0m │ \x1b[2m${dirname}\x1b[0m${ctx}${quorumTag}${toolsTag}`);
     } else {
-      process.stdout.write(`${nfUpdate}\x1b[2m${model}\x1b[0m │ \x1b[2m${dirname}\x1b[0m${ctx}${quorumTag}`);
+      process.stdout.write(`${nfUpdate}\x1b[2m${model}\x1b[0m │ \x1b[2m${dirname}\x1b[0m${ctx}${quorumTag}${toolsTag}`);
     }
 
-    // Quorum slots line (above the tools line)
+    // Per-slot quorum detail on line 2 (for terminals tall enough to show it).
     try {
       const slotsLine = buildSlotsLine(homeDir, slotHealth);
       if (slotsLine) {
         process.stdout.write('\n' + slotsLine);
-      }
-    } catch (_e) {}
-
-    // Tools status second line
-    try {
-      const toolsLine = buildToolsLine(homeDir, dir);
-      if (toolsLine) {
-        process.stdout.write('\n' + toolsLine);
       }
     } catch (_e) {}
   } catch (e) {

--- a/hooks/nf-statusline.js
+++ b/hooks/nf-statusline.js
@@ -105,9 +105,17 @@ function buildToolsLine(homeDir, dir) {
                 ? '\x1b[32m● River\x1b[0m'   // trained & recently active
                 : '\x1b[36m● River\x1b[0m';   // exploring (recent learning, not all trained)
             }
-            // A live shadow recommendation is by definition current → always active.
+            // A shadow recommendation counts as active only when it's RECENT —
+            // routing-policy stamps lastShadow.timestamp on every write, so an old
+            // recommendation lingering in the state file must not keep River green
+            // forever (same staleness trap as the visit counters above). A missing
+            // timestamp is treated as recent for backward compat with pre-stamp state.
             if (riverState.lastShadow && typeof riverState.lastShadow.recommendation === 'string' && riverState.lastShadow.recommendation) {
-              toolsRiver = `\x1b[33m● River: ${riverState.lastShadow.recommendation}\x1b[0m`;
+              const sts = Date.parse(riverState.lastShadow.timestamp);
+              const shadowRecent = Number.isNaN(sts) || (Date.now() - sts) < RIVER_ACTIVE_MS;
+              if (shadowRecent) {
+                toolsRiver = `\x1b[33m● River: ${riverState.lastShadow.recommendation}\x1b[0m`;
+              }
             }
           }
         }

--- a/hooks/nf-statusline.js
+++ b/hooks/nf-statusline.js
@@ -76,11 +76,16 @@ function buildToolsLine(homeDir, dir) {
           const riverState = JSON.parse(fs.readFileSync(riverPath, 'utf8'));
           const qTable = riverState && riverState.qTable;
           if (qTable && typeof qTable === 'object') {
-            // Check if ANY arm has been visited — means "ready to start learning"
+            // The bandit learns slowly (only during Mode C coding-task delegation),
+            // so "active" must mean RECENTLY active — otherwise a bandit that learned
+            // months ago would show green forever. Require a qTable update within the
+            // window below (or a live lastShadow). Stale visits → ○ idle, not ●.
             const RIVER_MIN_EXPLORE = 20;
+            const RIVER_ACTIVE_MS = 24 * 60 * 60 * 1000; // learned within the last day
             let hasArms = false;
             let hasVisits = false;
             let allAbove = true;
+            let recentlyActive = false;
             for (const taskType of Object.keys(qTable)) {
               const arms = qTable[taskType];
               if (arms && typeof arms === 'object') {
@@ -89,14 +94,18 @@ function buildToolsLine(homeDir, dir) {
                   const visits = arms[armName].visits || 0;
                   if (visits > 0) hasVisits = true;
                   if (visits < RIVER_MIN_EXPLORE) allAbove = false;
+                  const lu = Date.parse(arms[armName].lastUpdate);
+                  if (!Number.isNaN(lu) && (Date.now() - lu) < RIVER_ACTIVE_MS) recentlyActive = true;
                 }
               }
             }
-            if (hasArms && hasVisits) {
+            // Has learned but not recently → idle (honest: River isn't doing anything now).
+            if (hasArms && hasVisits && recentlyActive) {
               toolsRiver = allAbove
-                ? '\x1b[32m● River\x1b[0m'   // trained
-                : '\x1b[36m● River\x1b[0m';   // exploring (has learning data, not all trained)
+                ? '\x1b[32m● River\x1b[0m'   // trained & recently active
+                : '\x1b[36m● River\x1b[0m';   // exploring (recent learning, not all trained)
             }
+            // A live shadow recommendation is by definition current → always active.
             if (riverState.lastShadow && typeof riverState.lastShadow.recommendation === 'string' && riverState.lastShadow.recommendation) {
               toolsRiver = `\x1b[33m● River: ${riverState.lastShadow.recommendation}\x1b[0m`;
             }
@@ -400,27 +409,28 @@ process.stdin.on('end', () => {
       if (q) quorumTag = ` \x1b[2m│\x1b[0m ${q}`;
     } catch (_e) {}
 
-    // Output (tools line is assembled and written after the main line)
+    // Tools (coderlm/River/embed) on LINE 1 too — they used to live on a separate
+    // bottom row that terminals with little vertical space never paint, so they were
+    // effectively invisible. Surface them next to the quorum indicator instead.
+    let toolsTag = '';
+    try {
+      const t = buildToolsLine(homeDir, dir);
+      if (t) toolsTag = ` \x1b[2m│\x1b[0m ${t}`;
+    } catch (_e) {}
+
+    // Output: everything actionable on line 1; per-slot quorum detail on line 2.
     const dirname = path.basename(dir);
     if (task) {
-      process.stdout.write(`${nfUpdate}\x1b[2m${model}\x1b[0m │ \x1b[1m${task}\x1b[0m │ \x1b[2m${dirname}\x1b[0m${ctx}${quorumTag}`);
+      process.stdout.write(`${nfUpdate}\x1b[2m${model}\x1b[0m │ \x1b[1m${task}\x1b[0m │ \x1b[2m${dirname}\x1b[0m${ctx}${quorumTag}${toolsTag}`);
     } else {
-      process.stdout.write(`${nfUpdate}\x1b[2m${model}\x1b[0m │ \x1b[2m${dirname}\x1b[0m${ctx}${quorumTag}`);
+      process.stdout.write(`${nfUpdate}\x1b[2m${model}\x1b[0m │ \x1b[2m${dirname}\x1b[0m${ctx}${quorumTag}${toolsTag}`);
     }
 
-    // Quorum slots line (above the tools line)
+    // Per-slot quorum detail on line 2 (for terminals tall enough to show it).
     try {
       const slotsLine = buildSlotsLine(homeDir, slotHealth);
       if (slotsLine) {
         process.stdout.write('\n' + slotsLine);
-      }
-    } catch (_e) {}
-
-    // Tools status second line
-    try {
-      const toolsLine = buildToolsLine(homeDir, dir);
-      if (toolsLine) {
-        process.stdout.write('\n' + toolsLine);
       }
     } catch (_e) {}
   } catch (e) {

--- a/hooks/nf-statusline.test.js
+++ b/hooks/nf-statusline.test.js
@@ -467,6 +467,42 @@ test('TC21: Shadow recommendation displayed when lastShadow present', () => {
   }
 });
 
+// TC21b: stale shadow recommendation (old timestamp) must NOT render the shadow
+// form — an old lastShadow lingering in state file should not keep River green.
+test('TC21b: stale shadow (old timestamp) does not show shadow recommendation', () => {
+  const tempDir = makeTempDir('tc21b');
+  const river = makeRiverHome('tc21b');
+  const stateFile = path.join(tempDir, '.nf-river-state.json');
+  const old = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString(); // 30 days ago
+  fs.writeFileSync(stateFile, JSON.stringify({
+    qTable: {
+      implement: {
+        'codex-1': { q: 0.8, visits: 25, lastUpdate: old },
+        'gemini-1': { q: 0.6, visits: 30, lastUpdate: old },
+      },
+    },
+    lastShadow: {
+      recommendation: 'gemini-1',
+      confidence: 0.85,
+      taskType: 'implement',
+      timestamp: old,
+    },
+  }), 'utf8');
+
+  try {
+    const { stdout, exitCode } = runHook({
+      model: { display_name: 'M' },
+      workspace: { current_dir: tempDir },
+    }, river.env);
+    assert.strictEqual(exitCode, 0, 'exit code must be 0');
+    assert.ok(!stdout.includes('River: gemini-1'), 'stale shadow must NOT render "River: gemini-1"');
+    assert.ok(stdout.includes('○ River'), 'stale state shows idle ○ River');
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    river.cleanup();
+  }
+});
+
 // TC22: No shadow — falls back to River: active
 test('TC22: No shadow falls back to River: active', () => {
   const tempDir = makeTempDir('tc22');

--- a/hooks/nf-statusline.test.js
+++ b/hooks/nf-statusline.test.js
@@ -266,11 +266,12 @@ test('TC15: River exploring when arm visits below minExplore', () => {
   const tempDir = makeTempDir('tc15');
   const river = makeRiverHome('tc15');
   const stateFile = path.join(tempDir, '.nf-river-state.json');
+  const nowIso = new Date().toISOString();
   fs.writeFileSync(stateFile, JSON.stringify({
     qTable: {
       implement: {
-        'codex-1': { q: 0.5, visits: 5 },
-        'gemini-1': { q: 0.3, visits: 2 },
+        'codex-1': { q: 0.5, visits: 5, lastUpdate: nowIso },
+        'gemini-1': { q: 0.3, visits: 2, lastUpdate: nowIso },
       },
     },
   }), 'utf8');
@@ -294,11 +295,12 @@ test('TC16: River active when all arms above minExplore', () => {
   const tempDir = makeTempDir('tc16');
   const river = makeRiverHome('tc16');
   const stateFile = path.join(tempDir, '.nf-river-state.json');
+  const nowIso = new Date().toISOString();
   fs.writeFileSync(stateFile, JSON.stringify({
     qTable: {
       implement: {
-        'codex-1': { q: 0.8, visits: 25 },
-        'gemini-1': { q: 0.6, visits: 30 },
+        'codex-1': { q: 0.8, visits: 25, lastUpdate: nowIso },
+        'gemini-1': { q: 0.6, visits: 30, lastUpdate: nowIso },
       },
     },
   }), 'utf8');
@@ -311,6 +313,26 @@ test('TC16: River active when all arms above minExplore', () => {
     assert.strictEqual(exitCode, 0, 'exit code must be 0');
     assert.ok(stdout.includes('● River'), 'stdout must include "● River"');
     assert.ok(stdout.includes('\x1b[32m'), 'stdout must include green ANSI code');
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    river.cleanup();
+  }
+});
+
+// TC16b: River has visits but learned long ago → idle ○, NOT active ● (recency fix)
+test('TC16b: stale River (old lastUpdate) shows idle, not active', () => {
+  const tempDir = makeTempDir('tc16b');
+  const river = makeRiverHome('tc16b');
+  const stateFile = path.join(tempDir, '.nf-river-state.json');
+  const oldIso = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString(); // 30 days ago
+  fs.writeFileSync(stateFile, JSON.stringify({
+    qTable: { implement: { 'codex-1': { q: 0.8, visits: 25, lastUpdate: oldIso } } },
+  }), 'utf8');
+  try {
+    const { stdout, exitCode } = runHook({ model: { display_name: 'M' }, workspace: { current_dir: tempDir } }, river.env);
+    assert.strictEqual(exitCode, 0);
+    assert.ok(stdout.includes('○ River'), `stale River must show idle ○; got: ${JSON.stringify(stdout)}`);
+    assert.ok(!stdout.includes('● River'), `stale River must NOT show active ●; got: ${JSON.stringify(stdout)}`);
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
     river.cleanup();
@@ -366,14 +388,15 @@ test('TC19: Mixed task types shows exploring when any arm below minExplore', () 
   const tempDir = makeTempDir('tc19');
   const river = makeRiverHome('tc19');
   const stateFile = path.join(tempDir, '.nf-river-state.json');
+  const nowIso = new Date().toISOString();
   fs.writeFileSync(stateFile, JSON.stringify({
     qTable: {
       implement: {
-        'codex-1': { q: 0.8, visits: 25 },
-        'gemini-1': { q: 0.6, visits: 30 },
+        'codex-1': { q: 0.8, visits: 25, lastUpdate: nowIso },
+        'gemini-1': { q: 0.6, visits: 30, lastUpdate: nowIso },
       },
       review: {
-        'codex-1': { q: 0.1, visits: 3 },
+        'codex-1': { q: 0.1, visits: 3, lastUpdate: nowIso },
       },
     },
   }), 'utf8');
@@ -419,8 +442,8 @@ test('TC21: Shadow recommendation displayed when lastShadow present', () => {
   fs.writeFileSync(stateFile, JSON.stringify({
     qTable: {
       implement: {
-        'codex-1': { q: 0.8, visits: 25 },
-        'gemini-1': { q: 0.6, visits: 30 },
+        'codex-1': { q: 0.8, visits: 25, lastUpdate: new Date().toISOString() },
+        'gemini-1': { q: 0.6, visits: 30, lastUpdate: new Date().toISOString() },
       },
     },
     lastShadow: {
@@ -452,8 +475,8 @@ test('TC22: No shadow falls back to River: active', () => {
   fs.writeFileSync(stateFile, JSON.stringify({
     qTable: {
       implement: {
-        'codex-1': { q: 0.8, visits: 25 },
-        'gemini-1': { q: 0.6, visits: 30 },
+        'codex-1': { q: 0.8, visits: 25, lastUpdate: new Date().toISOString() },
+        'gemini-1': { q: 0.6, visits: 30, lastUpdate: new Date().toISOString() },
       },
     },
   }), 'utf8');
@@ -480,8 +503,8 @@ test('TC23: Shadow with null recommendation falls back to normal indicator', () 
   fs.writeFileSync(stateFile, JSON.stringify({
     qTable: {
       implement: {
-        'codex-1': { q: 0.8, visits: 25 },
-        'gemini-1': { q: 0.6, visits: 30 },
+        'codex-1': { q: 0.8, visits: 25, lastUpdate: new Date().toISOString() },
+        'gemini-1': { q: 0.6, visits: 30, lastUpdate: new Date().toISOString() },
       },
     },
     lastShadow: { recommendation: null },
@@ -832,8 +855,9 @@ test('TC37: malformed slot-health.json falls back to ○ (fail-open)', () => {
   }
 });
 
-// TC38: slots line is rendered ABOVE the tools line (coderlm/River/embed)
-test('TC38: slots line renders above tools line', () => {
+// TC38: tools (coderlm/River/embed) now render on LINE 1 (visible even on short
+// terminals); the per-slot quorum detail moved to line 2 below them.
+test('TC38: tools render on line 1, per-slot quorum detail on line 2 below', () => {
   const tempHome = setupSlotsHome('tc38', {
     providers: [{ name: 'codex-1' }],
     mcpServers: { 'codex-1': { command: 'node' } },
@@ -849,12 +873,9 @@ test('TC38: slots line renders above tools line', () => {
       { HOME: tempHome }
     );
     assert.strictEqual(exitCode, 0);
-    const codexIdx = stdout.indexOf('codex-1');
-    const coderlmIdx = stdout.indexOf('coderlm');
-    assert.ok(codexIdx >= 0, 'slots line must contain codex-1');
-    assert.ok(coderlmIdx >= 0, 'tools line must contain coderlm');
-    assert.ok(codexIdx < coderlmIdx,
-      `slots line must come BEFORE tools line; got codex=${codexIdx}, coderlm=${coderlmIdx}`);
+    const lines = stdout.split('\n');
+    assert.ok(lines[0].includes('coderlm'), `tools must be on line 1; got line1=${JSON.stringify(lines[0])}`);
+    assert.ok((lines[1] || '').includes('codex-1'), `per-slot detail must be on line 2; got line2=${JSON.stringify(lines[1])}`);
   } finally {
     fs.rmSync(tempHome, { recursive: true, force: true });
     fs.rmSync(tempDir, { recursive: true, force: true });


### PR DESCRIPTION
Addresses the "I never see River active" / "tools never visible" feedback.

## 1. Tools on line 1
`coderlm / River / embed` moved from a bottom row (that short terminals never paint) to line 1, next to the quorum indicator. Per-slot quorum detail stays on line 2. So everything actionable is on the one row terminals always show.

## 2. River recency (honest idle)
River's `●` now requires **recent** activity — a qTable update within 24h, or a live shadow recommendation. A bandit that learned long ago now reads `○` (idle) instead of a permanent green. This was the core of the "improperly wired" confusion: River *had* learned (visits in the qTable) but last ran months ago, yet showed green forever. Now it tells the truth.

## River left in shadow mode (deliberate)
Not promoted to drive routing (a cold/under-trained bandit shouldn't), not dropped (it's wired and works). The recency fix makes the indicator honest without the risk of either.

## Tests
TC15/16/19/22/23 carry a recent `lastUpdate`; new **TC16b** asserts stale visits → `○` idle (not `●`); **TC38** updated for the new layout (tools on line 1, slot detail on line 2). Full suite 47/0; `verify-hooks-sync` + `lint:isolation` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * River indicator now displays as active only when learning data has been recently updated within 24 hours, ensuring statusline reflects current real-time status
  * Reorganized statusline layout to consolidate tool indicators on the primary display line for improved visual organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->