### PR TITLE
feat(formal): semantic detection of dangling signature references (Option B)

### DIFF
--- a/bin/lint-formal-models.cjs
+++ b/bin/lint-formal-models.cjs
@@ -122,6 +122,68 @@ function parseFields(body) {
   return fields;
 }
 
+// Static semantic check: flag references to signatures that are not defined in
+// this model — a dangling signature reference (e.g. a predicate quantifying over
+// a nonexistent sig, or a field targeting an undefined type). This catches
+// semantic corruption that the structural counters (max-sigs/fields/scenarios)
+// miss, without invoking the real Alloy analyzer (stays --fast-native, no Java).
+//
+// Conservative to avoid false positives on valid models: only Capitalized
+// identifiers (Alloy sig naming convention) that appear in a TYPE position —
+// a field target type, an `extends` parent, or a quantifier binding `x: Type` —
+// and are neither a defined sig nor an Alloy built-in are flagged. nForma's
+// models use no `open` imports, so the in-file sig set is the complete universe.
+var ALLOY_BUILTINS = new Set(['Int', 'Bool', 'univ', 'none', 'iden', 'seq', 'String', 'Time', 'Ord']);
+
+function extractAlloyTypeRefs(typeExpr) {
+  // Candidate sig identifiers in a (possibly composite) type expression, e.g.
+  // "Account -> lone Balance", "set PoolState". Capitalized tokens only. Inline
+  // comments are stripped first — a multi-field sig body can leave a trailing
+  // `-- …Word` on an earlier field's type (parseFields only removes one to EOS),
+  // and prose Capitalized words must never be read as signatures.
+  var clean = String(typeExpr).replace(/--.*$/gm, '').replace(/\/\/.*$/gm, '');
+  return clean.match(/\b[A-Z]\w*/g) || [];
+}
+
+// Strip Alloy comments so prose (which is full of Capitalized words) is never
+// mistaken for code: line comments `--…` and `//…`, and block comments `/* … */`.
+function stripAlloyComments(content) {
+  return content
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/--[^\n]*/g, ' ')
+    .replace(/\/\/[^\n]*/g, ' ');
+}
+
+function checkAlloyDanglingRefs(content, sigs) {
+  var violations = [];
+  var known = new Set();
+  for (var s = 0; s < sigs.length; s++) known.add(sigs[s].name);
+  var seen = new Set();
+  function consider(name, where) {
+    if (!name || known.has(name) || ALLOY_BUILTINS.has(name)) return;
+    if (seen.has(name)) return;
+    seen.add(name);
+    violations.push({ rule: 'dangling-sig-ref', message: 'reference to undefined signature "' + name + '" (' + where + ')' });
+  }
+  // Field target types and `extends` parents come from the structural parse.
+  for (var i = 0; i < sigs.length; i++) {
+    if (sigs[i].parent) consider(sigs[i].parent, 'extends ' + sigs[i].name);
+    for (var j = 0; j < sigs[i].fields.length; j++) {
+      var refs = extractAlloyTypeRefs(sigs[i].fields[j].type);
+      for (var k = 0; k < refs.length; k++) consider(refs[k], 'field ' + sigs[i].name + '.' + sigs[i].fields[j].name);
+    }
+  }
+  // Quantifier bindings must be anchored to a real Alloy quantifier keyword —
+  // `all x: Type`, `some x: Type`, etc. — NOT any `word: Word` (which matches
+  // prose). Comments are stripped first. This is what catches a predicate that
+  // quantifies over a nonexistent signature.
+  var code = stripAlloyComments(content);
+  var bindingRe = /\b(?:all|some|no|one|lone|sum)\s+(?:disj\s+)?\w+(?:\s*,\s*\w+)*\s*:\s*(?:set\s+|one\s+|lone\s+|some\s+|seq\s+)?([A-Z]\w*)/g;
+  var m;
+  while ((m = bindingRe.exec(code)) !== null) consider(m[1], 'quantifier binding');
+  return violations;
+}
+
 function parseAlloyCommands(content) {
   var commands = [];
   var cmdRegex = /\b(run|check)\s+(?:(\w+)\s*)?(?:\{[^}]*\}\s*)?for\s+(.+)/g;
