### PR TITLE
chore(release): 0.44.0-rc.1 (prerelease → @next)

### DIFF
--- a/docs/assets/terminal.svg
+++ b/docs/assets/terminal.svg
@@ -80,7 +80,7 @@
     <path d="M100.8,143.0 H96.6 V132.0" stroke="#7dcfff" stroke-width="1.5" stroke-linecap="square" fill="none"/>
     <line x1="100.8" y1="143.0" x2="109.2" y2="143.0" stroke="#7dcfff" stroke-width="1.5" stroke-linecap="square" fill="none"/>
     <path d="M109.2,143.0 H113.4 V132.0" stroke="#7dcfff" stroke-width="1.5" stroke-linecap="square" fill="none"/>
-    <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="198" xml:space="preserve"><tspan fill="#c0caf5">  nForma </tspan><tspan fill="#c0caf5">— Consensus before code. Proof before production. </tspan><tspan fill="#565f89">v0.44.0</tspan></text>
+    <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="198" xml:space="preserve"><tspan fill="#c0caf5">  nForma </tspan><tspan fill="#c0caf5">— Consensus before code. Proof before production. </tspan><tspan fill="#565f89">v0.44.0-rc.1</tspan></text>
     <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="220" xml:space="preserve"><tspan fill="#565f89">  Built on GSD-CC by TÂCHES.</tspan></text>
     <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="264" xml:space="preserve"><tspan fill="#7dcfff">  The task of leadership is to create an alignment of strengths</tspan></text>
     <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="286" xml:space="preserve"><tspan fill="#7dcfff">   so strong that it makes the system’s weaknesses irrelevant.</tspan></text>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nforma.ai/nforma",
-  "version": "0.44.0",
+  "version": "0.44.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nforma.ai/nforma",
-      "version": "0.44.0",
+      "version": "0.44.0-rc.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nforma.ai/nforma",
-  "version": "0.44.0",
+  "version": "0.44.0-rc.1",
   "description": "nForma — Multi-agent coding orchestrator with quorum consensus and formal verification (TLA+, Alloy, PRISM). Consensus before code, proof before production.",
   "bin": {
     "nforma": "bin/nforma-cli.js",


### PR DESCRIPTION
## Release 0.44.0-rc.1 → @next

Cuts the **0.44.0 milestone as a release candidate** on the `@next` dist-tag, bringing `@next` up from `0.43.1`. Reserves the bare `0.44.0` for the eventual stable `@latest` cut.

### Includes (#272–#279)
- PreCompact output contract + source↔dist drift detection
- antigravity CLI family; the P0 `args_template` crash fix; slow-model (GLM/MiniMax) tuning
- **#278** — secrets/dispatch/MCP hardening: a 🔴 cross-slot credential leak, 5 prompt-injection vectors, fail-open DoS guards
- **#279** — enforcement-hook hardening: quorum-gate bypasses (CE-2/CE-3) + oscillation mis-detection

### Release hygiene
- `package.json` + `package-lock.json` → `0.44.0-rc.1` (in sync)
- CHANGELOG `[0.44.0]` present (prerelease gate checks the base version)
- terminal asset regenerated; `lint:isolation` + `check:assets` pass

On merge, I'll tag `v0.44.0-rc.1` from main → the prerelease pipeline publishes to `@next`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app version to `0.44.0-rc.1` for the next release candidate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->