### PR TITLE
harden(hooks): close quorum-gate bypasses + oscillation mis-detection in nf-stop & nf-circuit-breaker

### DIFF
--- a/hooks/dist/nf-circuit-breaker.js
+++ b/hooks/dist/nf-circuit-breaker.js
@@ -187,10 +187,10 @@ function hasReversionInHashes(gitRoot, hashes, files, pairStatsOut) {
   return (totalNetChange <= 0 && hasNegativePair) || contentReverts;
 }
 
-// Content fingerprint of the file set at one commit: the blob SHAs of `files`, sorted
-// for determinism, with an absent file recorded as a sentinel (so add/remove of a file
-// is itself a state change). One `git ls-tree` call per commit. Returns null on git
-// error so the caller can fall back rather than mis-decide.
+// Content fingerprint of the file set at one commit: git's own (repo-relative path, blob
+// SHA) pairs for `files`, sorted for determinism. An absent file simply doesn't appear in
+// the ls-tree output (so add/remove of a file changes the fingerprint). One `git ls-tree`
+// call per commit. Returns null on git error so the caller can fall back, not mis-decide.
 function fileSetContentFingerprint(gitRoot, hash, files) {
   const r = spawnSync('git', ['ls-tree', hash, '--', ...files], {
     cwd: gitRoot, encoding: 'utf8', timeout: 5000,

--- a/hooks/dist/nf-circuit-breaker.js
+++ b/hooks/dist/nf-circuit-breaker.js
@@ -129,6 +129,8 @@ function hasReversionInHashes(gitRoot, hashes, files, pairStatsOut) {
   // We diff older → newer: git diff <hashes[i]> <hashes[i-1]>
   let totalNetChange = 0;
   let hasNegativePair = false;
+  let hasPositivePair = false;
+  let negPairs = 0;
   let errorsOnly = true;
 
   for (let i = hashes.length - 1; i >= 1; i--) {
@@ -155,7 +157,8 @@ function hasReversionInHashes(gitRoot, hashes, files, pairStatsOut) {
 
     const pairNet = additions - deletions;
     totalNetChange += pairNet;
-    if (pairNet < 0) hasNegativePair = true;
+    if (pairNet < 0) { hasNegativePair = true; negPairs++; }
+    if (pairNet > 0) hasPositivePair = true;
 
     // Collect pair stats for rollback intent detection
     if (Array.isArray(pairStatsOut)) {
@@ -166,10 +169,64 @@ function hasReversionInHashes(gitRoot, hashes, files, pairStatsOut) {
   // If all pairs errored out → fall back to original behavior (treat as oscillation)
   if (errorsOnly) return true;
 
-  // Positive net change → file grew overall → TDD progression, not oscillation
-  // Zero or negative net change WITH at least one negative pair → real oscillation
-  // Zero or negative net change with NO negative pair → monotonic substitution workflow, not oscillation
-  return totalNetChange <= 0 && hasNegativePair;
+  const contentReverts = hasContentReversion(gitRoot, hashes, files) === true;
+
+  // SUSTAINED MONOTONIC SHRINK is a directional cleanup (e.g. dead-code removal
+  // 6→4→2 lines: two-plus deletion-only pairs, no additions anywhere, and the content
+  // never returns to a prior state), NOT a loop — do not trip the breaker. This is the
+  // false-positive the old `totalNetChange <= 0 && hasNegativePair` proxy produced. A
+  // SINGLE deletion pair or any size churn is still judged by the size signal below, so
+  // short patterns keep their established behavior.
+  if (negPairs >= 2 && !hasPositivePair && !contentReverts) return false;
+
+  // Oscillation when EITHER:
+  //  - the established size signal: non-positive net change with at least one removal
+  //    (catches size-alternating churn 1→2→1→2 and short net-negative reversions), OR
+  //  - a byte-level CONTENT REVERSION (A→B→A): catches EQUAL-LENGTH value toggles
+  //    (FLAG="on"↔"off") whose pairs are all net-zero, so the size signal can't see them.
+  return (totalNetChange <= 0 && hasNegativePair) || contentReverts;
+}
+
+// Content fingerprint of the file set at one commit: the blob SHAs of `files`, sorted
+// for determinism, with an absent file recorded as a sentinel (so add/remove of a file
+// is itself a state change). One `git ls-tree` call per commit. Returns null on git
+// error so the caller can fall back rather than mis-decide.
+function fileSetContentFingerprint(gitRoot, hash, files) {
+  const r = spawnSync('git', ['ls-tree', hash, '--', ...files], {
+    cwd: gitRoot, encoding: 'utf8', timeout: 5000,
+  });
+  if (r.error || r.status !== 0) return null;
+  // Build the fingerprint from git's OWN output pairs (repo-relative path + blob SHA),
+  // NOT by looking up the original `files` pathspecs — those may be absolute while
+  // ls-tree emits repo-relative paths, so a lookup would never match and every commit
+  // would fingerprint identically. An absent file simply doesn't appear (its state).
+  const pairs = [];
+  for (const line of (r.stdout || '').split('\n')) {
+    const m = line.match(/^\S+\s+\S+\s+(\S+)\t(.+)$/); // "<mode> blob <sha>\t<path>"
+    if (m) pairs.push(m[2] + '=' + m[1]);
+  }
+  pairs.sort();
+  return pairs.join('\0');
+}
+
+// True if the file set's content returns to a prior state across `hashes` (a real
+// A→B→A reversion), false if every state is unique (monotonic shrink or forward
+// progression — NOT oscillation), or null if fingerprints can't be computed (git error
+// → caller falls back). Consecutive identical states (a commit that touched only OTHER
+// files) are collapsed first so they don't read as a spurious repeat.
+function hasContentReversion(gitRoot, hashes, files) {
+  const fps = [];
+  for (const hash of hashes) {
+    const fp = fileSetContentFingerprint(gitRoot, hash, files);
+    if (fp === null) return null;
+    if (fps.length === 0 || fps[fps.length - 1] !== fp) fps.push(fp); // collapse adjacent dups
+  }
+  const seen = new Set();
+  for (const fp of fps) {
+    if (seen.has(fp)) return true; // a state recurs after leaving it → reversion
+    seen.add(fp);
+  }
+  return false;
 }
 
 // Counts full oscillation cycles for a file set key.

--- a/hooks/dist/nf-circuit-breaker.js
+++ b/hooks/dist/nf-circuit-breaker.js
@@ -169,15 +169,19 @@ function hasReversionInHashes(gitRoot, hashes, files, pairStatsOut) {
   // If all pairs errored out → fall back to original behavior (treat as oscillation)
   if (errorsOnly) return true;
 
-  const contentReverts = hasContentReversion(gitRoot, hashes, files) === true;
+  const reversion = hasContentReversion(gitRoot, hashes, files); // true | false | null (git error)
+  const contentReverts = reversion === true;
 
   // SUSTAINED MONOTONIC SHRINK is a directional cleanup (e.g. dead-code removal
   // 6→4→2 lines: two-plus deletion-only pairs, no additions anywhere, and the content
   // never returns to a prior state), NOT a loop — do not trip the breaker. This is the
   // false-positive the old `totalNetChange <= 0 && hasNegativePair` proxy produced. A
   // SINGLE deletion pair or any size churn is still judged by the size signal below, so
-  // short patterns keep their established behavior.
-  if (negPairs >= 2 && !hasPositivePair && !contentReverts) return false;
+  // short patterns keep their established behavior. Gate on `reversion === false`
+  // (POSITIVELY confirmed no reversion), not `!contentReverts` — if fingerprinting was
+  // unavailable (reversion === null, a transient git error) we must NOT assume "no
+  // reversion" and silently exempt; fall through to the size heuristic instead.
+  if (negPairs >= 2 && !hasPositivePair && reversion === false) return false;
 
   // Oscillation when EITHER:
   //  - the established size signal: non-positive net change with at least one removal

--- a/hooks/dist/nf-stop.js
+++ b/hooks/dist/nf-stop.js
@@ -734,11 +734,14 @@ function getLastDispatchRoundResults(currentTurnLines) {
 function countLiveSlotWorkers(currentTurnLines) {
   let liveCount = 0;
   for (const result of getLastDispatchRoundResults(currentTurnLines)) {
-    // A live voter carries an explicit APPROVE/BLOCK verdict. Matching the verdict
-    // positively (rather than excluding UNAVAIL/FLAG_TRUNCATED) avoids counting error
-    // results as votes, and avoids dropping a valid vote whose reasoning text merely
-    // mentions the word "UNAVAIL". Fails safe: an unrecognized result is not a vote.
-    if (/verdict:\s*(?:APPROVE|BLOCK)\b/i.test(result)) liveCount++;
+    // A live voter carries an explicit APPROVE/BLOCK/REJECT verdict. Matching the
+    // verdict positively (rather than excluding UNAVAIL/FLAG_TRUNCATED) avoids counting
+    // error results as votes, and avoids dropping a valid vote whose reasoning text
+    // merely mentions the word "UNAVAIL". REJECT (Mode B) counts like BLOCK (Mode A) so
+    // a mixed [APPROVE, REJECT] round reaches the CE-2 consensus backstop with the
+    // accurate "consensus not reached" reason instead of a misleading floor block.
+    // Fails safe: an unrecognized result is not a vote.
+    if (/verdict:\s*(?:APPROVE|BLOCK|REJECT)\b/i.test(result)) liveCount++;
   }
   return liveCount;
 }

--- a/hooks/dist/nf-stop.js
+++ b/hooks/dist/nf-stop.js
@@ -628,7 +628,11 @@ function detectUnavailWithoutFallback(currentTurnLines, cwd) {
 
     for (const taskId of round.taskIds) {
       const result = taskResults.get(taskId) || '';
-      if (/verdict:\s*UNAVAIL/i.test(result) || /\bUNAVAIL\b/.test(result)) {
+      // Anchor to the verdict line only. The old bare `/\bUNAVAIL\b/` whole-text match
+      // false-blocked a legitimate all-APPROVE consensus whose reasoning prose merely
+      // mentioned the word "UNAVAIL" (e.g. "codex-1 was UNAVAIL earlier") with a
+      // FALLBACK-01 VIOLATION — mirrors the hardening already in countLiveSlotWorkers.
+      if (/verdict:\s*UNAVAIL/i.test(result)) {
         hasUnavail = true;
         break;
       }
@@ -665,11 +669,13 @@ function detectUnavailWithoutFallback(currentTurnLines, cwd) {
 // tool_result blocks. A result counts as a live voter only if it carries an explicit
 // APPROVE or BLOCK verdict — UNAVAIL, FLAG_TRUNCATED, error, and empty results are
 // non-votes and excluded. Returns the count of valid votes in the last dispatch round.
-function countLiveSlotWorkers(currentTurnLines) {
-  // Track dispatch rounds (groups of parallel slot-worker Tasks per assistant message)
+// Walks the current turn for nf-quorum-slot-worker dispatch rounds and returns the
+// result texts of the LAST (consensus) dispatch round. Shared by countLiveSlotWorkers
+// and detectUnresolvedBlock so both reason over the same round with identical scoping —
+// a BLOCK that a later deliberation round resolved into APPROVE is never seen here.
+function getLastDispatchRoundResults(currentTurnLines) {
   const roundIds = [];       // Array of Sets, one per dispatch round
   const taskResults = new Map(); // tool_use_id → result text
-
   let currentRoundIds = null;
 
   for (const line of currentTurnLines) {
@@ -720,13 +726,14 @@ function countLiveSlotWorkers(currentTurnLines) {
     } catch { /* skip malformed */ }
   }
 
-  // Only count live voters from the LAST dispatch round (the consensus round)
-  if (roundIds.length === 0) return 0;
+  if (roundIds.length === 0) return [];
   const lastRound = roundIds[roundIds.length - 1];
+  return [...lastRound].map(id => taskResults.get(id) || '');
+}
 
+function countLiveSlotWorkers(currentTurnLines) {
   let liveCount = 0;
-  for (const id of lastRound) {
-    const result = taskResults.get(id) || '';
+  for (const result of getLastDispatchRoundResults(currentTurnLines)) {
     // A live voter carries an explicit APPROVE/BLOCK verdict. Matching the verdict
     // positively (rather than excluding UNAVAIL/FLAG_TRUNCATED) avoids counting error
     // results as votes, and avoids dropping a valid vote whose reasoning text merely
@@ -734,6 +741,19 @@ function countLiveSlotWorkers(currentTurnLines) {
     if (/verdict:\s*(?:APPROVE|BLOCK)\b/i.test(result)) liveCount++;
   }
   return liveCount;
+}
+
+// CE-2 (BLOCK is absolute) gate backstop. Returns true when the consensus (last)
+// dispatch round still carries an unresolved BLOCK/REJECT verdict. Anchored to the
+// verdict line so prose mentioning "block"/"reject" is not a vote; scoped to the last
+// round (via getLastDispatchRoundResults) so a BLOCK resolved by a later deliberation
+// round does NOT false-block. Without this the gate counted a BLOCK as a live voter and
+// let a unanimous-BLOCK / split-APPROVE-BLOCK round ship the planning output.
+function detectUnresolvedBlock(currentTurnLines) {
+  for (const result of getLastDispatchRoundResults(currentTurnLines)) {
+    if (/verdict:\s*(?:BLOCK|REJECT)\b/i.test(result)) return true;
+  }
+  return false;
 }
 
 // Extracts min_live_voters from config with safe default.
@@ -1001,6 +1021,27 @@ function main() {
             decision: 'block',
             reason: 'QUORUM FLOOR NOT MET: Only ' + liveSlotWorkers + ' live voter(s) (min_live_voters = ' + minLiveVoters + '). ' +
               'Too many slots are UNAVAIL for reliable consensus. Re-dispatch with extended timeouts, or re-run with --force-quorum to waive.'
+          }));
+          process.exit(0);
+        }
+
+        // CE-2 BLOCK-is-absolute backstop: even with the floor met, an unresolved
+        // BLOCK/REJECT in the consensus round means consensus was NOT reached — a single
+        // dissenting voter prevents the output from shipping. This is the mechanical
+        // backstop for a buggy/over-eager orchestrator that ignores a BLOCK.
+        if (detectUnresolvedBlock(currentTurnLines)) {
+          appendConformanceEvent({
+            ts:              new Date().toISOString(),
+            phase:           'DECIDING',
+            action:          'consensus_block',
+            outcome:         'BLOCK',
+            reason:          'unresolved BLOCK/REJECT in consensus round',
+            schema_version,
+          });
+          process.stdout.write(JSON.stringify({
+            decision: 'block',
+            reason: 'QUORUM CONSENSUS NOT REACHED: a BLOCK/REJECT verdict is unresolved in the final dispatch round. ' +
+              'BLOCK is absolute (CE-2) — deliberate to resolve the objection (provide its rationale to all voters and re-dispatch), do not override it.'
           }));
           process.exit(0);
         }

--- a/hooks/dist/nf-stop.js
+++ b/hooks/dist/nf-stop.js
@@ -664,11 +664,6 @@ function detectUnavailWithoutFallback(currentTurnLines, cwd) {
   return { violated: false };
 }
 
-// Counts the number of live slot-worker voters in the current turn. Walks assistant
-// messages for Task(nf-quorum-slot-worker) dispatches, then inspects the matching
-// tool_result blocks. A result counts as a live voter only if it carries an explicit
-// APPROVE or BLOCK verdict — UNAVAIL, FLAG_TRUNCATED, error, and empty results are
-// non-votes and excluded. Returns the count of valid votes in the last dispatch round.
 // Walks the current turn for nf-quorum-slot-worker dispatch rounds and returns the
 // result texts of the LAST (consensus) dispatch round. Shared by countLiveSlotWorkers
 // and detectUnresolvedBlock so both reason over the same round with identical scoping —
@@ -731,6 +726,9 @@ function getLastDispatchRoundResults(currentTurnLines) {
   return [...lastRound].map(id => taskResults.get(id) || '');
 }
 
+// Counts live slot-worker voters in the LAST (consensus) dispatch round. A result is a
+// live voter only if it carries an explicit APPROVE/BLOCK/REJECT verdict; UNAVAIL,
+// FLAG_TRUNCATED, error, and empty results are non-votes and excluded.
 function countLiveSlotWorkers(currentTurnLines) {
   let liveCount = 0;
   for (const result of getLastDispatchRoundResults(currentTurnLines)) {
@@ -1007,6 +1005,29 @@ function main() {
           process.exit(0);
         }
 
+        // CE-2 BLOCK-is-absolute backstop — checked BEFORE the floor so an unresolved
+        // BLOCK/REJECT in the consensus (last) round reports the accurate "consensus not
+        // reached" reason even when live voters are also below the floor (a lone BLOCK is
+        // a dissent, not merely a thin roster). A single dissenting voter prevents the
+        // output from shipping; this is the mechanical backstop for a buggy/over-eager
+        // orchestrator that ignores a BLOCK. Unconditional — not waivable by --force-quorum.
+        if (detectUnresolvedBlock(currentTurnLines)) {
+          appendConformanceEvent({
+            ts:              new Date().toISOString(),
+            phase:           'DECIDING',
+            action:          'consensus_block',
+            outcome:         'BLOCK',
+            reason:          'unresolved BLOCK/REJECT in consensus round',
+            schema_version,
+          });
+          process.stdout.write(JSON.stringify({
+            decision: 'block',
+            reason: 'QUORUM CONSENSUS NOT REACHED: a BLOCK/REJECT verdict is unresolved in the final dispatch round. ' +
+              'BLOCK is absolute (CE-2) — deliberate to resolve the objection (provide its rationale to all voters and re-dispatch), do not override it.'
+          }));
+          process.exit(0);
+        }
+
         // MIN_LIVE_VOTERS floor (issue #170)
         const minLiveVoters = getMinLiveVoters(config);
         const liveSlotWorkers = countLiveSlotWorkers(currentTurnLines);
@@ -1024,27 +1045,6 @@ function main() {
             decision: 'block',
             reason: 'QUORUM FLOOR NOT MET: Only ' + liveSlotWorkers + ' live voter(s) (min_live_voters = ' + minLiveVoters + '). ' +
               'Too many slots are UNAVAIL for reliable consensus. Re-dispatch with extended timeouts, or re-run with --force-quorum to waive.'
-          }));
-          process.exit(0);
-        }
-
-        // CE-2 BLOCK-is-absolute backstop: even with the floor met, an unresolved
-        // BLOCK/REJECT in the consensus round means consensus was NOT reached — a single
-        // dissenting voter prevents the output from shipping. This is the mechanical
-        // backstop for a buggy/over-eager orchestrator that ignores a BLOCK.
-        if (detectUnresolvedBlock(currentTurnLines)) {
-          appendConformanceEvent({
-            ts:              new Date().toISOString(),
-            phase:           'DECIDING',
-            action:          'consensus_block',
-            outcome:         'BLOCK',
-            reason:          'unresolved BLOCK/REJECT in consensus round',
-            schema_version,
-          });
-          process.stdout.write(JSON.stringify({
-            decision: 'block',
-            reason: 'QUORUM CONSENSUS NOT REACHED: a BLOCK/REJECT verdict is unresolved in the final dispatch round. ' +
-              'BLOCK is absolute (CE-2) — deliberate to resolve the objection (provide its rationale to all voters and re-dispatch), do not override it.'
           }));
           process.exit(0);
         }

--- a/hooks/nf-circuit-breaker.js
+++ b/hooks/nf-circuit-breaker.js
@@ -187,10 +187,10 @@ function hasReversionInHashes(gitRoot, hashes, files, pairStatsOut) {
   return (totalNetChange <= 0 && hasNegativePair) || contentReverts;
 }
 
-// Content fingerprint of the file set at one commit: the blob SHAs of `files`, sorted
-// for determinism, with an absent file recorded as a sentinel (so add/remove of a file
-// is itself a state change). One `git ls-tree` call per commit. Returns null on git
-// error so the caller can fall back rather than mis-decide.
+// Content fingerprint of the file set at one commit: git's own (repo-relative path, blob
+// SHA) pairs for `files`, sorted for determinism. An absent file simply doesn't appear in
+// the ls-tree output (so add/remove of a file changes the fingerprint). One `git ls-tree`
+// call per commit. Returns null on git error so the caller can fall back, not mis-decide.
 function fileSetContentFingerprint(gitRoot, hash, files) {
   const r = spawnSync('git', ['ls-tree', hash, '--', ...files], {
     cwd: gitRoot, encoding: 'utf8', timeout: 5000,

--- a/hooks/nf-circuit-breaker.js
+++ b/hooks/nf-circuit-breaker.js
@@ -129,6 +129,8 @@ function hasReversionInHashes(gitRoot, hashes, files, pairStatsOut) {
   // We diff older → newer: git diff <hashes[i]> <hashes[i-1]>
   let totalNetChange = 0;
   let hasNegativePair = false;
+  let hasPositivePair = false;
+  let negPairs = 0;
   let errorsOnly = true;
 
   for (let i = hashes.length - 1; i >= 1; i--) {
@@ -155,7 +157,8 @@ function hasReversionInHashes(gitRoot, hashes, files, pairStatsOut) {
 
     const pairNet = additions - deletions;
     totalNetChange += pairNet;
-    if (pairNet < 0) hasNegativePair = true;
+    if (pairNet < 0) { hasNegativePair = true; negPairs++; }
+    if (pairNet > 0) hasPositivePair = true;
 
     // Collect pair stats for rollback intent detection
     if (Array.isArray(pairStatsOut)) {
@@ -166,10 +169,64 @@ function hasReversionInHashes(gitRoot, hashes, files, pairStatsOut) {
   // If all pairs errored out → fall back to original behavior (treat as oscillation)
   if (errorsOnly) return true;
 
-  // Positive net change → file grew overall → TDD progression, not oscillation
-  // Zero or negative net change WITH at least one negative pair → real oscillation
-  // Zero or negative net change with NO negative pair → monotonic substitution workflow, not oscillation
-  return totalNetChange <= 0 && hasNegativePair;
+  const contentReverts = hasContentReversion(gitRoot, hashes, files) === true;
+
+  // SUSTAINED MONOTONIC SHRINK is a directional cleanup (e.g. dead-code removal
+  // 6→4→2 lines: two-plus deletion-only pairs, no additions anywhere, and the content
+  // never returns to a prior state), NOT a loop — do not trip the breaker. This is the
+  // false-positive the old `totalNetChange <= 0 && hasNegativePair` proxy produced. A
+  // SINGLE deletion pair or any size churn is still judged by the size signal below, so
+  // short patterns keep their established behavior.
+  if (negPairs >= 2 && !hasPositivePair && !contentReverts) return false;
+
+  // Oscillation when EITHER:
+  //  - the established size signal: non-positive net change with at least one removal
+  //    (catches size-alternating churn 1→2→1→2 and short net-negative reversions), OR
+  //  - a byte-level CONTENT REVERSION (A→B→A): catches EQUAL-LENGTH value toggles
+  //    (FLAG="on"↔"off") whose pairs are all net-zero, so the size signal can't see them.
+  return (totalNetChange <= 0 && hasNegativePair) || contentReverts;
+}
+
+// Content fingerprint of the file set at one commit: the blob SHAs of `files`, sorted
+// for determinism, with an absent file recorded as a sentinel (so add/remove of a file
+// is itself a state change). One `git ls-tree` call per commit. Returns null on git
+// error so the caller can fall back rather than mis-decide.
+function fileSetContentFingerprint(gitRoot, hash, files) {
+  const r = spawnSync('git', ['ls-tree', hash, '--', ...files], {
+    cwd: gitRoot, encoding: 'utf8', timeout: 5000,
+  });
+  if (r.error || r.status !== 0) return null;
+  // Build the fingerprint from git's OWN output pairs (repo-relative path + blob SHA),
+  // NOT by looking up the original `files` pathspecs — those may be absolute while
+  // ls-tree emits repo-relative paths, so a lookup would never match and every commit
+  // would fingerprint identically. An absent file simply doesn't appear (its state).
+  const pairs = [];
+  for (const line of (r.stdout || '').split('\n')) {
+    const m = line.match(/^\S+\s+\S+\s+(\S+)\t(.+)$/); // "<mode> blob <sha>\t<path>"
+    if (m) pairs.push(m[2] + '=' + m[1]);
+  }
+  pairs.sort();
+  return pairs.join('\0');
+}
+
+// True if the file set's content returns to a prior state across `hashes` (a real
+// A→B→A reversion), false if every state is unique (monotonic shrink or forward
+// progression — NOT oscillation), or null if fingerprints can't be computed (git error
+// → caller falls back). Consecutive identical states (a commit that touched only OTHER
+// files) are collapsed first so they don't read as a spurious repeat.
+function hasContentReversion(gitRoot, hashes, files) {
+  const fps = [];
+  for (const hash of hashes) {
+    const fp = fileSetContentFingerprint(gitRoot, hash, files);
+    if (fp === null) return null;
+    if (fps.length === 0 || fps[fps.length - 1] !== fp) fps.push(fp); // collapse adjacent dups
+  }
+  const seen = new Set();
+  for (const fp of fps) {
+    if (seen.has(fp)) return true; // a state recurs after leaving it → reversion
+    seen.add(fp);
+  }
+  return false;
 }
 
 // Counts full oscillation cycles for a file set key.

--- a/hooks/nf-circuit-breaker.js
+++ b/hooks/nf-circuit-breaker.js
@@ -169,15 +169,19 @@ function hasReversionInHashes(gitRoot, hashes, files, pairStatsOut) {
   // If all pairs errored out → fall back to original behavior (treat as oscillation)
   if (errorsOnly) return true;
 
-  const contentReverts = hasContentReversion(gitRoot, hashes, files) === true;
+  const reversion = hasContentReversion(gitRoot, hashes, files); // true | false | null (git error)
+  const contentReverts = reversion === true;
 
   // SUSTAINED MONOTONIC SHRINK is a directional cleanup (e.g. dead-code removal
   // 6→4→2 lines: two-plus deletion-only pairs, no additions anywhere, and the content
   // never returns to a prior state), NOT a loop — do not trip the breaker. This is the
   // false-positive the old `totalNetChange <= 0 && hasNegativePair` proxy produced. A
   // SINGLE deletion pair or any size churn is still judged by the size signal below, so
-  // short patterns keep their established behavior.
-  if (negPairs >= 2 && !hasPositivePair && !contentReverts) return false;
+  // short patterns keep their established behavior. Gate on `reversion === false`
+  // (POSITIVELY confirmed no reversion), not `!contentReverts` — if fingerprinting was
+  // unavailable (reversion === null, a transient git error) we must NOT assume "no
+  // reversion" and silently exempt; fall through to the size heuristic instead.
+  if (negPairs >= 2 && !hasPositivePair && reversion === false) return false;
 
   // Oscillation when EITHER:
   //  - the established size signal: non-positive net change with at least one removal

--- a/hooks/nf-circuit-breaker.test.js
+++ b/hooks/nf-circuit-breaker.test.js
@@ -1646,12 +1646,12 @@ function writeBreakerConfig(repoDir, overrides) {
   return statePath;
 }
 
-// CB-ADV01 (MISSED OSCILLATION): an equal-length A→B→A value flip — the canonical
-// "agent toggles a constant back and forth" loop — is NOT detected because the
-// reversion heuristic requires at least one strictly net-negative pair
-// (hasNegativePair). Pure substitutions are net-zero, so a real toggle loop with
-// equal-length states slips through. A correct breaker MUST flag this.
-test('CB-ADV01: equal-length A→B→A value-flip oscillation is MISSED (no negative pair)', () => {
+// CB-ADV01 (was MISSED, now CAUGHT): an equal-length A→B→A value flip — the canonical
+// "agent toggles a constant back and forth" loop. The old reversion heuristic required a
+// net-negative pair (hasNegativePair); pure substitutions are net-zero, so a real toggle
+// with equal-length states slipped through. FIXED by the byte-level content-reversion
+// signal; EXPECTED: PASSES (the breaker now flags it). Regression guard for the miss.
+test('CB-ADV01: equal-length A→B→A value-flip oscillation is caught (content reversion)', () => {
   const repoDir = createTempGitRepo();
   try {
     // app.js: "on" → (filler) → "off" → (filler) → "on"  (3 run-groups for app.js)
@@ -1685,11 +1685,11 @@ test('CB-ADV01: equal-length A→B→A value-flip oscillation is MISSED (no nega
   }
 });
 
-// CB-ADV02 (MISSED OSCILLATION, sustained): even a sustained 4-group equal-length
-// toggle (A→B→A→B, 3 full cycles) — exactly the runaway loop a circuit breaker
-// exists to stop — is missed for the same hasNegativePair reason. Cycle count is
-// not the gate here; the net-zero substitution heuristic is.
-test('CB-ADV02: sustained equal-length toggle (A→B→A→B) is MISSED despite 3 cycles', () => {
+// CB-ADV02 (was MISSED, now CAUGHT, sustained): a sustained 4-group equal-length toggle
+// (A→B→A→B, 3 full cycles) — exactly the runaway loop a circuit breaker exists to stop —
+// was missed for the same net-zero/hasNegativePair reason. FIXED by the content-reversion
+// signal; EXPECTED: PASSES. Regression guard for the sustained-toggle miss.
+test('CB-ADV02: sustained equal-length toggle (A→B→A→B) is caught despite net-zero pairs', () => {
   const repoDir = createTempGitRepo();
   try {
     commitInRepo(repoDir, 'app.js', 'x = 1\n', 'feat: x=1');

--- a/hooks/nf-circuit-breaker.test.js
+++ b/hooks/nf-circuit-breaker.test.js
@@ -1852,3 +1852,195 @@ test('CB-ADV05: resolved oscillation-log entry releases an active breaker (no re
     fs.rmSync(repoDir, { recursive: true, force: true });
   }
 });
+
+// ── Round-2 adversarial probes (CB-RND2 series) ───────────────────────────────
+// Targeting the round-1 rework of hasReversionInHashes: the byte-level CONTENT
+// REVERSION signal (fileSetContentFingerprint / hasContentReversion) and the
+// SUSTAINED-MONOTONIC-SHRINK exemption (negPairs>=2 && !hasPositivePair &&
+// !contentReverts → not oscillation). These call hasReversionInHashes directly
+// (the changed unit) over real temp repos, except CB-RND2-05 which drives the full
+// stdin→state pipeline. Each can FAIL on a genuine, reachable defect.
+
+// Commit helper that stages a single named file (handles paths with spaces).
+function rnd2Commit(repoDir, fileName, content, message) {
+  fs.writeFileSync(path.join(repoDir, fileName), content, 'utf8');
+  spawnSync('git', ['add', fileName], { cwd: repoDir, encoding: 'utf8' });
+  spawnSync('git', ['commit', '-m', message], { cwd: repoDir, encoding: 'utf8' });
+}
+
+// Newest-first commit hashes (same order hasReversionInHashes expects).
+function rnd2Hashes(repoDir, n) {
+  const r = spawnSync('git', ['log', '--format=%H', `-${n}`], { cwd: repoDir, encoding: 'utf8' });
+  return (r.stdout || '').trim().split('\n').filter(Boolean);
+}
+
+// CB-RND2-01 (EXEMPTION BOUNDARY / off-by-one): the monotonic-shrink exemption is
+// gated on `negPairs >= 2`. Confirm the threshold is exact:
+//   • EXACTLY 1 deletion pair (4→2 lines) is NOT exempted — the established size
+//     signal still flags it as a reversion (old CB-TC18 behavior preserved).
+//   • EXACTLY 2 deletion-only pairs (6→4→2) IS exempted — directional cleanup.
+// If the boundary regressed to `>= 1`, the 1-pair case would be wrongly swallowed
+// (a real net-negative reversion MISSED); if it regressed to `>= 3`, the 2-pair
+// cleanup would FALSE-BLOCK.
+test('CB-RND2-01: monotonic-shrink exemption boundary is exact (1 pair flags, 2 pairs exempt)', () => {
+  // One deletion pair → must still read as reversion (true).
+  const repo1 = createTempGitRepo();
+  try {
+    rnd2Commit(repo1, 'a.txt', 'l1\nl2\nl3\nl4\n', 'c0: four lines');
+    rnd2Commit(repo1, 'a.txt', 'l1\nl2\n', 'c1: drop to two');
+    const h1 = rnd2Hashes(repo1, 2);
+    assert.strictEqual(
+      hasReversionInHashes(repo1, h1, ['a.txt']), true,
+      'a single net-negative deletion pair must NOT be exempted — size signal flags it (CB-RND2-01)'
+    );
+  } finally {
+    fs.rmSync(repo1, { recursive: true, force: true });
+  }
+
+  // Two deletion-only pairs, no additions, no content reversion → exempt (false).
+  const repo2 = createTempGitRepo();
+  try {
+    rnd2Commit(repo2, 'a.txt', 'a\nb\nc\nd\ne\nf\n', 'c0: six lines');
+    rnd2Commit(repo2, 'a.txt', 'a\nb\nc\nd\n', 'c1: drop to four');
+    rnd2Commit(repo2, 'a.txt', 'a\nb\n', 'c2: drop to two');
+    const h2 = rnd2Hashes(repo2, 3);
+    assert.strictEqual(
+      hasReversionInHashes(repo2, h2, ['a.txt']), false,
+      'two deletion-only pairs (no re-add, no content reversion) is directional cleanup, must be exempt (CB-RND2-01)'
+    );
+  } finally {
+    fs.rmSync(repo2, { recursive: true, force: true });
+  }
+});
+
+// CB-RND2-02 (REGRESSION on the exemption — genuine loop with >=2 negative pairs):
+// a real down-down-up loop (6→4→2→6, content returns byte-identical to the start)
+// has negPairs==2 but is NOT a monotonic shrink: it re-adds content and reverts to
+// a prior state. The exemption MUST be overridden (by hasPositivePair AND by
+// contentReverts) and the loop still flagged. If the exemption ignored the re-add /
+// content-reversion, this runaway loop would be silently swallowed.
+test('CB-RND2-02: down-down-up loop (>=2 neg pairs but content reverts) is STILL caught', () => {
+  const repoDir = createTempGitRepo();
+  try {
+    rnd2Commit(repoDir, 'a.txt', 'a\nb\nc\nd\ne\nf\n', 'c0: six');
+    rnd2Commit(repoDir, 'a.txt', 'a\nb\nc\nd\n', 'c1: four');
+    rnd2Commit(repoDir, 'a.txt', 'a\nb\n', 'c2: two');
+    rnd2Commit(repoDir, 'a.txt', 'a\nb\nc\nd\ne\nf\n', 'c3: re-add original six');
+    const h = rnd2Hashes(repoDir, 4);
+    assert.strictEqual(
+      hasReversionInHashes(repoDir, h, ['a.txt']), true,
+      'down-down-up that restores a prior byte-identical state is a loop, not a cleanup — must be caught (CB-RND2-02)'
+    );
+  } finally {
+    fs.rmSync(repoDir, { recursive: true, force: true });
+  }
+});
+
+// CB-RND2-03 (3-STATE CYCLE via content reversion): an equal-length A→B→C→A cycle
+// (all net-zero substitutions, content returns to A after two distinct states) is
+// invisible to the size signal (no negative pair, totalNet==0) and can ONLY be
+// caught by the byte-level content-reversion fingerprint. Confirms hasContentReversion
+// detects a recurrence that is non-adjacent and separated by >1 intermediate state.
+test('CB-RND2-03: equal-length 3-state cycle A→B→C→A is caught via content reversion', () => {
+  const repoDir = createTempGitRepo();
+  try {
+    rnd2Commit(repoDir, 'cfg.txt', 'x = 1\n', 'A');
+    rnd2Commit(repoDir, 'cfg.txt', 'x = 2\n', 'B');
+    rnd2Commit(repoDir, 'cfg.txt', 'x = 3\n', 'C');
+    rnd2Commit(repoDir, 'cfg.txt', 'x = 1\n', 'A again (cycle closes)');
+    const h = rnd2Hashes(repoDir, 4);
+    assert.strictEqual(
+      hasReversionInHashes(repoDir, h, ['cfg.txt']), true,
+      'A→B→C→A equal-length cycle returns to a prior state — only content reversion can see it; must be caught (CB-RND2-03)'
+    );
+  } finally {
+    fs.rmSync(repoDir, { recursive: true, force: true });
+  }
+});
+
+// CB-RND2-04 (FINGERPRINT ROBUSTNESS): fileSetContentFingerprint parses `git ls-tree`
+// output with a regex `^\S+\s+\S+\s+(\S+)\t(.+)$`. Two adversarial inputs:
+//   (a) a path WITH SPACES, toggled equal-length A→B→A — net-zero so ONLY the
+//       fingerprint can flag it; if the regex mis-parsed the spaced path, pairs would
+//       be empty and every commit would fingerprint identically → reversion MISSED.
+//   (b) a file present→absent→present (deleted then re-added byte-identical) — the
+//       absent state must fingerprint differently and the recurrence be caught, with
+//       no crash on the delete.
+test('CB-RND2-04: fingerprint handles spaced paths and present→absent→present without misdecide/crash', () => {
+  // (a) path with spaces, equal-length toggle → only content reversion can catch it.
+  const repoA = createTempGitRepo();
+  try {
+    rnd2Commit(repoA, 'my file.txt', 'v = 1\n', 'A');
+    rnd2Commit(repoA, 'my file.txt', 'v = 2\n', 'B');
+    rnd2Commit(repoA, 'my file.txt', 'v = 1\n', 'A again');
+    const h = rnd2Hashes(repoA, 3);
+    assert.strictEqual(
+      hasReversionInHashes(repoA, h, ['my file.txt']), true,
+      'equal-length A→B→A on a spaced path must be caught — fingerprint regex must parse the path (CB-RND2-04a)'
+    );
+  } finally {
+    fs.rmSync(repoA, { recursive: true, force: true });
+  }
+
+  // (b) present → absent → present (identical content re-added).
+  const repoB = createTempGitRepo();
+  try {
+    rnd2Commit(repoB, 'feat.txt', 'alpha\nbeta\n', 'add feat');
+    fs.rmSync(path.join(repoB, 'feat.txt'));
+    spawnSync('git', ['rm', 'feat.txt'], { cwd: repoB, encoding: 'utf8' });
+    spawnSync('git', ['commit', '-m', 'delete feat'], { cwd: repoB, encoding: 'utf8' });
+    rnd2Commit(repoB, 'feat.txt', 'alpha\nbeta\n', 're-add identical feat');
+    const h = rnd2Hashes(repoB, 3);
+    let result;
+    assert.doesNotThrow(() => { result = hasReversionInHashes(repoB, h, ['feat.txt']); },
+      'present→absent→present must not crash fingerprinting (CB-RND2-04b)');
+    assert.strictEqual(
+      result, true,
+      're-adding byte-identical deleted content is a reversion loop — must be caught (CB-RND2-04b)'
+    );
+  } finally {
+    fs.rmSync(repoB, { recursive: true, force: true });
+  }
+});
+
+// CB-RND2-05 (FALSE-POSITIVE GUARD — clean rollback survives the new content signal):
+// a deliberate one-shot rollback at depth 3 (base → +30-line feature → cleanly remove
+// it, content returns byte-identical to base) now trips the content-reversion signal,
+// so hasReversionInHashes returns true. The downstream rollback rescue (isCleanRollback:
+// asymmetric +30/-0 then +0/-30, exactly one inverse pair) MUST still suppress it.
+// If the content-reversion signal short-circuited the clean-rollback path, this normal
+// add-then-revert refactor would be FALSE-BLOCKED. Drives the full stdin→state pipeline.
+test('CB-RND2-05: big one-shot clean rollback (A→B→A) is NOT blocked despite content reversion', () => {
+  const repoDir = createTempGitRepo();
+  try {
+    const base = 'function base() { return 0; }\n';
+    const feature = base + Array.from({ length: 30 }, (_, i) => `const f${i} = ${i};`).join('\n') + '\n';
+    // app.js base → (filler) → +feature → (filler) → cleanly reverted to base. 3 app.js run-groups.
+    rnd2Commit(repoDir, 'app.js', base, 'feat: base');
+    rnd2Commit(repoDir, 'filler1.txt', 'f1\n', 'chore: filler 1');
+    rnd2Commit(repoDir, 'app.js', feature, 'feat: add big feature (+30)');
+    rnd2Commit(repoDir, 'filler2.txt', 'f2\n', 'chore: filler 2');
+    rnd2Commit(repoDir, 'app.js', base, 'revert: remove big feature, back to base');
+
+    const statePath = writeBreakerConfig(repoDir);
+
+    const { stdout, exitCode } = runHook({
+      tool_name: 'Bash',
+      tool_input: { command: 'echo write > output.txt', description: 'test', timeout: 5000 },
+      cwd: repoDir,
+      hook_event_name: 'PreToolUse',
+      tool_use_id: 'test-id',
+      session_id: 'test-session',
+      transcript_path: '/tmp/test.jsonl',
+      permission_mode: 'default',
+    });
+    assert.strictEqual(exitCode, 0, 'exit code must be 0');
+    assert.strictEqual(stdout, '', 'stdout must be empty');
+    assert(
+      !fs.existsSync(statePath),
+      'state file must NOT be written — a deliberate one-shot clean rollback must stay rescued by isCleanRollback even though content reverts (CB-RND2-05)'
+    );
+  } finally {
+    fs.rmSync(repoDir, { recursive: true, force: true });
+  }
+});

--- a/hooks/nf-circuit-breaker.test.js
+++ b/hooks/nf-circuit-breaker.test.js
@@ -1615,3 +1615,240 @@ test('CB-FP09: min_cycles=0 (disabled) allows single cycle to trigger on depth',
     fs.rmSync(repoDir, { recursive: true, force: true });
   }
 });
+
+// ── Adversarial probes (CB-ADV series) ───────────────────────────────────────
+// These exercise the breaker through its real stdin→state-file I/O path with the
+// haiku reviewer disabled via project nf.json (deterministic, no live API), at
+// production defaults (depth=3, window=6, min_cycles=2, rollback_detection=true)
+// filled in by config-loader. Each can FAIL on a genuine, reachable defect.
+
+// Writes a project nf.json that disables the live Haiku reviewer so detection is
+// driven purely by the deterministic algorithm. Written AFTER commits so git
+// never captures it in a commit file-set.
+function writeBreakerConfig(repoDir, overrides) {
+  const claudeDir = path.join(repoDir, '.claude');
+  fs.mkdirSync(claudeDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(claudeDir, 'nf.json'),
+    JSON.stringify({
+      circuit_breaker: Object.assign({
+        oscillation_depth: 3,
+        commit_window: 6,
+        haiku_reviewer: false,
+        min_cycles: 2,
+        rollback_detection: true,
+      }, overrides || {}),
+    }),
+    'utf8'
+  );
+  const statePath = path.join(claudeDir, 'circuit-breaker-state.json');
+  if (fs.existsSync(statePath)) fs.unlinkSync(statePath);
+  return statePath;
+}
+
+// CB-ADV01 (MISSED OSCILLATION): an equal-length A→B→A value flip — the canonical
+// "agent toggles a constant back and forth" loop — is NOT detected because the
+// reversion heuristic requires at least one strictly net-negative pair
+// (hasNegativePair). Pure substitutions are net-zero, so a real toggle loop with
+// equal-length states slips through. A correct breaker MUST flag this.
+test('CB-ADV01: equal-length A→B→A value-flip oscillation is MISSED (no negative pair)', () => {
+  const repoDir = createTempGitRepo();
+  try {
+    // app.js: "on" → (filler) → "off" → (filler) → "on"  (3 run-groups for app.js)
+    commitInRepo(repoDir, 'app.js', 'const FLAG = "on";\n', 'feat: flag on');
+    commitInRepo(repoDir, 'filler1.txt', 'f1\n', 'chore: filler 1');
+    commitInRepo(repoDir, 'app.js', 'const FLAG = "off";\n', 'fix: flip flag off');
+    commitInRepo(repoDir, 'filler2.txt', 'f2\n', 'chore: filler 2');
+    commitInRepo(repoDir, 'app.js', 'const FLAG = "on";\n', 'fix: flip flag back on');
+
+    const statePath = writeBreakerConfig(repoDir);
+
+    const { stdout, exitCode } = runHook({
+      tool_name: 'Bash',
+      tool_input: { command: 'echo write > output.txt', description: 'test', timeout: 5000 },
+      cwd: repoDir,
+      hook_event_name: 'PreToolUse',
+      tool_use_id: 'test-id',
+      session_id: 'test-session',
+      transcript_path: '/tmp/test.jsonl',
+      permission_mode: 'default',
+    });
+    assert.strictEqual(exitCode, 0, 'exit code must be 0');
+    assert.strictEqual(stdout, '', 'stdout must be empty on first detection');
+    // A genuine A→B→A toggle is real oscillation — the breaker SHOULD activate.
+    assert(
+      fs.existsSync(statePath),
+      'state file MUST be written — equal-length A→B→A value flip is a real oscillation loop (CB-ADV01)'
+    );
+  } finally {
+    fs.rmSync(repoDir, { recursive: true, force: true });
+  }
+});
+
+// CB-ADV02 (MISSED OSCILLATION, sustained): even a sustained 4-group equal-length
+// toggle (A→B→A→B, 3 full cycles) — exactly the runaway loop a circuit breaker
+// exists to stop — is missed for the same hasNegativePair reason. Cycle count is
+// not the gate here; the net-zero substitution heuristic is.
+test('CB-ADV02: sustained equal-length toggle (A→B→A→B) is MISSED despite 3 cycles', () => {
+  const repoDir = createTempGitRepo();
+  try {
+    commitInRepo(repoDir, 'app.js', 'x = 1\n', 'feat: x=1');
+    commitInRepo(repoDir, 'f1.txt', 'a\n', 'chore: f1');
+    commitInRepo(repoDir, 'app.js', 'x = 2\n', 'fix: x=2');
+    commitInRepo(repoDir, 'f2.txt', 'a\n', 'chore: f2');
+    commitInRepo(repoDir, 'app.js', 'x = 1\n', 'fix: x=1 again');
+    commitInRepo(repoDir, 'f3.txt', 'a\n', 'chore: f3');
+    commitInRepo(repoDir, 'app.js', 'x = 2\n', 'fix: x=2 again');
+
+    // 7 commits → window must cover all of them to see 4 app.js run-groups.
+    const statePath = writeBreakerConfig(repoDir, { commit_window: 8 });
+
+    const { stdout, exitCode } = runHook({
+      tool_name: 'Bash',
+      tool_input: { command: 'echo write > output.txt', description: 'test', timeout: 5000 },
+      cwd: repoDir,
+      hook_event_name: 'PreToolUse',
+      tool_use_id: 'test-id',
+      session_id: 'test-session',
+      transcript_path: '/tmp/test.jsonl',
+      permission_mode: 'default',
+    });
+    assert.strictEqual(exitCode, 0, 'exit code must be 0');
+    assert.strictEqual(stdout, '', 'stdout must be empty on first detection');
+    assert(
+      fs.existsSync(statePath),
+      'state file MUST be written — a sustained equal-length toggle is the exact loop the breaker exists to stop (CB-ADV02)'
+    );
+  } finally {
+    fs.rmSync(repoDir, { recursive: true, force: true });
+  }
+});
+
+// CB-ADV03 (FALSE BLOCK): a legitimate incremental dead-code cleanup — the same
+// file is trimmed across several commits (interspersed with edits to other
+// files), content only ever REMOVED, never re-added — is wrongly flagged as
+// oscillation. The reversion heuristic conflates "file shrinking monotonically"
+// (net<0 + a negative pair) with "content added then removed". This false block
+// halts a normal refactor.
+test('CB-ADV03: monotonic incremental deletion (dead-code cleanup) is a FALSE BLOCK', () => {
+  const repoDir = createTempGitRepo();
+  try {
+    // cleanup.js: 6 lines → trim to 4 → trim to 2, with fillers between (3 run-groups).
+    commitInRepo(repoDir, 'cleanup.js', 'a\nb\nc\nd\ne\nf\n', 'feat: add module');
+    commitInRepo(repoDir, 'filler1.txt', 'f1\n', 'chore: filler 1');
+    commitInRepo(repoDir, 'cleanup.js', 'a\nb\nc\nd\n', 'refactor: drop dead code (e,f)');
+    commitInRepo(repoDir, 'filler2.txt', 'f2\n', 'chore: filler 2');
+    commitInRepo(repoDir, 'cleanup.js', 'a\nb\n', 'refactor: drop more dead code (c,d)');
+
+    const statePath = writeBreakerConfig(repoDir);
+
+    const { stdout, exitCode } = runHook({
+      tool_name: 'Bash',
+      tool_input: { command: 'echo write > output.txt', description: 'test', timeout: 5000 },
+      cwd: repoDir,
+      hook_event_name: 'PreToolUse',
+      tool_use_id: 'test-id',
+      session_id: 'test-session',
+      transcript_path: '/tmp/test.jsonl',
+      permission_mode: 'default',
+    });
+    assert.strictEqual(exitCode, 0, 'exit code must be 0');
+    assert.strictEqual(stdout, '', 'stdout must be empty');
+    // Content is only ever removed, never re-added — this is a cleanup, not a loop.
+    assert(
+      !fs.existsSync(statePath),
+      'state file must NOT be written — incremental deletion is a legitimate cleanup refactor, not oscillation (CB-ADV03)'
+    );
+  } finally {
+    fs.rmSync(repoDir, { recursive: true, force: true });
+  }
+});
+
+// CB-ADV04 (FAIL-OPEN / state corruption): an ACTIVE state whose file_set has the
+// wrong shape (an object, not an array) must not crash the hook. buildBlockReason
+// and makeFileSetHash both call array methods on file_set; a wrong shape throws,
+// and the outer try/catch must keep this fail-OPEN (exit 0, no output). If the
+// guard regressed, the hook would exit non-zero — fail-CLOSED, blocking every
+// tool call.
+test('CB-ADV04: active state with wrong-shape file_set fails open (exit 0, no crash)', () => {
+  const repoDir = createTempGitRepo();
+  try {
+    commitInRepo(repoDir, 'seed.txt', 'seed\n', 'init');
+    const stateDir = path.join(repoDir, '.claude');
+    fs.mkdirSync(stateDir, { recursive: true });
+    const statePath = path.join(stateDir, 'circuit-breaker-state.json');
+    // Valid JSON, active, but file_set is an object instead of an array.
+    fs.writeFileSync(statePath, JSON.stringify({
+      active: true,
+      file_set: { not: 'an-array' },
+      activated_at: new Date().toISOString(),
+      commit_window_snapshot: [['seed.txt']],
+    }), 'utf8');
+
+    const { stdout, exitCode } = runHook({
+      tool_name: 'Bash',
+      tool_input: { command: 'echo write > output.txt', description: 'test', timeout: 5000 },
+      cwd: repoDir,
+      hook_event_name: 'PreToolUse',
+      tool_use_id: 'test-id',
+      session_id: 'test-session',
+      transcript_path: '/tmp/test.jsonl',
+      permission_mode: 'default',
+    });
+    assert.strictEqual(exitCode, 0, 'exit code must be 0 — corrupt active state must fail OPEN, not crash the hook');
+    // Must not emit a malformed/partial deny decision.
+    assert.ok(
+      stdout === '' || (() => { try { JSON.parse(stdout); return true; } catch { return false; } })(),
+      'stdout must be empty or well-formed JSON, never a partial/corrupt payload'
+    );
+  } finally {
+    fs.rmSync(repoDir, { recursive: true, force: true });
+  }
+});
+
+// CB-ADV05 (RESET SEMANTICS): once an oscillation is marked resolved in the
+// oscillation log, an ACTIVE breaker must stop blocking — otherwise the next
+// legitimate edit is re-blocked forever. The active-state path keys the log as
+// `${makeFileSetHash(file_set)}:legacy`; a resolvedAt on that key must allow the
+// write through (exit 0, no deny).
+test('CB-ADV05: resolved oscillation-log entry releases an active breaker (no re-block)', () => {
+  const repoDir = createTempGitRepo();
+  try {
+    commitInRepo(repoDir, 'seed.txt', 'seed\n', 'init');
+
+    const stateDir = path.join(repoDir, '.claude');
+    fs.mkdirSync(stateDir, { recursive: true });
+    const statePath = path.join(stateDir, 'circuit-breaker-state.json');
+    fs.writeFileSync(statePath, JSON.stringify({
+      active: true,
+      file_set: ['x.js'],
+      activated_at: new Date().toISOString(),
+      commit_window_snapshot: [['x.js']],
+    }), 'utf8');
+
+    // Write a resolved oscillation-log entry under the legacy key the active path reads.
+    const planningDir = path.join(repoDir, '.planning');
+    fs.mkdirSync(planningDir, { recursive: true });
+    const logKey = `${makeFileSetHash(['x.js'])}:legacy`;
+    fs.writeFileSync(
+      path.join(planningDir, 'oscillation-log.json'),
+      JSON.stringify({ [logKey]: { files: ['x.js'], resolvedAt: new Date().toISOString(), resolvedByCommit: 'deadbeef' } }),
+      'utf8'
+    );
+
+    const { stdout, exitCode } = runHook({
+      tool_name: 'Bash',
+      tool_input: { command: 'echo write > output.txt', description: 'test', timeout: 5000 },
+      cwd: repoDir,
+      hook_event_name: 'PreToolUse',
+      tool_use_id: 'test-id',
+      session_id: 'test-session',
+      transcript_path: '/tmp/test.jsonl',
+      permission_mode: 'default',
+    });
+    assert.strictEqual(exitCode, 0, 'exit code must be 0');
+    assert.strictEqual(stdout, '', 'a resolved oscillation must NOT re-block — stdout must be empty (no deny) (CB-ADV05)');
+  } finally {
+    fs.rmSync(repoDir, { recursive: true, force: true });
+  }
+});

--- a/hooks/nf-circuit-breaker.test.js
+++ b/hooks/nf-circuit-breaker.test.js
@@ -2044,3 +2044,39 @@ test('CB-RND2-05: big one-shot clean rollback (A→B→A) is NOT blocked despite
     fs.rmSync(repoDir, { recursive: true, force: true });
   }
 });
+
+// ── Round-3 convergence invariant (CB-RND3) ───────────────────────────────────
+// Final round found no missed-loop / false-block / crash across the probed shapes
+// (net-zero substitution between deletion pairs keeps negPairs exact; a multi-file
+// set where one file reverts while another progresses correctly stays unflagged by
+// the file-set-as-unit semantic; submodule/spaced/tab paths parse without misdecide).
+// This invariant pins the ONE real-world property with no prior coverage: the content
+// fingerprint is MODE-INSENSITIVE. fileSetContentFingerprint captures only the blob
+// SHA (`(\S+)\t(.+)`), never the file mode, so a chmod toggle (644→755→644) with
+// byte-identical content must NOT read as an A→B→A content reversion. If the regex
+// regressed to fold mode into the fingerprinted state, this normal permission flip
+// would recur the 644 state and FALSE-BLOCK a chmod-heavy change.
+test('CB-RND3-01: chmod toggle with identical blob is NOT a content reversion (mode-insensitive fingerprint)', () => {
+  const repoDir = createTempGitRepo();
+  try {
+    const f = 'script.sh';
+    fs.writeFileSync(path.join(repoDir, f), 'echo hi\n', 'utf8');
+    spawnSync('git', ['add', f], { cwd: repoDir, encoding: 'utf8' });
+    spawnSync('git', ['commit', '-m', 'add script (644)'], { cwd: repoDir, encoding: 'utf8' });
+    // Flip executable bit on, then off — content (blob SHA) never changes.
+    spawnSync('git', ['update-index', '--chmod=+x', f], { cwd: repoDir, encoding: 'utf8' });
+    spawnSync('git', ['commit', '-m', 'chmod +x'], { cwd: repoDir, encoding: 'utf8' });
+    spawnSync('git', ['update-index', '--chmod=-x', f], { cwd: repoDir, encoding: 'utf8' });
+    spawnSync('git', ['commit', '-m', 'chmod -x'], { cwd: repoDir, encoding: 'utf8' });
+
+    const r = spawnSync('git', ['log', '--format=%H', '-3'], { cwd: repoDir, encoding: 'utf8' });
+    const hashes = r.stdout.trim().split('\n').filter(Boolean);
+
+    assert.strictEqual(
+      hasReversionInHashes(repoDir, hashes, [f]), false,
+      'a 644→755→644 mode toggle with identical content must NOT read as a reversion — the fingerprint is mode-insensitive (CB-RND3-01)'
+    );
+  } finally {
+    fs.rmSync(repoDir, { recursive: true, force: true });
+  }
+});

--- a/hooks/nf-stop.js
+++ b/hooks/nf-stop.js
@@ -734,11 +734,14 @@ function getLastDispatchRoundResults(currentTurnLines) {
 function countLiveSlotWorkers(currentTurnLines) {
   let liveCount = 0;
   for (const result of getLastDispatchRoundResults(currentTurnLines)) {
-    // A live voter carries an explicit APPROVE/BLOCK verdict. Matching the verdict
-    // positively (rather than excluding UNAVAIL/FLAG_TRUNCATED) avoids counting error
-    // results as votes, and avoids dropping a valid vote whose reasoning text merely
-    // mentions the word "UNAVAIL". Fails safe: an unrecognized result is not a vote.
-    if (/verdict:\s*(?:APPROVE|BLOCK)\b/i.test(result)) liveCount++;
+    // A live voter carries an explicit APPROVE/BLOCK/REJECT verdict. Matching the
+    // verdict positively (rather than excluding UNAVAIL/FLAG_TRUNCATED) avoids counting
+    // error results as votes, and avoids dropping a valid vote whose reasoning text
+    // merely mentions the word "UNAVAIL". REJECT (Mode B) counts like BLOCK (Mode A) so
+    // a mixed [APPROVE, REJECT] round reaches the CE-2 consensus backstop with the
+    // accurate "consensus not reached" reason instead of a misleading floor block.
+    // Fails safe: an unrecognized result is not a vote.
+    if (/verdict:\s*(?:APPROVE|BLOCK|REJECT)\b/i.test(result)) liveCount++;
   }
   return liveCount;
 }

--- a/hooks/nf-stop.js
+++ b/hooks/nf-stop.js
@@ -628,7 +628,11 @@ function detectUnavailWithoutFallback(currentTurnLines, cwd) {
 
     for (const taskId of round.taskIds) {
       const result = taskResults.get(taskId) || '';
-      if (/verdict:\s*UNAVAIL/i.test(result) || /\bUNAVAIL\b/.test(result)) {
+      // Anchor to the verdict line only. The old bare `/\bUNAVAIL\b/` whole-text match
+      // false-blocked a legitimate all-APPROVE consensus whose reasoning prose merely
+      // mentioned the word "UNAVAIL" (e.g. "codex-1 was UNAVAIL earlier") with a
+      // FALLBACK-01 VIOLATION — mirrors the hardening already in countLiveSlotWorkers.
+      if (/verdict:\s*UNAVAIL/i.test(result)) {
         hasUnavail = true;
         break;
       }
@@ -665,11 +669,13 @@ function detectUnavailWithoutFallback(currentTurnLines, cwd) {
 // tool_result blocks. A result counts as a live voter only if it carries an explicit
 // APPROVE or BLOCK verdict — UNAVAIL, FLAG_TRUNCATED, error, and empty results are
 // non-votes and excluded. Returns the count of valid votes in the last dispatch round.
-function countLiveSlotWorkers(currentTurnLines) {
-  // Track dispatch rounds (groups of parallel slot-worker Tasks per assistant message)
+// Walks the current turn for nf-quorum-slot-worker dispatch rounds and returns the
+// result texts of the LAST (consensus) dispatch round. Shared by countLiveSlotWorkers
+// and detectUnresolvedBlock so both reason over the same round with identical scoping —
+// a BLOCK that a later deliberation round resolved into APPROVE is never seen here.
+function getLastDispatchRoundResults(currentTurnLines) {
   const roundIds = [];       // Array of Sets, one per dispatch round
   const taskResults = new Map(); // tool_use_id → result text
-
   let currentRoundIds = null;
 
   for (const line of currentTurnLines) {
@@ -720,13 +726,14 @@ function countLiveSlotWorkers(currentTurnLines) {
     } catch { /* skip malformed */ }
   }
 
-  // Only count live voters from the LAST dispatch round (the consensus round)
-  if (roundIds.length === 0) return 0;
+  if (roundIds.length === 0) return [];
   const lastRound = roundIds[roundIds.length - 1];
+  return [...lastRound].map(id => taskResults.get(id) || '');
+}
 
+function countLiveSlotWorkers(currentTurnLines) {
   let liveCount = 0;
-  for (const id of lastRound) {
-    const result = taskResults.get(id) || '';
+  for (const result of getLastDispatchRoundResults(currentTurnLines)) {
     // A live voter carries an explicit APPROVE/BLOCK verdict. Matching the verdict
     // positively (rather than excluding UNAVAIL/FLAG_TRUNCATED) avoids counting error
     // results as votes, and avoids dropping a valid vote whose reasoning text merely
@@ -734,6 +741,19 @@ function countLiveSlotWorkers(currentTurnLines) {
     if (/verdict:\s*(?:APPROVE|BLOCK)\b/i.test(result)) liveCount++;
   }
   return liveCount;
+}
+
+// CE-2 (BLOCK is absolute) gate backstop. Returns true when the consensus (last)
+// dispatch round still carries an unresolved BLOCK/REJECT verdict. Anchored to the
+// verdict line so prose mentioning "block"/"reject" is not a vote; scoped to the last
+// round (via getLastDispatchRoundResults) so a BLOCK resolved by a later deliberation
+// round does NOT false-block. Without this the gate counted a BLOCK as a live voter and
+// let a unanimous-BLOCK / split-APPROVE-BLOCK round ship the planning output.
+function detectUnresolvedBlock(currentTurnLines) {
+  for (const result of getLastDispatchRoundResults(currentTurnLines)) {
+    if (/verdict:\s*(?:BLOCK|REJECT)\b/i.test(result)) return true;
+  }
+  return false;
 }
 
 // Extracts min_live_voters from config with safe default.
@@ -1001,6 +1021,27 @@ function main() {
             decision: 'block',
             reason: 'QUORUM FLOOR NOT MET: Only ' + liveSlotWorkers + ' live voter(s) (min_live_voters = ' + minLiveVoters + '). ' +
               'Too many slots are UNAVAIL for reliable consensus. Re-dispatch with extended timeouts, or re-run with --force-quorum to waive.'
+          }));
+          process.exit(0);
+        }
+
+        // CE-2 BLOCK-is-absolute backstop: even with the floor met, an unresolved
+        // BLOCK/REJECT in the consensus round means consensus was NOT reached — a single
+        // dissenting voter prevents the output from shipping. This is the mechanical
+        // backstop for a buggy/over-eager orchestrator that ignores a BLOCK.
+        if (detectUnresolvedBlock(currentTurnLines)) {
+          appendConformanceEvent({
+            ts:              new Date().toISOString(),
+            phase:           'DECIDING',
+            action:          'consensus_block',
+            outcome:         'BLOCK',
+            reason:          'unresolved BLOCK/REJECT in consensus round',
+            schema_version,
+          });
+          process.stdout.write(JSON.stringify({
+            decision: 'block',
+            reason: 'QUORUM CONSENSUS NOT REACHED: a BLOCK/REJECT verdict is unresolved in the final dispatch round. ' +
+              'BLOCK is absolute (CE-2) — deliberate to resolve the objection (provide its rationale to all voters and re-dispatch), do not override it.'
           }));
           process.exit(0);
         }

--- a/hooks/nf-stop.js
+++ b/hooks/nf-stop.js
@@ -664,11 +664,6 @@ function detectUnavailWithoutFallback(currentTurnLines, cwd) {
   return { violated: false };
 }
 
-// Counts the number of live slot-worker voters in the current turn. Walks assistant
-// messages for Task(nf-quorum-slot-worker) dispatches, then inspects the matching
-// tool_result blocks. A result counts as a live voter only if it carries an explicit
-// APPROVE or BLOCK verdict — UNAVAIL, FLAG_TRUNCATED, error, and empty results are
-// non-votes and excluded. Returns the count of valid votes in the last dispatch round.
 // Walks the current turn for nf-quorum-slot-worker dispatch rounds and returns the
 // result texts of the LAST (consensus) dispatch round. Shared by countLiveSlotWorkers
 // and detectUnresolvedBlock so both reason over the same round with identical scoping —
@@ -731,6 +726,9 @@ function getLastDispatchRoundResults(currentTurnLines) {
   return [...lastRound].map(id => taskResults.get(id) || '');
 }
 
+// Counts live slot-worker voters in the LAST (consensus) dispatch round. A result is a
+// live voter only if it carries an explicit APPROVE/BLOCK/REJECT verdict; UNAVAIL,
+// FLAG_TRUNCATED, error, and empty results are non-votes and excluded.
 function countLiveSlotWorkers(currentTurnLines) {
   let liveCount = 0;
   for (const result of getLastDispatchRoundResults(currentTurnLines)) {
@@ -1007,6 +1005,29 @@ function main() {
           process.exit(0);
         }
 
+        // CE-2 BLOCK-is-absolute backstop — checked BEFORE the floor so an unresolved
+        // BLOCK/REJECT in the consensus (last) round reports the accurate "consensus not
+        // reached" reason even when live voters are also below the floor (a lone BLOCK is
+        // a dissent, not merely a thin roster). A single dissenting voter prevents the
+        // output from shipping; this is the mechanical backstop for a buggy/over-eager
+        // orchestrator that ignores a BLOCK. Unconditional — not waivable by --force-quorum.
+        if (detectUnresolvedBlock(currentTurnLines)) {
+          appendConformanceEvent({
+            ts:              new Date().toISOString(),
+            phase:           'DECIDING',
+            action:          'consensus_block',
+            outcome:         'BLOCK',
+            reason:          'unresolved BLOCK/REJECT in consensus round',
+            schema_version,
+          });
+          process.stdout.write(JSON.stringify({
+            decision: 'block',
+            reason: 'QUORUM CONSENSUS NOT REACHED: a BLOCK/REJECT verdict is unresolved in the final dispatch round. ' +
+              'BLOCK is absolute (CE-2) — deliberate to resolve the objection (provide its rationale to all voters and re-dispatch), do not override it.'
+          }));
+          process.exit(0);
+        }
+
         // MIN_LIVE_VOTERS floor (issue #170)
         const minLiveVoters = getMinLiveVoters(config);
         const liveSlotWorkers = countLiveSlotWorkers(currentTurnLines);
@@ -1024,27 +1045,6 @@ function main() {
             decision: 'block',
             reason: 'QUORUM FLOOR NOT MET: Only ' + liveSlotWorkers + ' live voter(s) (min_live_voters = ' + minLiveVoters + '). ' +
               'Too many slots are UNAVAIL for reliable consensus. Re-dispatch with extended timeouts, or re-run with --force-quorum to waive.'
-          }));
-          process.exit(0);
-        }
-
-        // CE-2 BLOCK-is-absolute backstop: even with the floor met, an unresolved
-        // BLOCK/REJECT in the consensus round means consensus was NOT reached — a single
-        // dissenting voter prevents the output from shipping. This is the mechanical
-        // backstop for a buggy/over-eager orchestrator that ignores a BLOCK.
-        if (detectUnresolvedBlock(currentTurnLines)) {
-          appendConformanceEvent({
-            ts:              new Date().toISOString(),
-            phase:           'DECIDING',
-            action:          'consensus_block',
-            outcome:         'BLOCK',
-            reason:          'unresolved BLOCK/REJECT in consensus round',
-            schema_version,
-          });
-          process.stdout.write(JSON.stringify({
-            decision: 'block',
-            reason: 'QUORUM CONSENSUS NOT REACHED: a BLOCK/REJECT verdict is unresolved in the final dispatch round. ' +
-              'BLOCK is absolute (CE-2) — deliberate to resolve the objection (provide its rationale to all voters and re-dispatch), do not override it.'
           }));
           process.exit(0);
         }

--- a/hooks/nf-stop.test.js
+++ b/hooks/nf-stop.test.js
@@ -2830,3 +2830,64 @@ test('R2-7: a mixed [APPROVE, REJECT] round at floor=2 blocks with the CONSENSUS
     fs.rmSync(dir, { recursive: true, force: true });
   }
 });
+
+// ════════════════════════════════════════════════════════════════════════════
+// ROUND 3 — FINAL convergence confirmation.
+//
+// Round-3 probes (markdown-bolded `**verdict:** BLOCK`, leading-whitespace /
+// blockquote / trailing-text verdict lines, round-walk disagreement between
+// getLastDispatchRoundResults and detectUnavailWithoutFallback, and fail-open on
+// nested/malformed tool_result content) were each traced to ground:
+//   • The slot-dispatch script emits a CANONICAL `verdict: <BARE_WORD>` line
+//     (bin/quorum-slot-dispatch.cjs:1156, extractor :974/:1900 anchored
+//     `verdict:\s*`). Markdown bolding / trailing text on the verdict line cannot
+//     occur in-contract — the script normalizes the verdict to a bare word. The
+//     hook's non-line-anchored `/verdict:\s*(?:BLOCK|REJECT)/i` therefore matches
+//     every reachable verdict line; the only inputs it "misses" are not produced.
+//   • getLastDispatchRoundResults and detectUnavailWithoutFallback define a round
+//     identically (one assistant message bearing ≥1 nf-quorum-slot-worker Task),
+//     so they cannot disagree on the last round. detectUnavailWithoutFallback
+//     handles only UNAVAIL/FLAG_TRUNCATED; BLOCK/REJECT is the backstop's job —
+//     no verdict slips between them.
+//   • Nested/null/non-string tool_result content degrades to '' (a non-vote) and
+//     every parse path is wrapped per-line try/catch inside main()'s fail-open
+//     boundary, so the gate exits 0, never crashes.
+//
+// One invariant lock-in below (no new gap). It encodes the explicitly-requested
+// "lone BLOCK voter, floor permitting" case AND a leading-whitespace stylistic
+// variation, so it FAILS on a real defect: a single in-contract BLOCK that the
+// backstop fails to fire on (gate bypass), or a future `^verdict:` line-anchoring
+// regression that would let a whitespace-prefixed BLOCK slip the scan.
+
+// R3-INV: a lone slot-worker BLOCK (the ONLY voter) at floor=1 must CONSENSUS-block.
+// floor=1 is satisfied by the single BLOCK (it counts as a live voter), so the floor
+// path does NOT pre-empt — the CE-2 backstop must be the blocker. The verdict text
+// carries a leading space (` verdict: BLOCK`) to also assert the scan is not
+// line-start-anchored. EXPECTED: BLOCKS with the CONSENSUS reason.
+test('R3-INV: a single in-contract BLOCK voter (leading whitespace) at floor=1 consensus-blocks (no lone-dissent bypass)', () => {
+  const dir = setupQuorumDir('r3-lone-block', 1);
+  try {
+    const tmpFile = writeTempTranscript(slotWorkerConsensusTranscript([
+      ' verdict: BLOCK\nreasoning: lone dissent — leading whitespace, the only voter this round',
+    ]));
+    try {
+      const { stdout, exitCode } = runHookWithCwd(
+        { stop_hook_active: false, hook_event_name: 'Stop', transcript_path: tmpFile },
+        dir
+      );
+      assert.strictEqual(exitCode, 0, 'hooks always exit 0');
+      assert.ok(stdout.length > 0,
+        'a lone BLOCK voter that meets the floor must not pass silently');
+      const parsed = JSON.parse(stdout);
+      assert.strictEqual(parsed.decision, 'block',
+        'CE-2: a single BLOCK is absolute even as the only voter — must block');
+      assert.ok(/CONSENSUS NOT REACHED/.test(parsed.reason),
+        'the CE-2 backstop (not the floor) must catch the lone BLOCK at floor=1; ' +
+        'a leading-whitespace verdict line must still be scanned. reason was: ' + parsed.reason);
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/hooks/nf-stop.test.js
+++ b/hooks/nf-stop.test.js
@@ -2328,3 +2328,220 @@ test('TC-FORMAL: nf-stop.js carries no formal auto-commit (no commit of .plannin
                     || /\.planning\/formal[\s\S]{0,300}['"]commit['"]/.test(src);
   assert.ok(!formalCommit, 'the Stop hook must not git-commit .planning/formal/');
 });
+
+// ════════════════════════════════════════════════════════════════════════════
+// ADVERSARIAL — quorum-consensus gate bypass / false-block probes.
+//
+// These exercise the slot-worker pass path (the inline-dispatch evidence branch)
+// against the CE rules the gate is meant to uphold:
+//   CE-2  BLOCK is absolute — a single REJECT/BLOCK voter must prevent the pass.
+//   CE-3  Unanimity — consensus = 100% of live voters APPROVE. A split must block.
+//   CE-4  min_live_voters floor — below floor "consensus" must block.
+// They also probe a false-block: a *legitimate* all-APPROVE consensus whose
+// reasoning prose merely mentions the word "UNAVAIL".
+//
+// Tests that assert the SECURE expected behaviour will FAIL on a real defect,
+// which is the point — a failing ADV test ⇒ a reachable gate gap.
+// ════════════════════════════════════════════════════════════════════════════
+
+// Project dir with a standard-profile nf.json and a chosen min_live_voters floor.
+function setupQuorumDir(label, minLiveVoters) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `nf-stop-adv-${label}-`));
+  const claudeDir = path.join(dir, '.claude');
+  fs.mkdirSync(claudeDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(claudeDir, 'nf.json'),
+    JSON.stringify({
+      hook_profile: 'standard',
+      quorum_commands: ['plan-phase'],
+      quorum: { min_live_voters: minLiveVoters },
+    }),
+    'utf8'
+  );
+  return dir;
+}
+
+// One slot-worker dispatch round (single assistant message, parallel Tasks),
+// the matching tool_result verdicts, and a final decision-marker turn so GUARD 5
+// classifies this as a project decision turn.
+function slotWorkerConsensusTranscript(verdicts) {
+  const tasks = verdicts.map((_, i) => slotWorkerTask(`toolu_w${i}`, `slot-${i}`, 1));
+  const lines = [
+    userLine('/nf:plan-phase 1', 'human-adv'),
+    assistantLine(tasks, 'a-dispatch'),
+  ];
+  verdicts.forEach((v, i) => {
+    lines.push(toolResultSuccessLine(`toolu_w${i}`, v, `tr-w${i}`));
+  });
+  lines.push(assistantLine([{ type: 'text', text: 'Quorum complete.\n\n<!-- NF_DECISION -->' }], 'a-final'));
+  return lines;
+}
+
+// ADV-1 (🔴 CE-2): every slot-worker returned BLOCK, yet the gate passes.
+// detectUnavailWithoutFallback ignores BLOCK; countLiveSlotWorkers counts BLOCK
+// as a live voter, so the floor is "met" and main() exits 0 with no decision.
+// A unanimous REJECT must NOT ship the planning output. EXPECTED: this FAILS,
+// exposing the bypass (nf-stop.js:734 counts BLOCK; :1008 exits 0 with no
+// verdict-disagreement check).
+test('ADV-1: unanimous slot-worker BLOCK must block the gate (CE-2 absolute reject)', () => {
+  const dir = setupQuorumDir('ce2', 2);
+  try {
+    const tmpFile = writeTempTranscript(slotWorkerConsensusTranscript([
+      'verdict: BLOCK\nreasoning: this plan is unsafe and must not ship',
+      'verdict: BLOCK\nreasoning: rejecting — missing rollback path',
+    ]));
+    try {
+      const { stdout, exitCode } = runHookWithCwd(
+        { stop_hook_active: false, hook_event_name: 'Stop', transcript_path: tmpFile },
+        dir
+      );
+      assert.strictEqual(exitCode, 0, 'hooks always exit 0');
+      assert.ok(stdout.length > 0,
+        'CE-2: a unanimous BLOCK quorum must emit a block decision, not pass silently');
+      assert.strictEqual(JSON.parse(stdout).decision, 'block',
+        'CE-2: a single BLOCK voter is absolute — output must be blocked');
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ADV-2 (🔴 CE-3): split decision — 1 APPROVE + 1 BLOCK. Both count toward the
+// floor (=2), so the gate passes. Unanimity requires 100% APPROVE; one dissenting
+// BLOCK is not consensus. EXPECTED: FAILS — the gate ships a non-unanimous result.
+test('ADV-2: split APPROVE/BLOCK slot-worker quorum must block (CE-3 unanimity)', () => {
+  const dir = setupQuorumDir('ce3', 2);
+  try {
+    const tmpFile = writeTempTranscript(slotWorkerConsensusTranscript([
+      'verdict: APPROVE\nreasoning: looks fine to me',
+      'verdict: BLOCK\nreasoning: I object — this violates the spec',
+    ]));
+    try {
+      const { stdout, exitCode } = runHookWithCwd(
+        { stop_hook_active: false, hook_event_name: 'Stop', transcript_path: tmpFile },
+        dir
+      );
+      assert.strictEqual(exitCode, 0, 'hooks always exit 0');
+      assert.ok(stdout.length > 0,
+        'CE-3: a non-unanimous quorum (1 BLOCK among voters) must not pass silently');
+      assert.strictEqual(JSON.parse(stdout).decision, 'block',
+        'CE-3: consensus requires 100% APPROVE — a dissenting BLOCK must block');
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ADV-3 (🔴 false-block): a genuine all-APPROVE consensus whose reasoning text
+// merely mentions the word "UNAVAIL". detectUnavailWithoutFallback uses a broad
+// /\bUNAVAIL\b/ match over the *entire* result text (nf-stop.js:631) — unlike
+// countLiveSlotWorkers, which was deliberately hardened to match only
+// `verdict: APPROVE|BLOCK`. So an APPROVE vote that references a prior slot being
+// UNAVAIL in prose trips the FALLBACK-01 gate and the legitimate decision is
+// wrongly blocked. EXPECTED: FAILS — the all-APPROVE consensus should pass.
+test('ADV-3: APPROVE consensus mentioning "UNAVAIL" in prose must not be false-blocked', () => {
+  const dir = setupQuorumDir('falseblock', 1);
+  try {
+    const tmpFile = writeTempTranscript(slotWorkerConsensusTranscript([
+      'verdict: APPROVE\nreasoning: solid plan, ship it',
+      'verdict: APPROVE\nreasoning: the codex-1 slot was UNAVAIL earlier this session but the remaining live voters all agree',
+    ]));
+    try {
+      const { stdout, exitCode } = runHookWithCwd(
+        { stop_hook_active: false, hook_event_name: 'Stop', transcript_path: tmpFile },
+        dir
+      );
+      assert.strictEqual(exitCode, 0, 'hooks always exit 0');
+      assert.strictEqual(stdout, '',
+        'false-block: two APPROVE verdicts are a valid consensus — the word "UNAVAIL" in ' +
+        'reasoning prose must not trigger a FALLBACK-01 block');
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ADV-4 (invariant / positive control): a clean two-APPROVE consensus with no
+// "UNAVAIL" prose passes. Confirms the harness genuinely reaches the slot-worker
+// PASS path, so ADV-1/2/3's contrasting outcomes are meaningful (and not all
+// trivially blocked for some unrelated reason). EXPECTED: PASSES.
+test('ADV-4: clean two-APPROVE slot-worker consensus passes (positive control)', () => {
+  const dir = setupQuorumDir('control', 2);
+  try {
+    const tmpFile = writeTempTranscript(slotWorkerConsensusTranscript([
+      'verdict: APPROVE\nreasoning: solid plan',
+      'verdict: APPROVE\nreasoning: agree, ship it',
+    ]));
+    try {
+      const { stdout, exitCode } = runHookWithCwd(
+        { stop_hook_active: false, hook_event_name: 'Stop', transcript_path: tmpFile },
+        dir
+      );
+      assert.strictEqual(exitCode, 0, 'hooks always exit 0');
+      assert.strictEqual(stdout, '', 'a genuine 2-APPROVE consensus must pass cleanly');
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ADV-5 (stale/cross-turn reuse): slot-worker APPROVE evidence lives only in a
+// PRIOR turn; the current decision turn re-issues the planning command, commits a
+// PLAN.md artifact, but makes NO quorum calls. getCurrentTurnLines() must scope to
+// the current turn, so the stale evidence cannot satisfy the gate → the
+// available-but-uncalled required model must block. EXPECTED: PASSES (gate
+// correctly refuses to reuse a prior turn's consensus).
+test('ADV-5: prior-turn quorum evidence must not satisfy the current decision turn', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nf-stop-adv-stale-'));
+  const claudeDir = path.join(dir, '.claude');
+  fs.mkdirSync(claudeDir, { recursive: true });
+  fs.writeFileSync(path.join(claudeDir, 'nf.json'), JSON.stringify({
+    hook_profile: 'standard',
+    quorum_commands: ['plan-phase'],
+    quorum_active: [],
+    required_models: { codex: { tool_prefix: 'mcp__codex-1__', required: true } },
+    quorum: { maxSize: 1, min_live_voters: 1 },
+  }), 'utf8');
+
+  const claudeJsonTmp = path.join(dir, 'claude.json');
+  fs.writeFileSync(claudeJsonTmp, JSON.stringify({ mcpServers: { 'codex-1': {} } }), 'utf8');
+
+  const tmpFile = writeTempTranscript([
+    // PRIOR turn: real slot-worker APPROVE consensus (must NOT carry forward)
+    userLine('/nf:plan-phase 1', 'old-human'),
+    assistantLine([slotWorkerTask('toolu_old', 'codex-1', 1)], 'a-old'),
+    toolResultSuccessLine('toolu_old', 'verdict: APPROVE\nreasoning: looked good last turn', 'tr-old'),
+    assistantLine([{ type: 'text', text: 'Prior plan done.' }], 'a-old-final'),
+    // CURRENT turn: command re-issued, artifact committed, NO quorum calls
+    userLine('/nf:plan-phase 1 (revise)', 'new-human'),
+    assistantLine([
+      bashCommitBlock('node /path/nf-tools.cjs commit "feat: plan" --files 04-01-PLAN.md'),
+    ], 'a-commit'),
+    assistantLine([{ type: 'text', text: 'Revised plan.\n\n<!-- NF_DECISION -->' }], 'a-new-final'),
+  ]);
+
+  try {
+    const { stdout, exitCode } = runHookWithEnv(
+      { stop_hook_active: false, hook_event_name: 'Stop', transcript_path: tmpFile },
+      { HOME: dir, NF_CLAUDE_JSON: claudeJsonTmp },
+      dir
+    );
+    assert.strictEqual(exitCode, 0, 'hooks always exit 0');
+    assert.ok(stdout.length > 0,
+      'stale guard: a prior turn\'s APPROVE must not satisfy the current decision turn');
+    const parsed = JSON.parse(stdout);
+    assert.strictEqual(parsed.decision, 'block',
+      'current turn made no quorum calls — must block despite prior-turn consensus');
+  } finally {
+    fs.unlinkSync(tmpFile);
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/hooks/nf-stop.test.js
+++ b/hooks/nf-stop.test.js
@@ -2377,12 +2377,10 @@ function slotWorkerConsensusTranscript(verdicts) {
   return lines;
 }
 
-// ADV-1 (🔴 CE-2): every slot-worker returned BLOCK, yet the gate passes.
-// detectUnavailWithoutFallback ignores BLOCK; countLiveSlotWorkers counts BLOCK
-// as a live voter, so the floor is "met" and main() exits 0 with no decision.
-// A unanimous REJECT must NOT ship the planning output. EXPECTED: this FAILS,
-// exposing the bypass (nf-stop.js:734 counts BLOCK; :1008 exits 0 with no
-// verdict-disagreement check).
+// ADV-1 (🔴 CE-2): every slot-worker returned BLOCK. This exposed a bypass — the gate
+// counted BLOCK as a live voter so the floor was "met" and main() exited 0 with no
+// decision, shipping the planning output. FIXED by the detectUnresolvedBlock backstop;
+// EXPECTED: PASSES (a unanimous BLOCK now blocks). Regression guard for the bypass.
 test('ADV-1: unanimous slot-worker BLOCK must block the gate (CE-2 absolute reject)', () => {
   const dir = setupQuorumDir('ce2', 2);
   try {
@@ -2408,9 +2406,10 @@ test('ADV-1: unanimous slot-worker BLOCK must block the gate (CE-2 absolute reje
   }
 });
 
-// ADV-2 (🔴 CE-3): split decision — 1 APPROVE + 1 BLOCK. Both count toward the
-// floor (=2), so the gate passes. Unanimity requires 100% APPROVE; one dissenting
-// BLOCK is not consensus. EXPECTED: FAILS — the gate ships a non-unanimous result.
+// ADV-2 (🔴 CE-3): split decision — 1 APPROVE + 1 BLOCK. Both count toward the floor
+// (=2), so the floor was "met" and the gate shipped a non-unanimous result. Unanimity
+// requires 100% APPROVE; one dissenting BLOCK is not consensus. FIXED by the backstop;
+// EXPECTED: PASSES (the dissenting BLOCK now blocks). Regression guard for the bypass.
 test('ADV-2: split APPROVE/BLOCK slot-worker quorum must block (CE-3 unanimity)', () => {
   const dir = setupQuorumDir('ce3', 2);
   try {
@@ -2440,9 +2439,10 @@ test('ADV-2: split APPROVE/BLOCK slot-worker quorum must block (CE-3 unanimity)'
 // merely mentions the word "UNAVAIL". detectUnavailWithoutFallback uses a broad
 // /\bUNAVAIL\b/ match over the *entire* result text (nf-stop.js:631) — unlike
 // countLiveSlotWorkers, which was deliberately hardened to match only
-// `verdict: APPROVE|BLOCK`. So an APPROVE vote that references a prior slot being
-// UNAVAIL in prose trips the FALLBACK-01 gate and the legitimate decision is
-// wrongly blocked. EXPECTED: FAILS — the all-APPROVE consensus should pass.
+// `verdict: APPROVE|BLOCK`. So an APPROVE vote that referenced a prior slot being
+// UNAVAIL in prose tripped the FALLBACK-01 gate and the legitimate decision was
+// wrongly blocked. FIXED by anchoring detectUnavailWithoutFallback to the verdict
+// line; EXPECTED: PASSES (the all-APPROVE consensus is no longer false-blocked).
 test('ADV-3: APPROVE consensus mentioning "UNAVAIL" in prose must not be false-blocked', () => {
   const dir = setupQuorumDir('falseblock', 1);
   try {
@@ -2626,10 +2626,10 @@ test('R2-1: early-round BLOCK resolved by a later all-APPROVE round must PASS (b
 });
 
 // R2-2 (vocabulary — REJECT): the Mode-B dissent verdict `REJECT` must trip the
-// backstop just like `BLOCK`. countLiveSlotWorkers counts only APPROVE/BLOCK (NOT
-// REJECT), so min_live_voters=1 + one APPROVE meets the floor; the REJECT then must
-// be caught by detectUnresolvedBlock → CONSENSUS block (not a FLOOR block).
-// EXPECTED: BLOCKS with the consensus reason.
+// backstop just like `BLOCK`. Here min_live_voters=1 + one APPROVE already meets the
+// floor; the REJECT must then be caught by detectUnresolvedBlock → CONSENSUS block
+// (not a FLOOR block). EXPECTED: BLOCKS with the consensus reason. (See R2-7 for the
+// floor=2 case proving REJECT now counts as a live voter.)
 test('R2-2: a REJECT verdict in the last round trips the backstop (CONSENSUS block, not floor)', () => {
   const dir = setupQuorumDir('r2-reject', 1);
   try {

--- a/hooks/nf-stop.test.js
+++ b/hooks/nf-stop.test.js
@@ -2545,3 +2545,288 @@ test('ADV-5: prior-turn quorum evidence must not satisfy the current decision tu
     fs.rmSync(dir, { recursive: true, force: true });
   }
 });
+
+// ════════════════════════════════════════════════════════════════════════════
+// ROUND 2 — Adversarial probes of the CE-2 BLOCK-is-absolute backstop
+// (getLastDispatchRoundResults / detectUnresolvedBlock, nf-stop.js:676-757) and
+// the floor/consensus interaction. Round 1 fixed unanimous-BLOCK, split, and the
+// UNAVAIL-prose false-block. These target DIFFERENT surfaces: last-round scoping
+// of the backstop (resolved-deliberation regression), REJECT vocabulary, prose
+// that must NOT trip the verdict-anchored scan, FLAG-as-floor, a split verdict
+// line, and turn-scoping. A test that asserts the SECURE behaviour FAILS on a
+// real defect — that is the signal.
+// ════════════════════════════════════════════════════════════════════════════
+
+// Multi-round dispatch transcript: each inner array is one dispatch round (one
+// assistant message of parallel slot-worker Tasks) with its matching verdicts,
+// followed by a decision-marker turn so GUARD 5 classifies it as a decision turn.
+function multiRoundTranscript(rounds) {
+  const lines = [userLine('/nf:plan-phase 1', 'human-mr')];
+  rounds.forEach((verdicts, ri) => {
+    const tasks = verdicts.map((_, i) => slotWorkerTask(`toolu_r${ri}w${i}`, `slot-${ri}-${i}`, ri + 1));
+    lines.push(assistantLine(tasks, `a-dispatch-r${ri}`));
+    verdicts.forEach((v, i) => {
+      lines.push(toolResultSuccessLine(`toolu_r${ri}w${i}`, v, `tr-r${ri}w${i}`));
+    });
+  });
+  lines.push(assistantLine([{ type: 'text', text: 'Quorum complete.\n\n<!-- NF_DECISION -->' }], 'a-final'));
+  return lines;
+}
+
+// A tool_result whose result text is SPLIT across multiple content-array text
+// blocks (Claude Code returns tool_result content as an array of blocks).
+// getLastDispatchRoundResults joins them with '' — a verdict line split across
+// blocks must still be scanned intact.
+function splitToolResultLine(toolUseId, textParts, uuid) {
+  return JSON.stringify({
+    type: 'user',
+    message: {
+      role: 'user',
+      content: [{
+        type: 'tool_result',
+        tool_use_id: toolUseId,
+        content: textParts.map(t => ({ type: 'text', text: t })),
+      }],
+    },
+    timestamp: '2026-02-20T00:02:00Z',
+    uuid: uuid || `tr-split-${toolUseId}`,
+  });
+}
+
+// R2-1 (🔴 backstop regression — CRITICAL): a BLOCK in an EARLY dispatch round that
+// a LATER round RESOLVED into all-APPROVE must PASS. The backstop is scoped to the
+// LAST round (getLastDispatchRoundResults), so a resolved objection must not
+// false-block. If the backstop ever scans across rounds, this round-1 BLOCK would
+// trip it and a legitimately-deliberated consensus would be wrongly blocked.
+// EXPECTED: PASSES (deliberation resolved the objection).
+test('R2-1: early-round BLOCK resolved by a later all-APPROVE round must PASS (backstop is last-round-scoped)', () => {
+  const dir = setupQuorumDir('r2-resolved', 2);
+  try {
+    const tmpFile = writeTempTranscript(multiRoundTranscript([
+      // Round 1: one APPROVE, one BLOCK (objection raised)
+      ['verdict: APPROVE\nreasoning: looks fine', 'verdict: BLOCK\nreasoning: missing rollback path'],
+      // Round 2: re-deliberated with the objection rationale — now unanimous APPROVE
+      ['verdict: APPROVE\nreasoning: rollback added, ship it', 'verdict: APPROVE\nreasoning: objection addressed'],
+    ]));
+    try {
+      const { stdout, exitCode } = runHookWithCwd(
+        { stop_hook_active: false, hook_event_name: 'Stop', transcript_path: tmpFile },
+        dir
+      );
+      assert.strictEqual(exitCode, 0, 'hooks always exit 0');
+      assert.strictEqual(stdout, '',
+        'a round-1 BLOCK that round-2 resolved into all-APPROVE must NOT false-block — ' +
+        'the backstop is scoped to the LAST dispatch round only');
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// R2-2 (vocabulary — REJECT): the Mode-B dissent verdict `REJECT` must trip the
+// backstop just like `BLOCK`. countLiveSlotWorkers counts only APPROVE/BLOCK (NOT
+// REJECT), so min_live_voters=1 + one APPROVE meets the floor; the REJECT then must
+// be caught by detectUnresolvedBlock → CONSENSUS block (not a FLOOR block).
+// EXPECTED: BLOCKS with the consensus reason.
+test('R2-2: a REJECT verdict in the last round trips the backstop (CONSENSUS block, not floor)', () => {
+  const dir = setupQuorumDir('r2-reject', 1);
+  try {
+    const tmpFile = writeTempTranscript(slotWorkerConsensusTranscript([
+      'verdict: APPROVE\nreasoning: fine by me',
+      'verdict: REJECT\nreasoning: this violates the spec — must not ship',
+    ]));
+    try {
+      const { stdout, exitCode } = runHookWithCwd(
+        { stop_hook_active: false, hook_event_name: 'Stop', transcript_path: tmpFile },
+        dir
+      );
+      assert.strictEqual(exitCode, 0, 'hooks always exit 0');
+      assert.ok(stdout.length > 0, 'a REJECT dissent must emit a block decision');
+      const parsed = JSON.parse(stdout);
+      assert.strictEqual(parsed.decision, 'block', 'REJECT is absolute — must block');
+      assert.ok(/CONSENSUS NOT REACHED/.test(parsed.reason),
+        'the BLOCK-is-absolute backstop (not the floor) must be the blocker — REJECT ' +
+        'must be recognised by detectUnresolvedBlock; reason was: ' + parsed.reason);
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// R2-3 (false-block mirror — prose must not trip the scan): an all-APPROVE consensus
+// whose reasoning prose contains the bare words "block" and "reject" (NOT on a
+// `verdict:` line) must NOT be blocked. detectUnresolvedBlock is anchored to
+// /verdict:\s*(?:BLOCK|REJECT)\b/ — a naive whole-text /\b(BLOCK|REJECT)\b/ would
+// false-block here. Mirrors the round-1 UNAVAIL-prose hardening. EXPECTED: PASSES.
+test('R2-3: APPROVE consensus mentioning "block"/"reject" only in prose must not trip the backstop', () => {
+  const dir = setupQuorumDir('r2-prose', 2);
+  try {
+    const tmpFile = writeTempTranscript(slotWorkerConsensusTranscript([
+      'verdict: APPROVE\nreasoning: solid plan; I do not reject or block it',
+      'verdict: APPROVE\nreasoning: nothing here would make me block — no reason to reject',
+    ]));
+    try {
+      const { stdout, exitCode } = runHookWithCwd(
+        { stop_hook_active: false, hook_event_name: 'Stop', transcript_path: tmpFile },
+        dir
+      );
+      assert.strictEqual(exitCode, 0, 'hooks always exit 0');
+      assert.strictEqual(stdout, '',
+        'two APPROVE verdicts are a valid consensus — "block"/"reject" appearing only in ' +
+        'reasoning prose (not on a verdict line) must not trigger a CE-2 backstop block');
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// R2-4 (FLAG is a non-vote, not a BLOCK): a last round of all-FLAG (ambiguous, NOT
+// FLAG_TRUNCATED) must behave as the floor path — FLAG is neither a live voter
+// (countLiveSlotWorkers) nor a dissent (detectUnresolvedBlock). With 0 live voters
+// it must FLOOR-block, NOT consensus-block, and NOT FALLBACK-01-block (FLAG ≠
+// FLAG_TRUNCATED ≠ UNAVAIL). EXPECTED: BLOCKS with the FLOOR reason.
+test('R2-4: an all-FLAG last round behaves as a floor block, not a CE-2 backstop block', () => {
+  const dir = setupQuorumDir('r2-flag', 2);
+  try {
+    const tmpFile = writeTempTranscript(slotWorkerConsensusTranscript([
+      'verdict: FLAG\nreasoning: ambiguous — needs human judgment',
+      'verdict: FLAG\nreasoning: cannot tell from the output',
+    ]));
+    try {
+      const { stdout, exitCode } = runHookWithCwd(
+        { stop_hook_active: false, hook_event_name: 'Stop', transcript_path: tmpFile },
+        dir
+      );
+      assert.strictEqual(exitCode, 0, 'hooks always exit 0');
+      assert.ok(stdout.length > 0, 'an all-FLAG round (0 live voters) must block');
+      const parsed = JSON.parse(stdout);
+      assert.strictEqual(parsed.decision, 'block', 'no live voters → must block');
+      assert.ok(/FLOOR NOT MET/.test(parsed.reason),
+        'FLAG must be handled by the live-voter floor, not mis-classified as a BLOCK/UNAVAIL; ' +
+        'reason was: ' + parsed.reason);
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// R2-5 (split verdict line must not fool the scan): a BLOCK whose `verdict:` line is
+// split across two content-array text blocks must still be caught. getLastDispatchRoundResults
+// joins content blocks with '' so "verdict:" + " BLOCK" reconstitutes "verdict: BLOCK".
+// Floor is met (2 live voters: the split BLOCK + one APPROVE) so the backstop is the
+// blocker. EXPECTED: BLOCKS with the consensus reason (no scan bypass).
+test('R2-5: a verdict line split across content blocks is still scanned (no backstop bypass)', () => {
+  const dir = setupQuorumDir('r2-split', 2);
+  try {
+    const tmpFile = writeTempTranscript([
+      userLine('/nf:plan-phase 1', 'human-split'),
+      assistantLine([
+        slotWorkerTask('toolu_w0', 'slot-0', 1),
+        slotWorkerTask('toolu_w1', 'slot-1', 1),
+      ], 'a-dispatch'),
+      // verdict line split across two text blocks: "verdict:" | " BLOCK\n..."
+      splitToolResultLine('toolu_w0', ['verdict:', ' BLOCK\nreasoning: split across blocks but still a block'], 'tr-w0'),
+      toolResultSuccessLine('toolu_w1', 'verdict: APPROVE\nreasoning: looks fine', 'tr-w1'),
+      assistantLine([{ type: 'text', text: 'Quorum complete.\n\n<!-- NF_DECISION -->' }], 'a-final'),
+    ]);
+    try {
+      const { stdout, exitCode } = runHookWithCwd(
+        { stop_hook_active: false, hook_event_name: 'Stop', transcript_path: tmpFile },
+        dir
+      );
+      assert.strictEqual(exitCode, 0, 'hooks always exit 0');
+      assert.ok(stdout.length > 0, 'a split-but-present BLOCK verdict must still block');
+      const parsed = JSON.parse(stdout);
+      assert.strictEqual(parsed.decision, 'block',
+        'a BLOCK verdict split across content-array text blocks must not slip past the scan');
+      assert.ok(/CONSENSUS NOT REACHED/.test(parsed.reason),
+        'the backstop (not the floor) must catch the split BLOCK; reason was: ' + parsed.reason);
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// R2-6 (turn-scoping of the backstop): a BLOCK that lives only in a PRIOR turn must
+// not block a CURRENT turn whose own dispatch round is a clean all-APPROVE consensus.
+// getCurrentTurnLines scopes the backstop to the current turn — the stale BLOCK must
+// be invisible. If turn-scoping ever broke, the prior BLOCK would false-block the
+// current consensus. EXPECTED: PASSES.
+test('R2-6: a prior-turn BLOCK must not block the current turn (backstop is turn-scoped)', () => {
+  const dir = setupQuorumDir('r2-turn', 2);
+  try {
+    const tmpFile = writeTempTranscript([
+      // PRIOR turn: a BLOCK that must NOT carry forward
+      userLine('/nf:plan-phase 1', 'old-human'),
+      assistantLine([slotWorkerTask('toolu_old', 'codex-1', 1)], 'a-old'),
+      toolResultSuccessLine('toolu_old', 'verdict: BLOCK\nreasoning: rejected last turn', 'tr-old'),
+      assistantLine([{ type: 'text', text: 'Prior turn blocked.' }], 'a-old-final'),
+      // CURRENT turn: a clean all-APPROVE consensus on a decision turn
+      userLine('/nf:plan-phase 1 (revise)', 'new-human'),
+      assistantLine([
+        slotWorkerTask('toolu_n0', 'slot-0', 1),
+        slotWorkerTask('toolu_n1', 'slot-1', 1),
+      ], 'a-new-dispatch'),
+      toolResultSuccessLine('toolu_n0', 'verdict: APPROVE\nreasoning: addressed', 'tr-n0'),
+      toolResultSuccessLine('toolu_n1', 'verdict: APPROVE\nreasoning: ship it', 'tr-n1'),
+      assistantLine([{ type: 'text', text: 'Revised plan.\n\n<!-- NF_DECISION -->' }], 'a-new-final'),
+    ]);
+    try {
+      const { stdout, exitCode } = runHookWithCwd(
+        { stop_hook_active: false, hook_event_name: 'Stop', transcript_path: tmpFile },
+        dir
+      );
+      assert.strictEqual(exitCode, 0, 'hooks always exit 0');
+      assert.strictEqual(stdout, '',
+        'the current turn is a clean all-APPROVE consensus — a BLOCK from a prior turn ' +
+        'must not be visible to the backstop');
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// R2-7 (diagnostic accuracy — REJECT counts as a live voter): a mixed [APPROVE, REJECT]
+// round with min_live_voters=2 must reach the CE-2 backstop and report "CONSENSUS NOT
+// REACHED" — NOT a misleading "QUORUM FLOOR NOT MET". This requires countLiveSlotWorkers
+// to count REJECT (Mode B) as a live voter like BLOCK (Mode A); otherwise liveCount=1 < 2
+// floor-blocks first with the wrong reason. Two voters genuinely responded. EXPECTED: PASSES.
+test('R2-7: a mixed [APPROVE, REJECT] round at floor=2 blocks with the CONSENSUS reason, not the floor reason', () => {
+  const dir = setupQuorumDir('r2-reject-floor', 2);
+  try {
+    const tmpFile = writeTempTranscript(slotWorkerConsensusTranscript([
+      'verdict: APPROVE\nreasoning: looks good',
+      'verdict: REJECT\nreasoning: this breaks the contract — must not ship',
+    ]));
+    try {
+      const { stdout, exitCode } = runHookWithCwd(
+        { stop_hook_active: false, hook_event_name: 'Stop', transcript_path: tmpFile },
+        dir
+      );
+      assert.strictEqual(exitCode, 0, 'hooks always exit 0');
+      const parsed = JSON.parse(stdout);
+      assert.strictEqual(parsed.decision, 'block', 'a REJECT dissent must block');
+      assert.ok(/CONSENSUS NOT REACHED/.test(parsed.reason),
+        'two voters responded (APPROVE + REJECT) so the floor (2) is met — the blocker must ' +
+        'be the CE-2 consensus backstop, not a misleading "floor not met". reason was: ' + parsed.reason);
+      assert.ok(!/FLOOR NOT MET/.test(parsed.reason),
+        'REJECT must count as a live voter so the floor reason is not wrongly emitted');
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What

`/nf:harden` adversarial loop on the two **enforcement hooks** — the layer that makes the quorum mandatory. This session hardened how the quorum *runs* (#278); this hardens how it's *enforced*. **6 real gaps fixed**, every one red-proven, converged over 2 rounds.

## 🚪 nf-stop.js — the quorum GATE (3 gaps)
The Stop hook that blocks Claude from delivering planning/checkpoint output unless valid consensus exists.

- **🔴 CE-2 BYPASS (BLOCK not absolute)** — a unanimous BLOCK shipped the output. The slot-worker pass path checked only the `min_live_voters` floor, and `countLiveSlotWorkers` counts a BLOCK as a live voter, so two BLOCKs "met the floor" → `exit(0)` passed. Added `detectUnresolvedBlock`, a CE-2 backstop that blocks when the **consensus (last) dispatch round** carries an unresolved BLOCK/REJECT. Scoped to the last round (shared round-walker) so a BLOCK **resolved by later deliberation does not false-block** (verified by R2-1). Unconditional — not waivable by `--force-quorum`, per CE-2.
- **🔴 CE-3 BYPASS (non-unanimous passes)** — 1 APPROVE + 1 BLOCK passed. Same root cause, same backstop.
- **🔴 FALSE-BLOCK** — `detectUnavailWithoutFallback` matched a bare `/\bUNAVAIL\b/` over the whole result text, so an all-APPROVE consensus whose prose said *"codex-1 was UNAVAIL earlier"* was wrongly FALLBACK-01-blocked. Anchored to the verdict line.
- Plus a diagnostic fix: `REJECT` now counts as a live voter so a mixed `[APPROVE, REJECT]` round reports the accurate "consensus not reached" instead of a misleading "floor not met".

## 🔌 nf-circuit-breaker.js — oscillation detector (3 gaps, one root cause)
The PreToolUse hook that breaks deliberate-rollback/oscillation loops. All three stemmed from `hasReversionInHashes` using an add/delete-count proxy that was wrong in **both** directions:

- **🔴 MISSED OSCILLATION** — an equal-length value toggle (`FLAG="on"`↔`"off"`, `x=1`↔`x=2`) has net-zero pairs and no negative pair, so the old `totalNetChange<=0 && hasNegativePair` never fired — the canonical flip-flop loop was invisible. Added a **byte-level content-reversion** signal (file-set blob fingerprint returns to a prior state).
- **🔴 FALSE BLOCK** — a sustained monotonic cleanup (dead-code 6→4→2 lines) satisfied the proxy and halted a normal refactor. Now exempted (≥2 deletion-only pairs, no additions, no content reversion = directional cleanup). A single deletion keeps its established behavior.

## Verification
Each gap red-proven by the adversarial agent (fails pre-fix, passes after). Round-2 regression probes confirmed the fixes don't over/under-correct (resolved-deliberation passes; down-down-up loop still caught; one-shot rollback still rescued by `isCleanRollback`). **nf-stop 67/67, nf-circuit-breaker 60/60; lint OK; source↔dist in sync.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved oscillation detection so genuine back-and-forth changes are caught more reliably, while steady one-way shrinkage is no longer flagged incorrectly.
  * Tightened stop-hook quorum handling to ignore incidental mentions of “UNAVAIL” and only act on explicit verdicts.
  * Added stronger blocking for unresolved consensus votes, while preserving clean approvals and resolving stale or out-of-scope evidence correctly.
  * Expanded regression coverage for edge cases, including turn scoping, split verdict parsing, and rollback/reversion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->