### PR TITLE
test(solve): nf-solve --project-root targets the external repo, never its own install

### DIFF
--- a/bin/nf-solve.test.cjs
+++ b/bin/nf-solve.test.cjs
@@ -754,6 +754,51 @@ test('TC-INT: --project-root overrides CWD for diagnostic sweep', () => {
   assert.equal(typeof parsed.residual_vector.total, 'number');
 });
 
+// nf-solve must operate on the TARGET repo (--project-root / cwd), never its own
+// install. This is the isolation guarantee behind the decoupled benchmark and the
+// reason the autocommit-pollution only ever hit nForma when run inside its own repo.
+// Heavy (spawns the full binary) — opt-in via RUN_HEAVY_SOLVE_TESTS like TC-COMMIT-10.
+test('TC-ISOLATION-1: --project-root targets the external repo + challenge, leaves the install untouched', {
+  skip: process.env.RUN_HEAVY_SOLVE_TESTS ? false : 'heavy nf-solve spawn; set RUN_HEAVY_SOLVE_TESTS=1 to run',
+}, () => {
+  const os = require('os');
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'nf-target-'));
+  try {
+    // Seed an EXTERNAL repo with a challenge: REQ-01 has no formal model → r_to_f gap.
+    fs.mkdirSync(path.join(tmp, '.planning', 'formal', 'tla'), { recursive: true });
+    fs.writeFileSync(path.join(tmp, '.planning', 'formal', 'requirements.json'),
+      JSON.stringify({ schema_version: '1', requirements: [{ id: 'REQ-01', text: 'rejects an expired token', status: 'Complete' }] }));
+    fs.writeFileSync(path.join(tmp, '.planning', 'formal', 'model-registry.json'),
+      JSON.stringify({ models: [], search_dirs: [] }));
+    fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({ name: 'external-target', version: '0.0.0' }));
+
+    // Snapshot the install's solve-state.json mtime (must be unchanged afterward).
+    const selfState = path.join(ROOT, '.planning', 'formal', 'solve-state.json');
+    const selfBefore = fs.existsSync(selfState) ? fs.statSync(selfState).mtimeMs : null;
+
+    // A real (non-report) solve targeting the external repo. cwd is /tmp to prove the
+    // target comes from --project-root, not the working directory.
+    const r = spawnSync(process.execPath, [
+      path.join(ROOT, 'bin', 'nf-solve.cjs'),
+      '--json', '--fast', '--no-timeout', '--skip-tests', '--skip-proximity', '--skip-heatmap',
+      '--no-coderlm', '--max-iterations=1', '--no-auto-commit', '--project-root=' + tmp,
+    ], { encoding: 'utf8', cwd: os.tmpdir(), timeout: 120000, maxBuffer: 50 * 1024 * 1024 });
+    assert.ok(r.status === 0 || r.status === 1, 'nf-solve should exit cleanly');
+
+    // (1) it OPERATED ON THE TARGET — the solve wrote state into the target repo.
+    assert.ok(fs.existsSync(path.join(tmp, '.planning', 'formal', 'solve-state.json')),
+      'the target repo must receive the solve-state (mutation lands on the target)');
+
+    // (2) the INSTALL is untouched — its solve-state.json mtime did not change.
+    if (selfBefore !== null) {
+      assert.equal(fs.statSync(selfState).mtimeMs, selfBefore,
+        'the nForma install must NOT be mutated when targeting an external repo');
+    }
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 // ── TC-COV: crossReferenceFormalCoverage Tests ────────────────────────────────
 
 test('TC-COV-1: crossReferenceFormalCoverage returns unavailable when null input', () => {


### PR DESCRIPTION
## Answers "why does it affect its own repo — it should affect the target"

It *does* affect the target. `nf-solve` resolves its project from `cwd` (or `--project-root=DIR`), not its own install dir. It only ever touched nForma's own repo because development runs it **inside** nForma (cwd = nForma) — dogfooding, not a targeting bug. This is the same mechanism that powers the decoupled nf-benchmark (nForma-as-SUT against external fixture repos).

This test locks the **isolation guarantee** in at the source:

`TC-ISOLATION-1` (heavy, opt-in via `RUN_HEAVY_SOLVE_TESTS`) —
1. seeds an **external** repo with a challenge (`REQ-01` with no formal model → `r_to_f` gap),
2. runs a real solve with `--project-root` pointing there (cwd = a throwaway tmpdir, proving the target comes from the flag),
3. asserts the solve-state lands in the **target** repo, and
4. asserts the install's `solve-state.json` mtime is **unchanged** — the install is never mutated.

Verified green locally (1.4s). Demonstrated live end-to-end before codifying: target `r_to_f` residual = 1 (`REQ-01`), install HEAD/state untouched, no `chore(solve)` in self.

🤖 Generated with [Claude Code](https://claude.com/claude-code)