### PR TITLE
harden(quorum): close 8 adversarial edge-case gaps in dispatch + provider plumbing

### DIFF
--- a/bin/call-quorum-slot-stall-timeout.test.cjs
+++ b/bin/call-quorum-slot-stall-timeout.test.cjs
@@ -68,4 +68,27 @@ describe('ADVERSARIAL: parseVerdictLine edge cases', () => {
     // Sanity guard the multiline anchor + case-insensitivity actually work together.
     assert.equal(parseVerdictLine('here is my reasoning\nVerdict: reject\n(done)'), 'REJECT');
   });
+
+  // ─── ADVERSARIAL round 2 ────────────────────────────────────────────────────
+  it('extracts APPROVE from "verdict: APPROVE BUT WITH CONCERNS" (trailing prose after the keyword)', () => {
+    // The keyword sits immediately after `verdict:`; the \b boundary before the
+    // following space lets trailing prose ("BUT WITH CONCERNS") follow without
+    // breaking the capture. Confirms a hedged-but-on-protocol verdict still records.
+    assert.equal(parseVerdictLine('verdict: APPROVE BUT WITH CONCERNS'), 'APPROVE');
+  });
+
+  it('does NOT false-match REJECT inside "verdict: REJECTED" — the \\b boundary rejects an off-protocol suffix', () => {
+    // REJECTED is off the APPROVE|REJECT|FLAG protocol. The trailing \b after REJECT
+    // sees T→E (two word chars, no boundary), so the capture fails and the parser
+    // returns null rather than silently coercing a partial match to REJECT. This
+    // invariant-confirms the boundary anchor isn't leaking longer words into telemetry.
+    assert.equal(parseVerdictLine('verdict: REJECTED'), null);
+  });
+
+  it('extracts a verdict across a CRLF (\\r\\n) line ending without the \\r leaking into the keyword', () => {
+    // LLM output piped through Windows-ish tooling can carry CRLFs. The multiline ^
+    // must re-anchor after \n and a trailing \r must not corrupt the captured keyword
+    // (a \r immediately after APPROVE is non-word, so \b still holds).
+    assert.equal(parseVerdictLine('reasoning here\r\nverdict: APPROVE\r\nnext line'), 'APPROVE');
+  });
 });

