### PR TITLE
feat(formal): source-level detection of trivially-true TLA+ invariants

### DIFF
--- a/bin/lint-formal-models.cjs
+++ b/bin/lint-formal-models.cjs
@@ -27,6 +27,7 @@ var ROOT      = process.cwd();
 var ALLOY_DIR = path.join(ROOT, '.planning', 'formal', 'alloy');
 var POLICY    = path.join(ROOT, '.planning', 'formal', 'policy.yaml');
 var TLA_REPORT = path.join(ROOT, '.planning', 'formal', 'state-space-report.json');
+var TLA_DIR   = path.join(ROOT, '.planning', 'formal', 'tla');
 var TAG       = '[lint-formal]';
 
 var cliArgs = process.argv.slice(2);
@@ -485,44 +486,143 @@ function lintAlloyModels(policy) {
   return findings;
 }
 
+// Strip TLA+ comments so their prose can't be mistaken for spec text:
+// block comments `(* … *)` and line comments `\* …`.
+function stripTLAComments(content) {
+  return String(content)
+    .replace(/\(\*[\s\S]*?\*\)/g, ' ')
+    .replace(/\\\*[^\n]*/g, ' ');
+}
+
+// A definition body is a trivial tautology when it is true by construction,
+// independent of any .cfg CONSTANTS — the source alone decides it. This is the
+// TLA+ analog of the Alloy dangling-ref check: purely syntactic, so it fires
+// during a benchmark solve where a precomputed TLC report can't (the report is
+// stale relative to the mutated source). Kept deliberately narrow — only forms
+// that NEVER appear in a genuine spec (verified: 0 across the 67 real models):
+//   x = x | x <= x | x >= x  (same identifier, unprimed) · 1 = 1
+// `x' = x` (UNCHANGED) is safe: the prime makes the two tokens differ. Bare
+// `TRUE` is deliberately NOT flagged — a real model (QGSDSetupWizard's
+// `WizardStartsCorrectly == TRUE \* Enforced by Init`) uses it as a documented
+// placeholder invariant, so it is not a reliable corruption signal.
+function isTrivialTautology(body) {
+  var b = String(body).replace(/\s+/g, ' ').trim();
+  var idm = b.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*(=|<=|>=)\s*([A-Za-z_][A-Za-z0-9_]*)$/);
+  if (idm && idm[1] === idm[3]) return true;
+  var numm = b.match(/^(\d+)\s*=\s*(\d+)$/);
+  if (numm && numm[1] === numm[2]) return true;
+  return false;
+}
+
+// Scan a TLA+ module's source for definitions whose body is a trivial
+// tautology (a "meaningful invariant replaced with x = x" — BENCH-023). Blocks
+// are delimited by the next top-level `Name ==` header, so multi-line bodies
+// are captured. Only the module body (before the `====` terminator) is scanned.
+function checkTLATrivialInvariant(content) {
+  var violations = [];
+  var clean = stripTLAComments(content);
+  var term = clean.search(/^====/m);
+  if (term !== -1) clean = clean.slice(0, term);
+  var lines = clean.split('\n');
+  var headRe = /^([A-Za-z_][A-Za-z0-9_]*)(\([^)]*\))?\s*==(.*)$/;
+  var i = 0;
+  while (i < lines.length) {
+    var h = lines[i].match(headRe);
+    if (!h) { i++; continue; }
+    var name = h[1];
+    var parts = [h[3]];
+    var j = i + 1;
+    for (; j < lines.length; j++) {
+      if (headRe.test(lines[j])) break;
+      parts.push(lines[j]);
+    }
+    var body = parts.join(' ').replace(/\s+/g, ' ').trim();
+    if (body && isTrivialTautology(body)) {
+      violations.push({ rule: 'trivial-invariant', message: name + ' has a trivially-true body: ' + body });
+    }
+    i = j;
+  }
+  return violations;
+}
+
+// Source-level TLA+ scan, independent of the precomputed state-space report
+// (which is stale relative to a freshly-mutated .tla and may be absent in a SUT
+// worktree). Returns a map of file basename → trivial-invariant violations.
+function scanTLASourceViolations() {
+  var byFile = {};
+  if (!fs.existsSync(TLA_DIR)) return byFile;
+  var files;
+  try { files = fs.readdirSync(TLA_DIR).filter(function(f) { return f.endsWith('.tla') && f.indexOf('_TTrace_') === -1; }); }
+  catch (_) { return byFile; }
+  for (var i = 0; i < files.length; i++) {
+    try {
+      var v = checkTLATrivialInvariant(fs.readFileSync(path.join(TLA_DIR, files[i]), 'utf8'));
+      if (v.length) byFile[files[i]] = v;
+    } catch (_) { /* unreadable model — skip, never crash the sweep */ }
+  }
+  return byFile;
+}
+
 function lintTLAModels(policy) {
   var findings = [];
-  if (!fs.existsSync(TLA_REPORT)) return findings;
 
-  var report;
-  try { report = JSON.parse(fs.readFileSync(TLA_REPORT, 'utf8')); } catch (_) { return findings; }
+  // Source-level violations (trivial-invariant) — computed independent of the
+  // report so they fire even when the report is stale or absent. Consumed by
+  // basename as report findings are built; leftovers become their own findings.
+  var srcViolations = scanTLASourceViolations();
 
-  var entries = Object.entries(report.models || {});
-  for (var i = 0; i < entries.length; i++) {
-    var modelPath = entries[i][0];
-    var data = entries[i][1];
-    var name = data.module_name || path.basename(modelPath, '.tla');
-    if (name.indexOf('_TTrace_') !== -1) continue;
+  if (fs.existsSync(TLA_REPORT)) {
+    var report;
+    try { report = JSON.parse(fs.readFileSync(TLA_REPORT, 'utf8')); } catch (_) { report = null; }
+    var entries = report ? Object.entries(report.models || {}) : [];
+    for (var i = 0; i < entries.length; i++) {
+      var modelPath = entries[i][0];
+      var data = entries[i][1];
+      var name = data.module_name || path.basename(modelPath, '.tla');
+      if (name.indexOf('_TTrace_') !== -1) continue;
 
-    var violations = [];
-    var suggestions = [];
-    var states = data.estimated_states;
+      var violations = [];
+      var suggestions = [];
+      var states = data.estimated_states;
 
-    if (policy.require_bounded_tla && data.has_unbounded) {
-      violations.push({ rule: 'unbounded-tla', message: 'Unbounded: ' + (data.unbounded_domains || []).join(', ') });
-      suggestions = suggestTLAFix(data);
+      if (policy.require_bounded_tla && data.has_unbounded) {
+        violations.push({ rule: 'unbounded-tla', message: 'Unbounded: ' + (data.unbounded_domains || []).join(', ') });
+        suggestions = suggestTLAFix(data);
+      }
+      if (states !== null && states > policy.max_scenarios) {
+        violations.push({ rule: 'max-scenarios', message: states + ' states (max ' + policy.max_scenarios + ')' });
+      }
+      if (!data.cfg_file && policy.require_bounded_tla) {
+        violations.push({ rule: 'missing-cfg', message: 'No .cfg file — cannot be checked by TLC' });
+        if (suggestions.length === 0) suggestions = suggestTLAFix(data);
+      }
+
+      var base = path.basename(modelPath);
+      if (srcViolations[base]) {
+        violations = violations.concat(srcViolations[base]);
+        delete srcViolations[base];
+      }
+
+      findings.push({
+        framework: 'TLA+', model: name, file: base,
+        scenarios: states !== null ? BigInt(states) : null,
+        scenariosStr: states !== null ? String(states) : (data.has_unbounded ? 'UNBOUNDED' : '?'),
+        sigCount: (data.variables || []).length, fieldCount: 0,
+        commandCount: (data.invariant_count || 0) + (data.property_count || 0),
+        violations: violations, suggestions: suggestions, heatMap: [],
+        pass: violations.length === 0,
+      });
     }
-    if (states !== null && states > policy.max_scenarios) {
-      violations.push({ rule: 'max-scenarios', message: states + ' states (max ' + policy.max_scenarios + ')' });
-    }
-    if (!data.cfg_file && policy.require_bounded_tla) {
-      violations.push({ rule: 'missing-cfg', message: 'No .cfg file — cannot be checked by TLC' });
-      if (suggestions.length === 0) suggestions = suggestTLAFix(data);
-    }
+  }
 
+  // Files with trivial-invariant violations not covered by the report (report
+  // absent, or model missing from it) still surface as findings.
+  var leftover = Object.keys(srcViolations);
+  for (var k = 0; k < leftover.length; k++) {
     findings.push({
-      framework: 'TLA+', model: name, file: path.basename(modelPath),
-      scenarios: states !== null ? BigInt(states) : null,
-      scenariosStr: states !== null ? String(states) : (data.has_unbounded ? 'UNBOUNDED' : '?'),
-      sigCount: (data.variables || []).length, fieldCount: 0,
-      commandCount: (data.invariant_count || 0) + (data.property_count || 0),
-      violations: violations, suggestions: suggestions, heatMap: [],
-      pass: violations.length === 0,
+      framework: 'TLA+', model: leftover[k].replace(/\.tla$/, ''), file: leftover[k],
+      scenarios: null, scenariosStr: '?', sigCount: 0, fieldCount: 0, commandCount: 0,
+      violations: srcViolations[leftover[k]], suggestions: [], heatMap: [], pass: false,
     });
   }
   return findings;
@@ -648,7 +748,7 @@ function good(f) { return f.filter(function(x) { return x.pass; }).length; }
 function bad(f) { return f.filter(function(x) { return !x.pass; }).length; }
 
 // Export semantic-check helpers for unit testing without running the CLI scan.
-module.exports = { checkAlloyDanglingRefs: checkAlloyDanglingRefs, extractAlloyTypeRefs: extractAlloyTypeRefs, stripAlloyComments: stripAlloyComments, parseAlloySigs: parseAlloySigs };
+module.exports = { checkAlloyDanglingRefs: checkAlloyDanglingRefs, extractAlloyTypeRefs: extractAlloyTypeRefs, stripAlloyComments: stripAlloyComments, parseAlloySigs: parseAlloySigs, checkTLATrivialInvariant: checkTLATrivialInvariant, isTrivialTautology: isTrivialTautology, stripTLAComments: stripTLAComments };
 
 if (require.main === module) {
   main();

--- a/bin/lint-formal-models.test.cjs
+++ b/bin/lint-formal-models.test.cjs
@@ -8,7 +8,11 @@
 
 const { test } = require('node:test');
 const assert = require('node:assert');
-const { checkAlloyDanglingRefs, extractAlloyTypeRefs, stripAlloyComments, parseAlloySigs } = require('./lint-formal-models.cjs');
+const { checkAlloyDanglingRefs, extractAlloyTypeRefs, stripAlloyComments, parseAlloySigs, checkTLATrivialInvariant, isTrivialTautology, stripTLAComments } = require('./lint-formal-models.cjs');
+
+function trivialRules(content) {
+  return checkTLATrivialInvariant(content).filter(v => v.rule === 'trivial-invariant').map(v => v.message);
+}
 
 function danglingRules(content) {
   return checkAlloyDanglingRefs(content, parseAlloySigs(content))
@@ -85,4 +89,71 @@ test('no false positive from a Capitalized word inside a block comment in a fiel
   const model = 'sig Account {}\nsig Ledger { bal: one /* Legacy Balance Field */ Account }';
   assert.deepStrictEqual(danglingRules(model), [],
     'a block comment in a field type must not produce a dangling-sig-ref');
+});
+
+// ── TLA+ trivial-invariant detection (BENCH-023) ────────────────────────────
+// A meaningful safety invariant replaced with a tautology (x = x) is corruption
+// the structural counters and the precomputed TLC report both miss. Detected
+// purely from source so it fires during a --fast benchmark solve.
+
+test('detects a multi-line invariant whose body was replaced with x = x', () => {
+  const model = [
+    '---- MODULE M ----',
+    'VARIABLES recovered, fileExists',
+    'RecoveryRequiresFile ==',
+    '    recovered = recovered',
+    '====',
+  ].join('\n');
+  assert.deepStrictEqual(trivialRules(model),
+    ['RecoveryRequiresFile has a trivially-true body: recovered = recovered']);
+});
+
+test('detects inline x = x, x <= x, and 1 = 1 tautologies', () => {
+  assert.ok(isTrivialTautology('x = x'));
+  assert.ok(isTrivialTautology('stepCount <= stepCount'));
+  assert.ok(isTrivialTautology('n >= n'));
+  assert.ok(isTrivialTautology('1 = 1'));
+});
+
+test('does NOT flag UNCHANGED (x\' = x) — the prime makes the tokens differ', () => {
+  assert.ok(!isTrivialTautology("recovered' = recovered"));
+  const model = '---- MODULE M ----\nKeep ==\n    x\' = x\n====';
+  assert.deepStrictEqual(trivialRules(model), []);
+});
+
+test('does NOT flag a meaningful implication invariant', () => {
+  const model = [
+    '---- MODULE M ----',
+    'ActivityValid ==',
+    '    fileExists = TRUE => activity \\in Activities',
+    '====',
+  ].join('\n');
+  assert.deepStrictEqual(trivialRules(model), []);
+});
+
+test('does NOT flag bare TRUE — a documented placeholder invariant is legitimate', () => {
+  const model = '---- MODULE M ----\nWizardStartsCorrectly ==\n    TRUE \\* Enforced by Init\n====';
+  assert.deepStrictEqual(trivialRules(model), []);
+});
+
+test('does NOT flag a different-identifier equality (x = y)', () => {
+  assert.ok(!isTrivialTautology('x = y'));
+  assert.ok(!isTrivialTautology('a = b'));
+});
+
+test('ignores content after the ==== module terminator', () => {
+  const model = '---- MODULE M ----\nReal ==\n    x => y\n====\ntrailing == z = z';
+  assert.deepStrictEqual(trivialRules(model), [],
+    'a tautology after the terminator is dead text, not a spec definition');
+});
+
+test('does NOT flag a tautology hidden inside a comment', () => {
+  const model = '---- MODULE M ----\nReal ==\n    x => y  \\* note: x = x would be trivial\n====';
+  assert.deepStrictEqual(trivialRules(model), []);
+});
+
+test('stripTLAComments removes line and block comments', () => {
+  const stripped = stripTLAComments('Foo == bar \\* trailing\n(* block\ncomment *)\nBaz == qux');
+  assert.ok(/Foo == bar/.test(stripped) && /Baz == qux/.test(stripped));
+  assert.ok(!/trailing/.test(stripped) && !/block/.test(stripped));
 });

--- a/bin/nf-solve.cjs
+++ b/bin/nf-solve.cjs
@@ -3914,7 +3914,7 @@ function sweepFormalLint() {
     // error, an excess-complexity flag), NOT the structural budget rules
     // (max-sigs/fields/scenarios) which are expected baseline noise across the
     // real model corpus (~276 of those) and would swamp the signal.
-    const CORRUPTION_RULES = new Set(['dangling-sig-ref', 'parse-error', 'excess-variables', 'model_file_missing']);
+    const CORRUPTION_RULES = new Set(['dangling-sig-ref', 'parse-error', 'excess-variables', 'model_file_missing', 'trivial-invariant']);
     const violations = (Array.isArray(data.violations) ? data.violations.slice() : []);
     for (const finding of (data.findings || [])) {
       for (const v of (finding.violations || [])) {


### PR DESCRIPTION
## What

Adds `checkTLATrivialInvariant` — a purely-syntactic source scan that flags a TLA+ definition whose body is a trivial tautology (`x = x`, `x <= x`, `1 = 1`). This is the "meaningful invariant replaced with a trivially-true one" defect (nf-benchmark **BENCH-023**), and the TLA+ analog of the Alloy dangling-ref check shipped in #297.

## Why

`nf-solve`'s TLA+ lint (`lintTLAModels`) reads **only** the precomputed `state-space-report.json`. During a `--fast` benchmark solve that report is stale relative to the mutated `.tla` (and may be absent entirely in a SUT worktree), so a corrupted invariant is invisible. The new check parses source directly, as an independent pass that runs even when the report is missing, and is registered in `nf-solve`'s `CORRUPTION_RULES` so it raises the `f_to_f` residual.

## False-positive discipline

Verified **0 violations across all 253 `.tla`** in the repo (67 handwritten models + TTrace traces + fixtures). Deliberately narrow — these are NOT flagged:

- `x' = x` (UNCHANGED) — the prime makes the two tokens differ.
- bare `TRUE` — `QGSDSetupWizard`'s `WizardStartsCorrectly == TRUE \* Enforced by Init` is a documented placeholder, not corruption.
- `\in Nat` on a declared variable (`NFStopHook`'s `liveVoterCount`) — boundedness is a `.cfg` property, not source-decidable, so unbounded-Nat (BENCH-015) is intentionally left to the TLC report rather than a source heuristic that would false-positive here.

## Tests

9 new unit tests (multi-line detection, inline forms, UNCHANGED-safe, implication-safe, TRUE-safe, comment-safe, post-`====`-safe, comment stripping). `bin/lint-formal-models.test.cjs` 18/18 green; `formal-scope-scan-semantic` 9/9 green; both edited files pass `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)