### PR TITLE
fix(solve): autocommit only commits generated artifacts, not bin/ + test/ source

### DIFF
--- a/bin/solve-commit-artifacts.cjs
+++ b/bin/solve-commit-artifacts.cjs
@@ -6,12 +6,18 @@ const path = require('path');
 
 const ROOT = path.resolve(__dirname, '..');
 
+// What the solve actually GENERATES — and nothing else. Everything nf-solve produces
+// (manifests, evidence, model registry, generated-stubs/ incl. implemented *.stub.test.js,
+// requirements coverage) lives under these paths. `bin/` and `test/` were previously
+// swept wholesale, but the solve writes NOTHING there — so `git add -A -- bin/`/`test/`
+// only ever captured a developer's in-progress source edits and buried them inside a
+// `chore(solve)` commit (it did exactly that to this very file mid-PR). Generated code
+// goes to .planning/formal/generated-stubs/, which is already covered, so dropping bin/
+// and test/ loses no real artifact and stops the source pollution at the root.
 const PATHSPECS = [
   '.planning/formal/',
   '.planning/upstream-state.json',
   'docs/dev/requirements-coverage.md',
-  'bin/',
-  'test/',
 ];
 
 // Machine-local / generated snapshots that get regenerated per-developer (golden

--- a/bin/solve-commit-artifacts.test.cjs
+++ b/bin/solve-commit-artifacts.test.cjs
@@ -194,6 +194,30 @@ test('TC-COMMIT-16: unstageArtifacts drops an ALREADY-TRACKED trace that was re-
   }
 });
 
+test('TC-COMMIT-17: a developer edit in bin/ or test/ is NEVER swept into a solve commit', () => {
+  const tmp = createTempRepo();
+  try {
+    // seed tracked bin/ + test/ source, then modify them (an in-progress dev edit)
+    fs.mkdirSync(path.join(tmp, 'bin'), { recursive: true });
+    fs.mkdirSync(path.join(tmp, 'test'), { recursive: true });
+    fs.writeFileSync(path.join(tmp, 'bin', 'tool.cjs'), 'v1\n');
+    fs.writeFileSync(path.join(tmp, 'test', 'tool.test.cjs'), 'v1\n');
+    spawnSync('git', ['add', '-A'], { encoding: 'utf8', cwd: tmp });
+    spawnSync('git', ['commit', '-m', 'seed', '--no-verify'], { encoding: 'utf8', cwd: tmp });
+    fs.writeFileSync(path.join(tmp, 'bin', 'tool.cjs'), 'v2 — work in progress\n');   // dev edit
+    fs.writeFileSync(path.join(tmp, 'test', 'new.test.cjs'), 'brand new\n');           // untracked dev file
+    // a real generated artifact the solve DID produce
+    fs.writeFileSync(path.join(tmp, '.planning', 'formal', 'layer-manifest.json'), '{"v":2}');
+    stagePaths({ cwd: tmp });
+    const staged = spawnSync('git', ['diff', '--cached', '--name-only'], { encoding: 'utf8', cwd: tmp }).stdout || '';
+    assert.ok(staged.includes('.planning/formal/layer-manifest.json'), 'generated formal artifact must still be staged');
+    assert.ok(!staged.includes('bin/'), 'a bin/ source edit must NOT be swept into a solve commit');
+    assert.ok(!staged.includes('test/'), 'a test/ file must NOT be swept into a solve commit');
+  } finally {
+    cleanup(tmp);
+  }
+});
+
 test('TC-COMMIT-12: isProtectedBranch is true on main, false on a feature branch', () => {
   const main = createTempRepoOnMain();
   const feat = createTempRepo();


### PR DESCRIPTION
## Closes the remaining autocommit-pollution hole

`bin/solve-commit-artifacts.cjs` staged `bin/` and `test/` **wholesale**, but nf-solve writes *nothing* there — every generated artifact (manifests, evidence, model registry, and `generated-stubs/` including implemented `*.stub.test.js`) lives under `.planning/formal/`. So `git add -A -- bin/`/`test/` only ever captured a developer's **in-progress source edits** and buried them inside a `chore(solve)` commit. It did exactly that to `nf-solve.cjs` (and to this very file) **during this PR series** — I had to recover atomically twice.

### Fix
Drop `bin/` and `test/` from `PATHSPECS`. Generated content stays fully covered by `.planning/formal/`, so no real artifact is lost — the source pollution is stopped at the root.

Complements #287 (which excluded ephemeral `*_TTrace_*` traces). Together the autocommit now commits **only what the solve actually produced**.

### Evidence the solve writes nothing to bin/test
- Stub generator + implementer write to `.planning/formal/generated-stubs/` (incl. `*.stub.test.js`).
- Every `bin/`/`test/` file in recent `chore(solve)` history is recognizable hand-authored source.

### Test
`TC-COMMIT-17` — a modified `bin/` file and a new `test/` file are never staged, while a generated `.planning/formal/` artifact still is. Suite 16/16 (+1 heavy skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)