--- a/bin/call-quorum-slot-stall-timeout.test.cjs
+++ b/bin/call-quorum-slot-stall-timeout.test.cjs
@@ -8,7 +8,7 @@
 
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
-const { stallTimeoutFor } = require('./call-quorum-slot.cjs');
+const { stallTimeoutFor, parseVerdictLine } = require('./call-quorum-slot.cjs');
 
 describe('stallTimeoutFor — per-slot stall timeout override', () => {
   it('defaults to 30000ms when stall_timeout_ms is absent', () => {
@@ -43,5 +43,29 @@ describe('stallTimeoutFor — per-slot stall timeout override', () => {
     assert.equal(stallTimeoutFor({ stall_timeout_ms: MAX + 1 }), MAX);
     assert.equal(stallTimeoutFor({ stall_timeout_ms: Infinity }), MAX);
     assert.equal(stallTimeoutFor({ stall_timeout_ms: MAX }), MAX); // boundary, unchanged
+  });
+
+  // ─── ADVERSARIAL: type-coercion gap ──────────────────────────────────────────
+  it('falls back to 30000 for a boolean true instead of a 1ms stall timer (type-coercion gap)', () => {
+    // Number(true) === 1, which passes the `v > 0` guard, so a boolean config value
+    // yields a 1ms stall timeout — every slot is instantly false-killed as STALLed.
+    // A non-numeric type like a boolean is not a valid duration and must fall back.
+    assert.equal(stallTimeoutFor({ stall_timeout_ms: true }), 30000);
+  });
+});
+
+// ─── ADVERSARIAL: parseVerdictLine robustness ─────────────────────────────────
+describe('ADVERSARIAL: parseVerdictLine edge cases', () => {
+  it('extracts APPROVE from a markdown-bolded value "verdict: **APPROVE**"', () => {
+    // VERDICT_LINE_RE requires the keyword immediately after `verdict:\s*`, so a
+    // markdown-emphasized value (very common in LLM output) parses as null and the
+    // verdict telemetry the whole VERDICT-01 fix exists to protect silently records
+    // UNKNOWN.
+    assert.equal(parseVerdictLine('verdict: **APPROVE**'), 'APPROVE');
+  });
+
+  it('parses a verdict that appears mid-text on its own line, case-insensitively', () => {
+    // Sanity guard the multiline anchor + case-insensitivity actually work together.
+    assert.equal(parseVerdictLine('here is my reasoning\nVerdict: reject\n(done)'), 'REJECT');
   });
 });

--- a/bin/call-quorum-slot.cjs
+++ b/bin/call-quorum-slot.cjs
@@ -47,7 +47,10 @@ function sleep(ms) {
 //      (e.g. "I would not APPROVE this" parsed as APPROVE), corrupting the
 //      verdict telemetry that feeds the score-delta calibration (#175).
 const VERDICTS = Object.freeze(['APPROVE', 'REJECT', 'FLAG']);
-const VERDICT_LINE_RE = /^verdict:\s*(APPROVE|REJECT|FLAG)\b/im;
+// Tolerant of common LLM markdown: leading blockquote/bold (`> `, `**`) and bold
+// around the keyword (`verdict: **APPROVE**`). Still effectively line-anchored —
+// only whitespace/`>`/`*` may precede `verdict:`, so prose mentions don't register.
+const VERDICT_LINE_RE = /^[\s>*]*verdict:\s*\**\s*(APPROVE|REJECT|FLAG)\b/im;
 
 /**
  * parseVerdictLine — extract the verdict from an anchored `verdict:` line.
@@ -399,8 +402,12 @@ function readStdin() {
 
 // ─── SHELL-ESCAPE-01: Args builder (extracted for testability) ────────────────
 function buildSpawnArgs(provider, prompt, allowedToolsFlag) {
+  // Match `ccr` as a path SEGMENT/basename, not a raw substring: a plain
+  // `.includes('ccr')` false-matches innocent paths (e.g. /Users/mccray/bin/gemini),
+  // wrongly flagging the slot as CCR and neutralizing $/!/backticks in its prompt.
+  const _cliPath = provider.resolvedCli ?? provider.cli ?? '';
   const isCcr = provider.display_type === 'claude-code-router' ||
-    ((provider.resolvedCli ?? provider.cli) && (provider.resolvedCli ?? provider.cli).includes('ccr'));
+    /(^|\/)ccr([\/-]|$)/.test(_cliPath);
 
   let args;
   let useStdinPrompt = false;
@@ -433,7 +440,12 @@ function buildSpawnArgs(provider, prompt, allowedToolsFlag) {
       `(run install or /nf:mcp-setup), or add an args_template to this slot.`
     );
   }
-  args = argsTemplate.map(a => (a === '{prompt}' ? safePrompt : a));
+  // Substitute the {prompt} placeholder. Handle both a bare element (`'{prompt}'`)
+  // AND an embedded form (`'--prompt={prompt}'`), and replace every occurrence —
+  // exact-equality-only substitution silently shipped a literal `{prompt}` to the CLI.
+  args = argsTemplate.map(a =>
+    (typeof a === 'string' && a.includes('{prompt}')) ? a.split('{prompt}').join(safePrompt) : a
+  );
   // Only use stdin for slots that explicitly require it (none currently do)
   useStdinPrompt = false;
 
@@ -462,7 +474,12 @@ function buildSpawnArgs(provider, prompt, allowedToolsFlag) {
 // at TIMEOUT_MAX to keep the timer well-formed.
 const TIMEOUT_MAX = 2147483647; // 2^31 - 1
 function stallTimeoutFor(provider) {
-  const v = Number(provider && provider.stall_timeout_ms);
+  const raw = provider && provider.stall_timeout_ms;
+  // Only coerce real numbers / numeric strings. Without this, Number(true) === 1
+  // would pass the `> 0` guard and yield a 1ms stall timer that instantly false-kills
+  // every slot. Booleans/objects/etc. fall back to the default.
+  if (typeof raw !== 'number' && typeof raw !== 'string') return 30000;
+  const v = Number(raw);
   if (!(v > 0)) return 30000;
   return Math.min(v, TIMEOUT_MAX);
 }

--- a/bin/call-quorum-slot.cjs
+++ b/bin/call-quorum-slot.cjs
@@ -440,6 +440,16 @@ function buildSpawnArgs(provider, prompt, allowedToolsFlag) {
       `(run install or /nf:mcp-setup), or add an args_template to this slot.`
     );
   }
+  // The prompt is delivered exclusively through a {prompt} placeholder (no slot uses
+  // stdin). An empty template or one lacking the placeholder would silently drop the
+  // prompt — the CLI runs with flags but no question. Fail LOUD instead, matching the
+  // missing-args_template contract above.
+  if (!useStdinPrompt && !argsTemplate.some(a => typeof a === 'string' && a.includes('{prompt}'))) {
+    throw new Error(
+      `provider ${provider.name || '(unnamed)'} args_template has no {prompt} placeholder ` +
+      `(${JSON.stringify(argsTemplate)}) — the prompt would be silently dropped; fix providers.json.`
+    );
+  }
   // Substitute the {prompt} placeholder. Handle both a bare element (`'{prompt}'`)
   // AND an embedded form (`'--prompt={prompt}'`), and replace every occurrence —
   // exact-equality-only substitution silently shipped a literal `{prompt}` to the CLI.

--- a/bin/provider-arg-templates.cjs
+++ b/bin/provider-arg-templates.cjs
@@ -43,7 +43,10 @@ const FAMILY_ARGS_TEMPLATE = {
  */
 function argsTemplateFor(mainTool) {
   const t = FAMILY_ARGS_TEMPLATE[mainTool];
-  return t ? t.slice() : null;
+  // Array.isArray (not a truthy check): a prototype-chain key like '__proto__' or
+  // 'constructor' resolves to a function/Object.prototype here — truthy but not a
+  // template — so guard on the actual shape and treat it as an unknown family.
+  return Array.isArray(t) ? t.slice() : null;
 }
 
 /**

--- a/bin/provider-arg-templates.cjs
+++ b/bin/provider-arg-templates.cjs
@@ -58,7 +58,9 @@ function argsTemplateFor(mainTool) {
  * @returns {string[]|null}
  */
 function resolveArgsTemplate(provider) {
-  if (provider && Array.isArray(provider.args_template)) return provider.args_template;
+  // Return a defensive COPY (like argsTemplateFor) so a caller mutating the result
+  // can't corrupt the provider's stored args_template for later dispatches.
+  if (provider && Array.isArray(provider.args_template)) return provider.args_template.slice();
   if (provider && provider.mainTool) return argsTemplateFor(provider.mainTool);
   return null;
 }

--- a/bin/provider-arg-templates.test.cjs
+++ b/bin/provider-arg-templates.test.cjs
@@ -210,3 +210,60 @@ describe('ADVERSARIAL round 3: EXEC-01 --allowedTools injection for review-only 
     assert.deepEqual(gem.args, ['-p', 'review this'], 'non-CCR argv is unaffected by the allowedTools flag');
   });
 });
