### PR TITLE
chore(formal): strip benchmark-append pollution from committed models

### DIFF
--- a/.planning/formal/alloy/account-pool-structure.als
+++ b/.planning/formal/alloy/account-pool-structure.als
@@ -123,17 +123,3 @@ check RemoveShrinksPool       for 5 Account, 5 PoolState
 
 -- Witness: confirm a valid state with 2 accounts exists
 run { some s: PoolState | ValidState[s] and #s.pool = 2 } for 3 Account, 1 PoolState
-
-// modified by benchmark
-// modified by benchmark
-// modified by benchmark
-// modified by benchmark
-// modified by benchmark
-// modified by benchmark
-// modified by benchmark
-// modified by benchmark
-// modified by benchmark
-// modified by benchmark
-// modified by benchmark
-// modified by benchmark
-// modified by benchmark

--- a/.planning/formal/tla/QGSDActivityTracking.tla
+++ b/.planning/formal/tla/QGSDActivityTracking.tla
@@ -140,25 +140,3 @@ Spec ==
     /\ [][Next]_vars
 
 ====
-
-// modified by benchmark
-// modified by benchmark
-// modified by benchmark
-// modified by benchmark
-// modified by benchmark
-// modified by benchmark
-// modified by benchmark
-// modified by benchmark
-// modified by benchmark
-// modified by benchmark
-// modified by benchmark
-// modified by benchmark
-// modified by benchmark
-// modified by benchmark
-// modified by benchmark
-// modified by benchmark
-// modified by benchmark
-// modified by benchmark
-// modified by benchmark
-// modified by benchmark
-// modified by benchmark


### PR DESCRIPTION
## What

Removes `// modified by benchmark` junk that old append-based nf-benchmark runs autocommitted onto two real formal models:
- `QGSDActivityTracking.tla` — 21 lines after the `====` module terminator
- `account-pool-structure.als` — 13 trailing `//` comment lines

## Why

The junk is inert to TLC/Alloy (it sits after the module terminator / in line comments), but it pollutes the baseline that every formal sweep reads, and it's a committed artifact of a measurement bug. Now that the benchmark uses `find`/`replace` (nf-benchmark#10) instead of blind append, this pollution class stops recurring.

Pure deletion — no spec content changed; the TLA module still ends at `====`. 36 deletions, 0 insertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)