### PR TITLE
fix(hooks): detect source↔dist drift in verify-hooks-sync; resync stale circuit-breaker

### DIFF
--- a/hooks/dist/nf-circuit-breaker.js
+++ b/hooks/dist/nf-circuit-breaker.js
@@ -349,23 +349,28 @@ function detectOscillation(fileSets, depth, hashes, gitRoot, options) {
           continue;
         }
 
-        // Rollback detection: commit message intent + diff-level analysis
+        // Rollback detection: diff-level analysis + commit message corroboration
         // Only applies at the borderline (cycles == minCycles).
         // With cycles > minCycles, the pattern is sustained enough to be real oscillation
         // even if a commit message uses "revert" keywords.
+        //
+        // Two independent paths to suppression:
+        // Path A: Clean inverse diff (asymmetric add→remove) — strong structural signal
+        // Path B: BOTH intent keyword AND clean inverse diff — corroborated signal
+        //         (keyword alone is insufficient — true oscillation often has "revert" commits)
         const cycles = countOscillationCycles(keyRunList);
         if (options && options.rollbackDetection && cycles === minCycles) {
-          const messages = getCommitMessages(gitRoot, oscillatingHashes);
-          if (hasRollbackIntent(messages, pairStats)) {
-            // Deliberate rollback signaled by commit message — not oscillation
+          // Expensive check: diff-level inverse pair analysis (asymmetric add→remove)
+          const cleanRollback = isCleanRollback(gitRoot, oscillatingHashes, files);
+
+          if (cleanRollback) {
+            // Path A: strong structural signal — clean one-shot rollback
             continue;
           }
 
-          // Expensive check: diff-level inverse pair analysis
-          if (isCleanRollback(gitRoot, oscillatingHashes, files)) {
-            // Clean one-shot rollback — not oscillation
-            continue;
-          }
+          // Path B: keyword alone is NOT sufficient (true oscillation often says "revert")
+          // Removed: hasRollbackIntent as a standalone gate.
+          // Intent keywords are only useful for Haiku classification (see consultHaiku).
         }
       }
 
@@ -469,9 +474,9 @@ function writeState(statePath, fileSet, snapshot) {
 }
 
 // Appends a false-negative entry to .claude/circuit-breaker-false-negatives.json
-// for audit trail when Haiku classifies detected oscillation as REFINEMENT.
+// for audit trail when Haiku classifies detected oscillation as REFINEMENT or DELIBERATE_ROLLBACK.
 // Fail-open: any error is logged to stderr but does not block the tool call.
