### PR TITLE
fix(solve): autocommit never commits ephemeral TLC trace artifacts (root-cause)

### DIFF
--- a/bin/solve-commit-artifacts.cjs
+++ b/bin/solve-commit-artifacts.cjs
@@ -21,6 +21,14 @@ const PATHSPECS = [
 // it can silently stage nothing — so we stage then `git reset` these paths out).
 const STAGE_EXCLUDE_PATHS = ['test/golden/'];
 
+// Ephemeral TLC trace artifacts (`<spec>_TTrace_<id>.tla` / `.bin`) are produced as a
+// side effect of every model-check run with a fresh random id each time. They are pure
+// output — never a committed input — so committing them bloats the repo and churns
+// feature branches (this autocommit has buried 100+ of them before). The chokepoint
+// hard-excludes them regardless of .gitignore completeness: even a tracked or
+// not-yet-ignored trace is un-staged here so it can never enter a solve commit.
+const ARTIFACT_EXCLUDE_RE = /_TTrace_\d+\.(tla|bin)$/;
+
 // Branches the auto-commit must never write to. Solve commits its formal-artifact
 // churn (and its own code fixes) on a working branch; committing directly to the
 // default branch pollutes it with unpushed churn and breaks branches cut from it.
@@ -81,6 +89,27 @@ function stagePaths(opts) {
       encoding: 'utf8', cwd, timeout: 15000, stdio: 'pipe',
     });
   }
+  unstageArtifacts(opts);
+}
+
+// Un-stage ephemeral TLC trace artifacts (matched by ARTIFACT_EXCLUDE_RE) that the
+// broad `git add` may have picked up. Returns the list of dropped paths. Matching on
+// the actual staged file list (rather than a pathspec glob) is deterministic across
+// nested spec dirs and avoids git pathspec-glob subtleties.
+function unstageArtifacts(opts) {
+  const cwd = (opts && opts.cwd) || ROOT;
+  const r = spawnSync('git', ['diff', '--cached', '--name-only'], {
+    encoding: 'utf8', cwd, timeout: 15000, stdio: 'pipe',
+  });
+  if (r.status !== 0 || !r.stdout) return [];
+  const drop = r.stdout.split('\n').map(s => s.trim()).filter(Boolean)
+    .filter(p => ARTIFACT_EXCLUDE_RE.test(p));
+  if (drop.length) {
+    spawnSync('git', ['reset', '-q', '--', ...drop], {
+      encoding: 'utf8', cwd, timeout: 15000, stdio: 'pipe',
+    });
+  }
+  return drop;
 }
 
 function hasStagedChanges(opts) {
@@ -130,7 +159,8 @@ function main() {
       if (r.stdout && r.stdout.trim()) {
         // Drop excluded paths from the preview so it matches what actually commits.
         const lines = r.stdout.trim().split('\n')
-          .filter(line => !STAGE_EXCLUDE_PATHS.some(ex => line.includes(ex)));
+          .filter(line => !STAGE_EXCLUDE_PATHS.some(ex => line.includes(ex)))
+          .filter(line => !ARTIFACT_EXCLUDE_RE.test(line.replace(/^add\s+'?|'$/g, '')));
         if (lines.length) console.log(lines.join('\n'));
       }
     }
@@ -181,7 +211,7 @@ if (require.main === module) {
 }
 
 module.exports = {
-  PATHSPECS, STAGE_EXCLUDE_PATHS, PROTECTED_BRANCHES, COMMIT_MSG,
+  PATHSPECS, STAGE_EXCLUDE_PATHS, ARTIFACT_EXCLUDE_RE, PROTECTED_BRANCHES, COMMIT_MSG,
   isGitRepo, currentBranch, defaultBranch, isProtectedBranch,
-  stagePaths, hasStagedChanges, doCommit,
+  stagePaths, unstageArtifacts, hasStagedChanges, doCommit,
 };

--- a/bin/solve-commit-artifacts.test.cjs
+++ b/bin/solve-commit-artifacts.test.cjs
@@ -158,6 +158,42 @@ test('TC-COMMIT-11: stagePaths excludes test/golden/ snapshots', () => {
   }
 });
 
