### PR TITLE
fix(solve): report-only never auto-commits (side-effect-free diagnostic)

### DIFF
--- a/bin/nf-solve.cjs
+++ b/bin/nf-solve.cjs
@@ -6877,7 +6877,12 @@ function main() {
   const exitCode = 0;
   const outputText = jsonMode ? (jsonText + '\n') : reportText;
 
-  if (!noAutoCommit) {
+  // `--report-only` is a no-mutation diagnostic sweep — it must never create a commit.
+  // Auto-committing here meant that simply RUNNING nf-solve to inspect residual (e.g.
+  // verifying a fix, or a benchmark measuring the gap) produced a `chore(solve)` commit
+  // that swept whatever was in the working tree onto the current branch. Only a real
+  // (non-report) solve, which is meant to make and record progress, auto-commits.
+  if (!noAutoCommit && !reportOnly) {
     try {
       const commitResult = spawnTool('bin/solve-commit-artifacts.cjs', ['--json']);
       if (commitResult.ok && commitResult.stdout) {

--- a/bin/nf-solve.test.cjs
+++ b/bin/nf-solve.test.cjs
@@ -1494,6 +1494,18 @@ test('TC-IDEMPOTENT-1: the solve-state.json write is guarded by !reportOnly', ()
     'the solve-state.json write must be guarded by `if (!reportOnly)` so a report-only sweep stays idempotent');
 });
 
+test('TC-IDEMPOTENT-2: the auto-commit is guarded so report-only never commits', () => {
+  const src = fs.readFileSync(path.join(__dirname, 'nf-solve.cjs'), 'utf8');
+  // A report-only sweep must be side-effect-free — it must NOT spawn the
+  // solve-commit-artifacts auto-commit (which would sweep the working tree onto the
+  // current branch just for inspecting residual). The guard must include !reportOnly.
+  const idx = src.indexOf("spawnTool('bin/solve-commit-artifacts.cjs'");
+  assert.ok(idx !== -1, 'expected the auto-commit invocation');
+  const preceding = src.slice(Math.max(0, idx - 300), idx);
+  assert.ok(/if\s*\([^)]*!reportOnly[^)]*\)/.test(preceding),
+    'the auto-commit must be guarded by !reportOnly so a report-only run never creates a commit');
+});
+
 // ── TC-MISSING: Missing-file residual tests (DIAG-02) ────────────────────────
 
 test('TC-MISSING-1: missing-file returns use residual -1 not 0 (source verification)', () => {


### PR DESCRIPTION
## The actual trigger behind the autocommit interference

`--report-only` is documented as a no-mutation diagnostic sweep, but `nf-solve.cjs` ran the `solve-commit-artifacts` auto-commit on **every** run that wasn't `--no-auto-commit` — including report-only. So merely *running* nf-solve to inspect residual (verifying a fix, or a benchmark measuring a gap) produced a `chore(solve)` commit that swept the working tree onto the current branch.

This is precisely what interfered **twice** in this PR series: a `nf-solve --report-only` verification run created a `chore(solve)` commit over my in-progress `bin/` edits.

### Fix
Guard the auto-commit with `!reportOnly` (alongside the existing `!noAutoCommit`). Only a real, non-report solve — which is meant to make and record progress — auto-commits.

This completes report-only's no-side-effect contract: it already skips the solve-state write (#288) and now also never commits. Combined with #287 (trace exclude) and #289 (bin/test pathspec narrowing), the autocommit can no longer touch your working tree during diagnostic runs.

### Test
`TC-IDEMPOTENT-2` — the auto-commit invocation is guarded by `!reportOnly`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented automatic post-run commits during report-only runs, so diagnostic executions no longer create unwanted commits.
  * Preserved the existing no-auto-commit behavior.

* **Tests**
  * Added a new test to verify that report-only runs do not trigger the auto-commit path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->