+
+// ─── ADVERSARIAL round 4 (final convergence): non-string template elements + ──
+// empty/special-only CCR prompt. Round-4 re-swept the three remaining "last
+// things to consider": (a) an explicit args_template carrying non-string
+// elements alongside a bare {prompt}; (b) safePrompt CCR neutralization on a
+// prompt that is empty or only special chars; (c) the shallow-copy depth of
+// argsTemplateFor (arrays of immutable strings → .slice() suffices). All three
+// are non-defects: the `typeof a === 'string'` gate fronts every `.includes`,
+// neutralization always yields a valid string argv element, and the templates
+// have no nested mutation surface. This single invariant locks in the riskiest
+// of the three — the typeof gate around substitution — so a future regression
+// that drops it (and calls `.includes`/`.split` on a number → TypeError) is
+// caught. CONVERGED — no new real gaps.
+describe('ADVERSARIAL round 4: non-string template elements + empty/special CCR prompt', () => {
+  it('passes non-string args_template elements through untouched while substituting a bare {prompt} (no TypeError on numbers/objects)', () => {
+    // The {prompt}-presence guard and the substitution map both front `.includes`
+    // with `typeof a === 'string'`, so numeric/object elements never hit a string
+    // method. They must survive verbatim and the lone string {prompt} must resolve.
+    const obj = { k: 'v' };
+    const { args } = buildSpawnArgs(
+      { name: 'x-1', mainTool: 'gemini', args_template: [42, obj, '{prompt}', true] },
+      'HELLO'
+    );
+    assert.equal(args.length, 4, 'all four elements preserved');
+    assert.equal(args[0], 42, 'numeric element passes through unchanged');
+    assert.equal(args[1], obj, 'object element passes through by reference, untouched');
+    assert.equal(args[2], 'HELLO', 'the bare string {prompt} is substituted');
+    assert.equal(args[3], true, 'boolean element passes through unchanged');
+  });
+
+  it('a CCR slot with an empty-string prompt yields a valid empty argv element (not undefined, not dropped, promptMutated=false)', () => {
+    // safePrompt on '' is '' (no special chars to neutralize), so the {prompt}
+    // slot must still materialize as an empty string element — a valid argv entry —
+    // and promptMutated must be false (nothing changed).
+    const { args, isCcr, promptMutated } = buildSpawnArgs(
+      { name: 'ccr-1', display_type: 'claude-code-router', mainTool: 'claude' },
+      ''
+    );
+    assert.equal(isCcr, true);
+    assert.equal(promptMutated, false, 'an empty prompt is unchanged by neutralization');
+    const pIdx = args.indexOf('-p');
+    assert.equal(args[pIdx + 1], '', 'the prompt slot is a valid empty string, not undefined/dropped');
+  });
+
+  it('a CCR slot with an only-special-chars prompt neutralizes to a valid string element and flags promptMutated', () => {
+    // '`$!' → backtick→', $→stripped, !→.  → produces "'." — still a non-empty,
+    // valid string argv element, and promptMutated is true (chars were changed).
+    const { args, promptMutated } = buildSpawnArgs(
+      { name: 'ccr-1', display_type: 'claude-code-router', mainTool: 'claude' },
+      '`$!'
+    );
+    assert.equal(promptMutated, true, 'special chars were neutralized');
+    const pIdx = args.indexOf('-p');
+    assert.equal(typeof args[pIdx + 1], 'string', 'neutralized prompt remains a string argv element');
+    assert.equal(args[pIdx + 1], "'.", 'backtick→quote, $ stripped, !→. — deterministic neutralization');
+  });
+});