-function appendFalseNegative(statePath, fileSet) {
+function appendFalseNegative(statePath, fileSet, verdict) {
   try {
     const fnLogPath = statePath.replace('circuit-breaker-state.json', 'circuit-breaker-false-negatives.json');
     let existing = [];
@@ -487,7 +492,7 @@ function appendFalseNegative(statePath, fileSet) {
       detected_at: new Date().toISOString(),
       file_set: fileSet,
       reviewer: 'haiku',
-      verdict: 'REFINEMENT',
+      verdict: verdict || 'REFINEMENT',
     });
     fs.writeFileSync(fnLogPath, JSON.stringify(existing, null, 2), 'utf8');
   } catch (e) {
@@ -948,7 +953,7 @@ req.end();
           // Haiku confirmed this is iterative refinement or deliberate rollback, not a bug loop — do not notify.
           // Log false-negative for auditability (stderr + persistent file).
           process.stderr.write(`[nf] INFO: circuit breaker false-negative — Haiku classified oscillation as ${verdict} (files: ${result.fileSet.join(', ')}). Allowing tool call to proceed.\n`);
-          appendFalseNegative(statePath, result.fileSet);
+          appendFalseNegative(statePath, result.fileSet, verdict);
           process.exit(0);
         }
         // verdict === 'GENUINE' or null (API unavailable) → trust the algorithm and notify

--- a/scripts/verify-hooks-sync.cjs
+++ b/scripts/verify-hooks-sync.cjs
@@ -89,7 +89,9 @@ for (const hook of hooksToCopy) {
   const distPath = path.join(DIST_DIR, hook);
   if (!fs.existsSync(distPath)) {
     errors.push(`DIST MISSING: hooks/dist/${hook} does not exist (run 'npm run build:hooks')`);
-  } else if (fs.readFileSync(hookPath, 'utf8') !== fs.readFileSync(distPath, 'utf8')) {
+  } else if (!fs.readFileSync(hookPath).equals(fs.readFileSync(distPath))) {
+    // Compare raw Buffers (not UTF-8 strings) so the check is truly byte-level —
+    // catches BOM, CRLF, and any non-UTF8 byte differences a string compare hides.
     errors.push(`DIST DRIFT: hooks/dist/${hook} differs from source hooks/${hook} (run 'npm run build:hooks' and commit)`);
   }
 }

--- a/scripts/verify-hooks-sync.cjs
+++ b/scripts/verify-hooks-sync.cjs
@@ -1,8 +1,11 @@
 #!/usr/bin/env node
 /**
  * CI guard: verifies that every hook registered by the installer has a
- * corresponding entry in the build-hooks HOOKS_TO_COPY list, and that
- * every require('./...') dependency inside those hooks is also included.
+ * corresponding entry in the build-hooks HOOKS_TO_COPY list, that every
+ * require('./...') dependency inside those hooks is also included, AND that
+ * each hook's built artifact in hooks/dist/ is byte-identical to its source
+ * (the installer ships hooks/dist/, so a stale dist means users run old code —
+ * exactly the drift that shipped a stale nf-circuit-breaker for several releases).
  *
  * Exits non-zero on drift so the test suite catches it early.
  */
@@ -16,6 +19,7 @@ const ROOT = path.resolve(__dirname, '..');
 const INSTALL_JS = path.join(ROOT, 'bin', 'install.js');
 const BUILD_HOOKS_JS = path.join(ROOT, 'scripts', 'build-hooks.js');
 const HOOKS_DIR = path.join(ROOT, 'hooks');
+const DIST_DIR = path.join(HOOKS_DIR, 'dist');
 
 // --- Extract HOOKS_TO_COPY from build-hooks.js ---
 function getHooksToCopy() {
@@ -78,13 +82,24 @@ for (const hook of hooksToCopy) {
       errors.push(`MISSING from HOOKS_TO_COPY: '${dep}' (required by ${hook})`);
     }
   }
+
+  // 3. The built artifact in hooks/dist/ must be byte-identical to the source.
+  //    build-hooks.js is a plain copy (no transform), so any difference means
+  //    dist is stale — the installer would ship outdated hook code.
+  const distPath = path.join(DIST_DIR, hook);
+  if (!fs.existsSync(distPath)) {
+    errors.push(`DIST MISSING: hooks/dist/${hook} does not exist (run 'npm run build:hooks')`);
+  } else if (fs.readFileSync(hookPath, 'utf8') !== fs.readFileSync(distPath, 'utf8')) {
+    errors.push(`DIST DRIFT: hooks/dist/${hook} differs from source hooks/${hook} (run 'npm run build:hooks' and commit)`);
+  }
 }
 
 if (errors.length > 0) {
   console.error('hooks-sync verification FAILED:\n');
   for (const e of errors) console.error(`  - ${e}`);
-  console.error('\nFix: update HOOKS_TO_COPY in scripts/build-hooks.js');
+  console.error('\nFix: update HOOKS_TO_COPY in scripts/build-hooks.js, and/or run');
+  console.error("     'npm run build:hooks' to refresh hooks/dist/, then commit the result.");
   process.exit(1);
 } else {
-  console.log(`hooks-sync OK: ${hooksToCopy.size} hooks in build list, ${installerHooks.size} registered by installer`);
+  console.log(`hooks-sync OK: ${hooksToCopy.size} hooks in build list, ${installerHooks.size} registered by installer, dist in sync`);
 }


### PR DESCRIPTION
## Problem

`hooks/dist/nf-circuit-breaker.js` had silently drifted from its source (`hooks/nf-circuit-breaker.js`) since #195: the source carried refined rollback-detection logic but `dist` was never rebuilt and committed. Because **the installer ships `hooks/dist/`**, users have been running stale circuit-breaker code for several releases.

The existing `verify-hooks-sync` CI gate only checked the installer registration list and `require()` dependency closure — it never compared source↔dist **content**, so the drift was invisible to CI.

(Surfaced while building #272, where `npm run build:hooks` regenerated this dist file.)

## Fix

- **`scripts/verify-hooks-sync.cjs`**: add a third check — for every `HOOKS_TO_COPY` hook, `hooks/dist/<name>` must be byte-identical to its source. `build-hooks.js` is a plain `copyFileSync` (no transform), so any difference means dist is stale. Reports `DIST DRIFT` / `DIST MISSING` and exits 1.
- **`hooks/dist/nf-circuit-breaker.js`**: rebuilt to match the CI-validated source (the test suite imports the source, so this only brings the shipped artifact in line with already-tested code).

## Verification (red-proven)

```
# RED — before resyncing dist:
$ node scripts/verify-hooks-sync.cjs
hooks-sync verification FAILED:
  - DIST DRIFT: hooks/dist/nf-circuit-breaker.js differs from source ...
exit 1

# GREEN — after `npm run build:hooks`:
$ node scripts/verify-hooks-sync.cjs
hooks-sync OK: 22 hooks in build list, 19 registered by installer, dist in sync
exit 0
```

The check runs in `test:ci` on every PR, so this drift class can no longer ship silently. Audited all 22 built hooks — `nf-circuit-breaker` was the only drifted one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)