### PR TITLE
fix(solve): report-only is idempotent — don't persist solve-state.json (issue #5)

### DIFF
--- a/bin/nf-solve.cjs
+++ b/bin/nf-solve.cjs
@@ -6750,15 +6750,23 @@ function main() {
   const prevClean = (existingSolveState && existingSolveState.consecutive_clean_sessions) || 0;
   solveState.consecutive_clean_sessions = isCleanSession ? prevClean + 1 : 0;
 
-  try {
-    const stateDir = path.join(ROOT, '.planning', 'formal');
-    fs.mkdirSync(stateDir, { recursive: true });
-    fs.writeFileSync(
-      path.join(stateDir, 'solve-state.json'),
-      JSON.stringify(solveState, null, 2) + '\n'
-    );
-  } catch (e) {
-    process.stderr.write(TAG + ' WARNING: could not write solve-state.json: ' + e.message + '\n');
+  // Report-only is documented as a no-mutation diagnostic sweep. Persisting
+  // solve-state.json here violated that and made the measurement non-idempotent:
+  // the residual penalizes a stale solve-state (wave_count===0), so a report run
+  // rewrote the state and the NEXT report run then measured a lower residual
+  // (issue #5 — "Residual unstable: pre=348→post=340" on no-op stability checks).
+  // Only persist when actually solving.
+  if (!reportOnly) {
+    try {
+      const stateDir = path.join(ROOT, '.planning', 'formal');
+      fs.mkdirSync(stateDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(stateDir, 'solve-state.json'),
+        JSON.stringify(solveState, null, 2) + '\n'
+      );
+    } catch (e) {
+      process.stderr.write(TAG + ' WARNING: could not write solve-state.json: ' + e.message + '\n');
+    }
   }
 
   // Step 8a: Auto-promote eligible models (PROMO-01)

--- a/bin/nf-solve.test.cjs
+++ b/bin/nf-solve.test.cjs
@@ -1478,6 +1478,22 @@ test('TC-FOCUS-4: sweepFtoT filters gaps by focusSet (source code verification)'
   assert.ok(ftoT.includes('gapsList.filter'), 'sweepFtoT should filter gapsList');
 });
 
+// ── TC-IDEMPOTENT: report-only must not mutate solve-state.json (issue #5) ────
+
+test('TC-IDEMPOTENT-1: the solve-state.json write is guarded by !reportOnly', () => {
+  const src = fs.readFileSync(path.join(__dirname, 'nf-solve.cjs'), 'utf8');
+  // Locate the solve-state.json write and confirm an `if (!reportOnly)` guard
+  // immediately precedes it. Report-only is documented as a no-mutation sweep; an
+  // unguarded write made the residual non-idempotent (a report run rewrote state,
+  // and the residual penalizes stale solve-state, so the next run measured lower).
+  // Anchor on the unique write expression (not the reads of the same filename).
+  const idx = src.indexOf('JSON.stringify(solveState, null, 2)');
+  assert.ok(idx !== -1, 'expected the solve-state.json write site');
+  const preceding = src.slice(Math.max(0, idx - 400), idx);
+  assert.ok(/if\s*\(\s*!reportOnly\s*\)/.test(preceding),
+    'the solve-state.json write must be guarded by `if (!reportOnly)` so a report-only sweep stays idempotent');
+});
+
 // ── TC-MISSING: Missing-file residual tests (DIAG-02) ────────────────────────
 
 test('TC-MISSING-1: missing-file returns use residual -1 not 0 (source verification)', () => {


### PR DESCRIPTION
## Fixes nf-benchmark issue #5 (nf-solve non-idempotency)

`--report-only` is documented as a no-mutation diagnostic sweep, but `bin/nf-solve.cjs` wrote `.planning/formal/solve-state.json` **unconditionally**. The residual computation *penalizes* a stale solve-state (`wave_count===0` → +3 on `r_to_f`), so a report run rewrote the state and the **next** report run measured a lower residual — the exact source of the benchmark's `Residual unstable: pre=348→post=340` failures on no-op stability checks.

### Fix
Guard the write with `if (!reportOnly)`. solve-state.json is still persisted on real (non-report) solves, where progress *should* be recorded.

### Verified
- A full `--report-only` run (no skip flags) exits 0 with valid JSON and leaves `solve-state.json` **byte-identical** (hash + mtime unchanged) — idempotent on the complete pipeline.
- `TC-IDEMPOTENT-1` (source-static) asserts the write stays guarded by `!reportOnly`.

This is the product-side root cause behind the `stability` category scoring 0/15 (see issue #5); with it, two consecutive no-op report runs produce the same residual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Report-only runs now avoid writing persistent state, keeping them idempotent and preventing stale “solved” data from being left behind.
  * State-saving errors are now handled more safely, with a warning shown if persistence fails.

* **Tests**
  * Added coverage to verify that report-only mode does not perform an unguarded state write.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->