--- a/bin/provider-arg-templates.test.cjs
+++ b/bin/provider-arg-templates.test.cjs
@@ -174,3 +174,39 @@ describe('ADVERSARIAL round 2: silent prompt-drop + template aliasing', () => {
     );
   });
 });
+
+// ─── ADVERSARIAL round 3 (convergence check): EXEC-01 allowedTools splice branch ──
+// The `if (allowedToolsFlag && isCcr)` injection in buildSpawnArgs was entirely
+// untested across rounds 1+2. Round-3 sweep of the source (atomicUpdateJson,
+// findProjectRoot, writeFailureLog, stallTimeoutFor(null), lowercase/anchored
+// verdict parsing, {prompt} substitution) surfaced NO new real defect — the helpers
+// fail-open and the shape guards hold. This test locks in the one genuinely
+// uncovered code path so a future regression in the splice (wrong order, missing
+// value, or accidental duplication) is caught.
+describe('ADVERSARIAL round 3: EXEC-01 --allowedTools injection for review-only CCR slots', () => {
+  it('injects --allowedTools once, ordered before --dangerously-skip-permissions, and ONLY for CCR slots', () => {
+    // Positive: a CCR slot gets the flag/value pair spliced directly before
+    // --dangerously-skip-permissions, exactly once (no order/duplication drift).
+    const ccr = buildSpawnArgs(
+      { name: 'ccr-rev-1', display_type: 'claude-code-router', mainTool: 'claude' },
+      'review this',
+      'Read,Grep,Glob'
+    );
+    assert.equal(ccr.isCcr, true, 'a claude-code-router slot must be classified as CCR');
+    const atIdx = ccr.args.indexOf('--allowedTools');
+    const dspIdx = ccr.args.indexOf('--dangerously-skip-permissions');
+    assert.ok(atIdx !== -1, '--allowedTools must be injected for a review-only CCR slot');
+    assert.equal(ccr.args[atIdx + 1], 'Read,Grep,Glob', 'the tools value must immediately follow the flag');
+    assert.equal(dspIdx - atIdx, 2, 'the flag/value pair must sit directly before --dangerously-skip-permissions');
+    assert.equal(
+      ccr.args.filter(a => a === '--allowedTools').length, 1,
+      'must not duplicate --allowedTools'
+    );
+
+    // Negative guard: the injection is claude-CLI-specific (`&& isCcr`). A plain
+    // gemini slot must never receive --allowedTools (gemini has no such flag).
+    const gem = buildSpawnArgs({ name: 'gemini-1', mainTool: 'gemini' }, 'review this', 'Read,Grep,Glob');
+    assert.equal(gem.isCcr, false);
+    assert.deepEqual(gem.args, ['-p', 'review this'], 'non-CCR argv is unaffected by the allowedTools flag');
+  });
+});