+test('TC-COMMIT-15: stagePaths never stages TLC trace artifacts (_TTrace_)', () => {
+  const tmp = createTempRepo();
+  try {
+    const specDir = path.join(tmp, '.planning', 'formal', 'spec', 'debug-bench-sort');
+    fs.mkdirSync(specDir, { recursive: true });
+    // a real artifact (should commit) + two trace files (must be dropped)
+    fs.writeFileSync(path.join(tmp, '.planning', 'formal', 'layer-manifest.json'), '{"v":1}');
+    fs.writeFileSync(path.join(specDir, 'bug_TTrace_1782725126.tla'), '\\* trace\n');
+    fs.writeFileSync(path.join(specDir, 'bug_TTrace_1782725126.bin'), 'BINARY');
+    stagePaths({ cwd: tmp });
+    const staged = spawnSync('git', ['diff', '--cached', '--name-only'], { encoding: 'utf8', cwd: tmp }).stdout || '';
+    assert.ok(staged.includes('layer-manifest.json'), 'real formal artifact should be staged');
+    assert.ok(!staged.includes('_TTrace_'), 'TLC trace artifacts must never be staged');
+  } finally {
+    cleanup(tmp);
+  }
+});
+
+test('TC-COMMIT-16: unstageArtifacts drops an ALREADY-TRACKED trace that was re-modified', () => {
+  const tmp = createTempRepo();
+  try {
+    // Simulate a trace that slipped into git history before the guard existed.
+    const traceRel = '.planning/formal/spec/x/bug_TTrace_1.tla';
+    fs.mkdirSync(path.join(tmp, '.planning', 'formal', 'spec', 'x'), { recursive: true });
+    fs.writeFileSync(path.join(tmp, traceRel), 'v1\n');
+    spawnSync('git', ['add', '-f', traceRel], { encoding: 'utf8', cwd: tmp });
+    spawnSync('git', ['commit', '-m', 'legacy trace', '--no-verify'], { encoding: 'utf8', cwd: tmp });
+    fs.writeFileSync(path.join(tmp, traceRel), 'v2\n'); // modify it
+    stagePaths({ cwd: tmp });
+    const staged = spawnSync('git', ['diff', '--cached', '--name-only'], { encoding: 'utf8', cwd: tmp }).stdout || '';
+    assert.ok(!staged.includes('_TTrace_'), 'a re-modified tracked trace must still be un-staged');
+  } finally {
+    cleanup(tmp);
+  }
+});
+
 test('TC-COMMIT-12: isProtectedBranch is true on main, false on a feature branch', () => {
   const main = createTempRepoOnMain();
   const feat = createTempRepo();


### PR DESCRIPTION
## Root-cause fix for the recurring autocommit pollution

The solve autocommit (`bin/solve-commit-artifacts.cjs`) stages `.planning/formal/` wholesale, which sweeps **TLC trace files** (`<spec>_TTrace_<id>.tla` / `.bin`) into `chore(solve)` commits. These have a fresh random id every run and are pure model-check *output* — never an input. This is the same pattern hit repeatedly this week (most recently **104** trace files removed in #286).

### The fix
A hard exclude at the single chokepoint:
- `ARTIFACT_EXCLUDE_RE = /_TTrace_\d+\.(tla|bin)$/`
- After the broad `git add`, `unstageArtifacts()` un-stages any matching path — so a trace can **never** enter a solve commit, regardless of `.gitignore` completeness, **and even if it was already tracked** before the guard existed.
- `--dry-run` preview mirrors the exclusion.

### Deliberately NOT excluded
`solve-state.json` / `solve-trend.jsonl` — these are **real convergence state** consumed by `convergence-report.cjs` / `analyze-solve-convergence.cjs`. Only ephemeral traces are dropped.

### Tests
- **TC-COMMIT-15** — a trace is never staged alongside a real artifact.
- **TC-COMMIT-16** — an already-tracked, re-modified trace is still un-staged.
- Suite: 15/15 (+1 heavy nf-solve integration skipped).

Complements the `.gitignore` guard added in #286 (defense-in-depth: gitignore stops untracked-ignored; this stops everything at the commit chokepoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)