### PR TITLE
feat(quorum): add antigravity (agy) as a quorum CLI family

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -38,12 +38,23 @@ try {
   if (providersData.providers.length === 0) {
     log('providers.json is empty — scanning PATH for known CLIs...');
     const { resolveCli } = require('./resolve-cli.cjs');
-    const KNOWN_CLIS = ['claude', 'codex', 'gemini', 'opencode', 'copilot'];
+    // Most families' binary name == family name; antigravity is the exception
+    // (family "antigravity" ships the `agy` binary), so each entry carries an
+    // explicit binary. `cli` is recorded so resolveSpawnTarget spawns the real
+    // binary while the slot/model keeps the family name.
+    const KNOWN_CLIS = [
+      { family: 'claude',      bin: 'claude' },
+      { family: 'codex',       bin: 'codex' },
+      { family: 'gemini',      bin: 'gemini' },
+      { family: 'opencode',    bin: 'opencode' },
+      { family: 'copilot',     bin: 'copilot' },
+      { family: 'antigravity', bin: 'agy' },
+    ];
     const found = [];
-    for (const name of KNOWN_CLIS) {
-      const resolved = resolveCli(name);
-      if (resolved !== name) {
-        found.push({ name, resolvedPath: resolved, found: true });
+    for (const { family, bin } of KNOWN_CLIS) {
+      const resolved = resolveCli(bin);
+      if (resolved !== bin) {
+        found.push({ name: family, cli: bin, resolvedPath: resolved, found: true });
       }
     }
     if (found.length > 0) {
@@ -76,6 +87,7 @@ function getInstallHint(mainTool) {
     gemini:   'npm i -g @google/gemini-cli',
     opencode: 'npm i -g opencode',
     copilot:  'npm i -g @githubnext/github-copilot-cli',
+    antigravity: 'curl -fsSL https://antigravity.google/cli/install.sh | bash',
   };
   return hints[mainTool] || '';
 }

--- a/bin/nForma.cjs
+++ b/bin/nForma.cjs
@@ -2556,6 +2556,7 @@ async function updateAgentsFlow() {
     opencode: { installType: 'npm-global',   pkg: 'opencode'           },
     copilot:  { installType: 'gh-extension', ext: 'github/gh-copilot'  },
     ccr:      { installType: 'npm-global',   pkg: 'claude-code-router'  },
+    antigravity: { installType: 'curl-script', bin: 'agy', installCommand: 'curl -fsSL https://antigravity.google/cli/install.sh | bash' },
   };
 
   const lines = ['{bold}Update Status{/bold}', '─'.repeat(50)];

--- a/bin/skill-mcp-lint.cjs
+++ b/bin/skill-mcp-lint.cjs
@@ -23,6 +23,7 @@ const VALID_TOOLS = {
   gemini: ['gemini', 'identity', 'health_check', 'deep_health_check', 'help', 'ping'],
   copilot: ['copilot', 'suggest', 'explain', 'identity', 'health_check', 'deep_health_check', 'help', 'ping'],
   opencode: ['opencode', 'opencode_check_update', 'identity', 'health_check', 'deep_health_check', 'help', 'ping'],
+  antigravity: ['antigravity', 'identity', 'health_check', 'deep_health_check', 'help', 'ping'],
 };
 const FAMILIES = Object.keys(VALID_TOOLS);
 

--- a/bin/skill-mcp-lint.test.cjs
+++ b/bin/skill-mcp-lint.test.cjs
@@ -34,6 +34,18 @@ describe('skill-mcp-lint detector', () => {
     assert.deepEqual(v('mcp__codex-1__identity'), []); // shared tools too
   });
 
+  it('recognizes the antigravity family (slot + real/shared tools)', () => {
+    assert.deepEqual(v('mcp__antigravity-1__antigravity'), []);
+    assert.deepEqual(v('mcp__antigravity-1__identity'), []);
+    assert.deepEqual(v('mcp__antigravity-1__health_check'), []);
+  });
+
+  it('flags a tool antigravity does not expose (the `ask` class)', () => {
+    const r = v('mcp__antigravity-1__ask');
+    assert.equal(r.length, 1);
+    assert.equal(r[0].rule, 'mcp-bad-tool');
+  });
+
   it('does NOT validate install-specific / external slots', () => {
     assert.deepEqual(v('mcp__claude-1__claude'), []);
     assert.deepEqual(v('mcp__claude-z-ai__identity'), []);

--- a/bin/token-dashboard.cjs
+++ b/bin/token-dashboard.cjs
@@ -19,6 +19,7 @@ const COST_PER_M = {
   'gemini':    { input: 1.25,  output: 5.00 },
   'opencode':  { input: 2.00,  output: 8.00 },
   'copilot':   { input: 0.00,  output: 0.00, subscription: true },
+  'antigravity': { input: 0.00, output: 0.00, subscription: true },
   'default':   { input: 3.00,  output: 15.00 },
 };
 

--- a/bin/update-agents.cjs
+++ b/bin/update-agents.cjs
@@ -23,6 +23,10 @@ const CLI_META = {
   opencode: { installType: 'npm-global',   pkg: 'opencode' },
   copilot:  { installType: 'gh-extension', ext: 'github/gh-copilot' },
   ccr:      { installType: 'npm-global',   pkg: 'claude-code-router' },
+  // Antigravity ships a self-installing binary `agy` (curl script), not an
+  // npm/gh package — detectCurrent/detectLatest fall through to null for this
+  // installType, so it shows as "unknown" rather than crashing the updater.
+  antigravity: { installType: 'curl-script', bin: 'agy', installCommand: 'curl -fsSL https://antigravity.google/cli/install.sh | bash' },
 };
 
 // ---------------------------------------------------------------------------

--- a/bin/update-scoreboard.cjs
+++ b/bin/update-scoreboard.cjs
@@ -67,7 +67,7 @@ function loadScoreDeltas() {
   return { deltas: DEFAULT_SCORE_DELTAS, source: 'default' };
 }
 
-const VALID_MODELS   = ['claude', 'gemini', 'opencode', 'copilot', 'codex', 'deepseek', 'minimax', 'qwen-coder', 'kimi', 'llama4'];
+const VALID_MODELS   = ['claude', 'gemini', 'opencode', 'copilot', 'codex', 'antigravity', 'deepseek', 'minimax', 'qwen-coder', 'kimi', 'llama4'];
 const VALID_RESULTS  = ['TP', 'TN', 'FP', 'FN', 'TP+', 'TN+', 'UNAVAIL', ''];
 const VALID_VERDICTS = ['APPROVE', 'BLOCK', 'DELIBERATE', 'CONSENSUS', 'GAPS_FOUND', '—'];
 

--- a/bin/update-scoreboard.test.cjs
+++ b/bin/update-scoreboard.test.cjs
@@ -229,6 +229,25 @@ test('SC-TC11: invalid --model value exits 1', () => {
   );
 });
 
+// SC-TC11b: 'antigravity' is a recognized family — a vote with --model antigravity
+// is accepted (exit 0) and recorded. Regression guard for the antigravity quorum
+// CLI family (VALID_MODELS membership); before adding it, this exits 1.
+test('SC-TC11b: --model antigravity is accepted and recorded', () => {
+  const sb = tmpScoreboard();
+  try {
+    const { exitCode } = runCLI([
+      '--model', 'antigravity', '--result', 'TP', '--task', 'quick-99',
+      '--round', '1', '--verdict', 'APPROVE', '--scoreboard', sb,
+    ]);
+    assert.strictEqual(exitCode, 0, 'antigravity must be a valid --model');
+    const data = JSON.parse(fs.readFileSync(sb, 'utf8'));
+    assert.ok(data.models.antigravity, 'antigravity must appear in the scoreboard models map');
+    assert.strictEqual(data.models.antigravity.score, 1, 'one TP vote → score 1');
+  } finally {
+    cleanup(sb);
+  }
+});
+
 // SC-TC12: invalid --result value → exits 1
 test('SC-TC12: invalid --result value exits 1', () => {
   const { stderr, exitCode } = runCLI([

--- a/commands/nf/mcp-status.md
+++ b/commands/nf/mcp-status.md
@@ -100,7 +100,7 @@ if(fs.existsSync(cfgPath)){
 
 // Classify slots dynamically
 const SKIP_SLOTS = ['canopy', 'sentry'];
-const CLI_COMMANDS = ['codex', 'gemini', 'opencode', 'gh', 'copilot'];
+const CLI_COMMANDS = ['codex', 'gemini', 'opencode', 'gh', 'copilot', 'agy'];
 let slots = { cli: [], http: [], mcp: [], skip: [] };
 try {
   if(fs.existsSync(cfgPath)){


### PR DESCRIPTION
## Summary

Adds **Google Antigravity** (`agy` CLI) as a first-class quorum agent family, alongside codex / gemini / opencode / copilot. Requested earlier ("we also need to extend support to antigravity CLI"); implemented via the agreed **research + implement-blind** path.

Antigravity is the first family where the **family name ≠ binary name** (`antigravity` family ships the `agy` binary) and it **subscription-auths** via a self-installing curl binary (default model **Gemini 3.5 Flash**), so each registry handles that explicitly rather than assuming `family == binary`.

## Registries wired

| File | Change |
|---|---|
| `bin/skill-mcp-lint.cjs` | `VALID_TOOLS.antigravity` — lint Rule 6 recognizes `mcp__antigravity-N__antigravity`, rejects bogus tools (`ask`) |
| `bin/update-scoreboard.cjs` | `VALID_MODELS` += `antigravity` (votes accepted + recorded) |
| `bin/token-dashboard.cjs` | subscription cost entry (flat-fee, 0/0) |
| `commands/nf/mcp-status.md` | `CLI_COMMANDS` += `agy` (slot classification) |
| `bin/update-agents.cjs`, `bin/nForma.cjs` | `CLI_META` curl-script installType (version detect → null, no crash) |
| `bin/install.js` | `KNOWN_CLIS` family→binary map (resolves `agy`, records `antigravity` family+cli); curl install hint |

CLI contract (from public docs): binary `agy`; one-shot `agy -p "prompt"` (+`--output-format json`); model via `agy --model`; install `curl -fsSL https://antigravity.google/cli/install.sh | bash`.

## Deliberately NOT changed

`verify-quorum-health.cjs` `SLOTS` is left as the 4-agent fleet (gemini/opencode/copilot/codex). That array feeds the calibrated **P(majority) / maxDeliberation** math tied to the formal PRISM model; adding a 5th standing agent silently shifts the quorum thresholds — a composition decision out of scope for "recognize the family". (Caught by CI: adding it broke the two probability-calibration tests; reverted.)

## Tests (red-proven)

- `skill-mcp-lint.test.cjs`: recognizes the antigravity family (slot + shared tools) and flags a non-exposed tool — **fails against pre-change source**.
- `update-scoreboard.test.cjs` (SC-TC11b): `--model antigravity` accepted (exit 0) and recorded — **fails against pre-change source**.
- All touched suites green; lint Rule 6 green; all changed scripts pass `node -c`.

## ⚠️ Verification caveat

Implemented **without a live `agy` binary** to test against. The registry/validation layer is unit-tested, but **end-to-end quorum dispatch against a real antigravity MCP slot is unverified** until run on a box with the CLI installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)