--- a/bin/provider-arg-templates.test.cjs
+++ b/bin/provider-arg-templates.test.cjs
@@ -120,3 +120,57 @@ describe('ADVERSARIAL: provider-arg-templates + buildSpawnArgs edge cases', () =
     assert.equal(args[0], '--prompt=HELLO', 'embedded {prompt} token must be substituted');
   });
 });
+
+// ─── ADVERSARIAL round 2: silent prompt-drop + reference aliasing ─────────────
+describe('ADVERSARIAL round 2: silent prompt-drop + template aliasing', () => {
+  it('buildSpawnArgs does NOT silently drop the prompt when args_template is an empty array []', () => {
+    // resolveArgsTemplate accepts [] (it IS an Array, so the shape guard passes), then
+    // buildSpawnArgs maps it to [] and returns an EMPTY argv — the prompt vanishes and
+    // the CLI is spawned with no input at all. There is no guard that the resolved
+    // template actually carries a {prompt} slot, so the slot runs the model against an
+    // empty prompt instead of failing LOUD the way an unknown family does. A malformed
+    // providers.json with `args_template: []` is exactly the ARGS-TEMPLATE-01 failure
+    // class (auto-generated bad templates) — it should not silently mis-dispatch.
+    // Fix chose the loud-failure path (which this test's own comment endorses): an
+    // empty template can't carry the prompt, so dispatch throws a clear config error
+    // rather than spawning the CLI with an empty argv. Safer than guessing where to
+    // append the prompt.
+    assert.throws(
+      () => buildSpawnArgs({ name: 'gemini-1', mainTool: 'gemini', args_template: [] }, 'PAYLOAD'),
+      /no \{prompt\} placeholder/,
+      'an empty args_template must fail loud, not silently drop the prompt'
+    );
+  });
+
+  it('buildSpawnArgs does NOT silently drop the prompt when args_template has no {prompt} placeholder', () => {
+    // A provider that forgets the {prompt} token (e.g. a typo'd ['-p'] template) is
+    // mapped verbatim — nothing matches `.includes('{prompt}')`, so the prompt is never
+    // substituted in. The CLI is invoked with flags but NO actual question. Exact-token
+    // substitution means a missing placeholder is completely undetected; the model
+    // answers an empty prompt and the verdict telemetry records garbage.
+    // Loud-failure path (per the test's own comment): a template lacking {prompt}
+    // can't deliver the prompt, so dispatch throws rather than invoking the CLI with
+    // flags but no question.
+    assert.throws(
+      () => buildSpawnArgs({ name: 'gemini-1', mainTool: 'gemini', args_template: ['-p'] }, 'PAYLOAD'),
+      /no \{prompt\} placeholder/,
+      'a template missing {prompt} must fail loud, not silently drop the prompt'
+    );
+  });
+
+  it('resolveArgsTemplate returns a defensive COPY of an explicit args_template, not the provider\'s own array by reference', () => {
+    // argsTemplateFor() returns `t.slice()` (round-1 locked this in), but the explicit
+    // branch of resolveArgsTemplate returns `provider.args_template` DIRECTLY. A caller
+    // that mutates the returned array (e.g. an EXEC-01 --allowedTools splice, or any
+    // consumer in unified-mcp-server / probe-quorum-slots) corrupts the provider's
+    // STORED template for every subsequent dispatch in the same process — an
+    // inconsistent, unsafe aliasing gap relative to argsTemplateFor.
+    const p = { mainTool: 'gemini', args_template: ['-p', '{prompt}'] };
+    const returned = resolveArgsTemplate(p);
+    returned.push('MUTATED');
+    assert.ok(
+      !p.args_template.includes('MUTATED'),
+      'resolveArgsTemplate must not expose the provider\'s stored template by reference'
+    );
+  });
+});

--- a/bin/provider-arg-templates.test.cjs
+++ b/bin/provider-arg-templates.test.cjs
@@ -84,3 +84,39 @@ describe('buildSpawnArgs: no crash on a provider missing args_template', () => {
     );
   });
 });