@@ -350,6 +412,11 @@ function lintAlloyModels(policy) {
       var violations = [];
       var suggestions = [];
 
+      // Semantic: dangling signature references (undefined sigs used in fields,
+      // extends, or quantifier bindings). Catches corruption the counters miss.
+      var danglingRefs = checkAlloyDanglingRefs(content, sigs);
+      for (var dr = 0; dr < danglingRefs.length; dr++) violations.push(danglingRefs[dr]);
+
       if (sigs.length > policy.max_sigs) {
         violations.push({ rule: 'max-sigs', message: sigs.length + ' sigs (max ' + policy.max_sigs + ')' });
       }
@@ -577,4 +644,9 @@ function main() {
 function good(f) { return f.filter(function(x) { return x.pass; }).length; }
 function bad(f) { return f.filter(function(x) { return !x.pass; }).length; }
 
-main();
+// Export semantic-check helpers for unit testing without running the CLI scan.
+module.exports = { checkAlloyDanglingRefs: checkAlloyDanglingRefs, extractAlloyTypeRefs: extractAlloyTypeRefs, stripAlloyComments: stripAlloyComments, parseAlloySigs: parseAlloySigs };
+
+if (require.main === module) {
+  main();
+}

--- a/bin/lint-formal-models.cjs
+++ b/bin/lint-formal-models.cjs
@@ -141,7 +141,10 @@ function extractAlloyTypeRefs(typeExpr) {
   // comments are stripped first — a multi-field sig body can leave a trailing
   // `-- …Word` on an earlier field's type (parseFields only removes one to EOS),
   // and prose Capitalized words must never be read as signatures.
-  var clean = String(typeExpr).replace(/--.*$/gm, '').replace(/\/\/.*$/gm, '');
+  // Strip ALL comment forms (line --/// AND block; per CodeRabbit review) — an
+  // inline block comment in a field type ("one /* Word */ Balance") would leak a
+  // prose Capitalized word as a false-positive dangling ref.
+  var clean = stripAlloyComments(String(typeExpr));
   return clean.match(/\b[A-Z]\w*/g) || [];
 }
 

--- a/bin/lint-formal-models.test.cjs
+++ b/bin/lint-formal-models.test.cjs
@@ -77,4 +77,12 @@ test('stripAlloyComments removes line and block comments', () => {
 test('extractAlloyTypeRefs pulls Capitalized tokens, ignoring inline comments', () => {
   assert.deepStrictEqual(extractAlloyTypeRefs('Account -> lone Balance'), ['Account', 'Balance']);
   assert.deepStrictEqual(extractAlloyTypeRefs('Bool  -- must be False per INTENT-03'), ['Bool']);
+  // Block comments must also be stripped (CodeRabbit review on #297).
+  assert.deepStrictEqual(extractAlloyTypeRefs('one /* Some Prose Word */ Balance'), ['Balance']);
+});
+
+test('no false positive from a Capitalized word inside a block comment in a field type', () => {
+  const model = 'sig Account {}\nsig Ledger { bal: one /* Legacy Balance Field */ Account }';
+  assert.deepStrictEqual(danglingRules(model), [],
+    'a block comment in a field type must not produce a dangling-sig-ref');
 });

--- a/bin/lint-formal-models.test.cjs
+++ b/bin/lint-formal-models.test.cjs
@@ -1,0 +1,80 @@
+'use strict';
+
+// Unit tests for the static formal-model semantic checks added to
+// lint-formal-models.cjs. These catch semantic corruption (a reference to a
+// signature that is not defined) that the structural counters miss — the gap
+// that made the benchmark's f_to_f detection challenges unwinnable — while
+// staying --fast-native (pure static analysis, no Alloy/TLC invocation).
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { checkAlloyDanglingRefs, extractAlloyTypeRefs, stripAlloyComments, parseAlloySigs } = require('./lint-formal-models.cjs');
+
+function danglingRules(content) {
+  return checkAlloyDanglingRefs(content, parseAlloySigs(content))
+    .filter(v => v.rule === 'dangling-sig-ref')
+    .map(v => v.message);
+}
+
+test('detects a predicate quantifying over a nonexistent signature', () => {
+  const model = [
+    'sig ValidSig { f: one ValidSig }',
+    'pred Corrupt {',
+    '  some x: NonexistentSignature | x.f = x',
+    '}',
+    'run Corrupt for 3',
+  ].join('\n');
+  const msgs = danglingRules(model);
+  assert.ok(msgs.some(m => m.includes('NonexistentSignature')),
+    'expected a dangling-sig-ref for NonexistentSignature, got: ' + JSON.stringify(msgs));
+});
+
+test('detects a field targeting an undefined signature', () => {
+  const model = 'sig A { link: one MissingSig }';
+  const msgs = danglingRules(model);
+  assert.ok(msgs.some(m => m.includes('MissingSig')), JSON.stringify(msgs));
+});
+
+test('detects an extends of an undefined parent signature', () => {
+  const model = 'sig Child extends GhostParent { }';
+  const msgs = danglingRules(model);
+  assert.ok(msgs.some(m => m.includes('GhostParent')), JSON.stringify(msgs));
+});
+
+test('clean model: quantifiers over defined sigs produce no dangling ref', () => {
+  const model = [
+    'sig Account { }',
+    'sig PoolState { active: lone Account }',
+    'pred Valid { all p: PoolState | some a: Account | p.active = a }',
+    'run Valid for 3',
+  ].join('\n');
+  assert.deepStrictEqual(danglingRules(model), [], 'valid model must be clean');
+});
+
+test('no false positive from Capitalized words in comments/prose', () => {
+  const model = [
+    'sig Node { }',
+    '-- Coverage: V8 Digest of URLs and Structural Disjointness per INTENT-03',
+    '// The Hypothesis references Every Trace and Phase; ID exists in Envelope',
+    'sig Line { at: one Node -- must always be False per INTENT-03',
+    '}',
+  ].join('\n');
+  assert.deepStrictEqual(danglingRules(model), [],
+    'Capitalized words in comments must not be read as signatures');
+});
+
+test('Bool/Int/univ/seq built-ins are not flagged as dangling', () => {
+  const model = 'sig S { flag: one Bool, n: one Int, u: set univ }';
+  assert.deepStrictEqual(danglingRules(model), []);
+});
+
+test('stripAlloyComments removes line and block comments', () => {
+  const stripped = stripAlloyComments('sig A {} -- c1\n/* block\nInside */ sig B {} // c2');
+  assert.ok(!/c1|block|Inside|c2/.test(stripped), stripped);
+  assert.ok(/sig A/.test(stripped) && /sig B/.test(stripped));
+});
+
+test('extractAlloyTypeRefs pulls Capitalized tokens, ignoring inline comments', () => {
+  assert.deepStrictEqual(extractAlloyTypeRefs('Account -> lone Balance'), ['Account', 'Balance']);
+  assert.deepStrictEqual(extractAlloyTypeRefs('Bool  -- must be False per INTENT-03'), ['Bool']);
+});

--- a/bin/nf-solve.cjs
+++ b/bin/nf-solve.cjs
@@ -3906,7 +3906,23 @@ function sweepFormalLint() {
     }
 
     const data = JSON.parse(result.stdout);
-    const violations = data.violations || [];
+    // lint-formal-models emits per-model results under `findings[]`, not a
+    // top-level `violations` array — so `data.violations` was always undefined
+    // and every per-model violation (semantic corruption included) was ignored.
+    // Count only CORRUPTION-class violation rules from findings: genuine defects
+    // that should raise the residual (a dangling signature reference, a parse
+    // error, an excess-complexity flag), NOT the structural budget rules
+    // (max-sigs/fields/scenarios) which are expected baseline noise across the
+    // real model corpus (~276 of those) and would swamp the signal.
+    const CORRUPTION_RULES = new Set(['dangling-sig-ref', 'parse-error', 'excess-variables', 'model_file_missing']);
+    const violations = (Array.isArray(data.violations) ? data.violations.slice() : []);
+    for (const finding of (data.findings || [])) {
+      for (const v of (finding.violations || [])) {
+        if (CORRUPTION_RULES.has(v.rule)) {
+          violations.push({ model: finding.model || finding.file, rule: v.rule, message: v.message });
+        }
+      }
+    }
 
     // Direct solve-state.json check — BENCH-225: wave_count=0 is a mutation indicator
     try {


### PR DESCRIPTION
## Summary

Quorum-ratified (3/3 APPROVE, 2 rounds — codex-1 conceded from a real-analyzer approach; debate `2026-07-03-nf-solve-formal-semantic-detection.md`) capability build: give nf-solve **real formal-model semantic detection** — catching corruption like a predicate quantifying over a **nonexistent signature** — that the previous purely-structural `formal_lint` missed. Stays `--fast`-native (static analysis, no Alloy/TLC/Java).

## Two parts (both verified)

1. **`bin/lint-formal-models.cjs`** — add a static `dangling-sig-ref` check: build the known-sig set from `parseAlloySigs` + an Alloy built-in allowlist; flag Capitalized identifiers in TYPE positions (field targets, `extends`, quantifier bindings `all/some/… x: Type`) that aren't a defined sig or built-in. Comments stripped; bindings anchored to real quantifier keywords. Helpers exported + `require.main` guard.

2. **`bin/nf-solve.cjs` (`sweepFormalLint`)** — empirical verification exposed that the lint's `--json` has **no top-level `violations`** (results live under `findings[]`), so `data.violations` was always `undefined` and **every per-model violation was ignored**. Now aggregate CORRUPTION-class rules from `findings[]` (`dangling-sig-ref`, `parse-error`, `excess-variables`, `model_file_missing`), deliberately excluding structural budget rules (baseline noise that would shift the residual by ~275).

## Safety (no regression)

- **0 false positives** across all **170** of nForma's real `.als` models
- Clean models → **0 corruption-class violations** → `formal_lint` baseline **unchanged**
- `bin/lint-formal-models.test.cjs` — 8 unit tests (3 detection, 5 no-false-positive incl. comment prose + built-ins)
- `lint:isolation` ✓

## End-to-end proof

Benchmark **BENCH-013** ("Alloy predicate with nonexistent signature") flips **FAIL → PASS**: *"Layer f_to_f residual increased 1→2 — mutation detected"*.

## Follow-ups (separate)

- **nf-benchmark**: 105 of 120 file-modify detection challenges have **no `append`/`content`** — they inject only a default comment, so they can't be detected regardless of capability. The single biggest benchmark-repair lever. (BENCH-013's mutation fixed separately to demonstrate this loop.)
- TLA `excess-variables` check (for BENCH-019) — CORRUPTION rule wired; the lint-side check is a next increment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a stricter Alloy model check to flag references to undefined signatures in fields, inheritance, and quantified bindings.
  * Improved command-line behavior so the linting script only runs when executed directly.

* **Bug Fixes**
  * Fixed aggregation of lint results so only relevant corruption issues are counted from model findings.

* **Tests**
  * Added unit coverage for dangling signature detection, comment handling, built-in exclusions, and type-reference parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->