+
+// ─── ADVERSARIAL edge cases (added to expose shape-guard / coercion gaps) ──────
+describe('ADVERSARIAL: provider-arg-templates + buildSpawnArgs edge cases', () => {
+  it('argsTemplateFor("__proto__") treats a prototype-chain key as unknown and returns null (no thrown TypeError)', () => {
+    // FAMILY_ARGS_TEMPLATE['__proto__'] resolves to Object.prototype (truthy), so the
+    // `t ? t.slice() : null` guard calls Object.prototype.slice → TypeError instead of
+    // returning null for this unknown "family". A dotted-path/prototype key must be
+    // handled identically to any other unknown family: null, not a crash.
+    assert.equal(argsTemplateFor('__proto__'), null, '__proto__ must be treated as an unknown family');
+  });
+
+  it('buildSpawnArgs does NOT misclassify a non-ccr slot as CCR when the CLI path merely contains the substring "ccr"', () => {
+    // isCcr uses `cli.includes('ccr')` — a loose substring match. A perfectly normal
+    // home-dir path like /Users/mccray/bin/gemini contains "ccr" (m-c-c-r-ay), so the
+    // gemini slot is wrongly treated as CCR and its prompt gets $/!/backtick-neutralized,
+    // corrupting any review that cites those characters.
+    const { isCcr, promptMutated, args } = buildSpawnArgs(
+      { name: 'gemini-1', mainTool: 'gemini', cli: '/Users/mccray/bin/gemini' },
+      'fix the `code` and the $VAR and the bang!'
+    );
+    assert.equal(Boolean(isCcr), false, 'a username substring "ccr" must not flag the slot as CCR');
+    assert.equal(promptMutated, false, 'the prompt must not be mutated for a non-CCR slot');
+    assert.equal(args[1], 'fix the `code` and the $VAR and the bang!', 'prompt passed through verbatim');
+  });
+
+  it('buildSpawnArgs substitutes an embedded {prompt} token (e.g. --prompt={prompt}), not only a bare element', () => {
+    // Substitution is `a === '{prompt}'` (exact element equality). A provider that writes
+    // the placeholder embedded in a flag (--prompt={prompt}) gets the literal token sent
+    // to the CLI instead of the real prompt — a silent, hard-to-debug dispatch failure.
+    const { args } = buildSpawnArgs(
+      { name: 'x-1', mainTool: 'gemini', args_template: ['--prompt={prompt}'] },
+      'HELLO'
+    );
+    assert.equal(args[0], '--prompt=HELLO', 'embedded {prompt} token must be substituted');
+  });
+});


### PR DESCRIPTION
## What

`/nf:harden` adversarial loop on the quorum-dispatch + provider plumbing (`call-quorum-slot.cjs`, `provider-arg-templates.cjs`). **Converged after 4 iterations** (2 consecutive zero-change) — **8 genuine gaps found and fixed**, plus invariant tests locking the verified-correct behavior.

## Gaps fixed (all reachable from real config / real LLM output)

**Iteration 1 (5):**
1. `argsTemplateFor('__proto__'/'constructor')` resolved to a prototype object (truthy) → `TypeError` on `.slice`. Now `Array.isArray`-guarded → treated as unknown family.
2. `isCcr` used `cli.includes('ccr')` (raw substring) → `/Users/mccray/bin/gemini` was flagged CCR and had `$`/`!`/backticks neutralized in its prompt. Now matches a path **segment**.
3. `{prompt}` substitution was exact-element-only → an embedded `--prompt={prompt}` shipped a literal token. Now replaces every occurrence (bare or embedded).
4. `stallTimeoutFor` coerced booleans: `Number(true)===1` → a 1ms stall timer that false-kills every slot. Now only coerces real numbers / numeric strings.
5. `VERDICT_LINE_RE` missed `verdict: **APPROVE**` (markdown bold) — **hit live in this session's quorum**; verdict silently recorded UNKNOWN. Regex now tolerates leading `>`/`*` and bold around the keyword, still line-anchored.

**Iteration 2 (3):**
6. Empty `[]` `args_template` → silent prompt drop (empty argv). Now **fails loud** (no `{prompt}` placeholder → clear error), matching the missing-args_template contract.
7. Placeholder-less template (`['-p']`) → same silent drop, same fail-loud guard.
8. `resolveArgsTemplate` returned the provider's array **by reference** (unlike `argsTemplateFor` which copies) → a consumer mutating it corrupted the stored template. Now returns a defensive copy.

**Iterations 3 & 4 (zero-change):** verified `atomicUpdateJson`, `findProjectRoot`, `writeFailureLog`, `stallTimeoutFor(null)`, lowercase/CRLF/REJECTED-boundary verdicts, the `--allowedTools` EXEC-01 splice, and non-string/empty/special-char prompt handling are all already correct — added invariant tests, no source changes. Converged.

## Verification

In-scope suite **89/89**; lint OK. Each fix was red-proven by the adversarial agent (the test failed against pre-fix source, passes after). Two prompt-drop tests assert the fail-loud path their own comments endorse (safer for a quorum than guessing where to append a prompt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)