### PR TITLE
feat(formal): source-level detection of invalid PRISM probability sums

### DIFF
--- a/bin/lint-formal-models.cjs
+++ b/bin/lint-formal-models.cjs
@@ -28,6 +28,7 @@ var ALLOY_DIR = path.join(ROOT, '.planning', 'formal', 'alloy');
 var POLICY    = path.join(ROOT, '.planning', 'formal', 'policy.yaml');
 var TLA_REPORT = path.join(ROOT, '.planning', 'formal', 'state-space-report.json');
 var TLA_DIR   = path.join(ROOT, '.planning', 'formal', 'tla');
+var PRISM_DIR = path.join(ROOT, '.planning', 'formal', 'prism');
 var TAG       = '[lint-formal]';
 
 var cliArgs = process.argv.slice(2);
@@ -628,6 +629,95 @@ function lintTLAModels(policy) {
   return findings;
 }
 
+// ── PRISM probabilistic-model checks ─────────────────────────────────────────
+
+// Strip PRISM comments (`// …` line, `/* … */` block) so commented-out example
+// commands can't be read as live transitions.
+function stripPrismComments(content) {
+  return String(content)
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/\/\/[^\n]*/g, ' ');
+}
+
+// Split on a separator char only at paren-depth 0 — so `+` between probability
+// branches splits, but `+`/`-` inside a branch expression like `(1 - p)` or an
+// update `(a + b)` does not.
+function splitTopLevel(str, sep) {
+  var out = [], depth = 0, cur = '';
+  for (var i = 0; i < str.length; i++) {
+    var ch = str[i];
+    if (ch === '(') depth++;
+    else if (ch === ')') depth--;
+    if (ch === sep && depth === 0) { out.push(cur); cur = ''; }
+    else cur += ch;
+  }
+  out.push(cur);
+  return out;
+}
+
+// Sum the probability coefficients of a command's update section that are PURE
+// numeric literals. Symbolic branches (`p`, `(1 - p)`) are un-evaluable from
+// source and are skipped — so a valid `p : … + (1-p) : …` contributes no
+// literal and is never flagged, while an injected `1.5 : …` (or `0.7 : … +
+// 0.5 : …`) makes the literal sum exceed 1.0. Returns null when the command has
+// no literal branch at all. The probability is the text before the FIRST
+// top-level `:` in each `+`-separated branch.
+function prismLiteralProbSum(updateSection) {
+  var branches = splitTopLevel(updateSection, '+');
+  var sum = 0, sawLiteral = false;
+  for (var i = 0; i < branches.length; i++) {
+    var parts = splitTopLevel(branches[i], ':');
+    if (parts.length < 2) continue;
+    var coeff = parts[0].trim();
+    if (/^\d+(\.\d+)?$/.test(coeff)) { sum += parseFloat(coeff); sawLiteral = true; }
+  }
+  return sawLiteral ? sum : null;
+}
+
+// Flag PRISM commands whose literal branch probabilities sum to > 1.0 — an
+// invalid probability distribution (BENCH-017). Purely source-decidable, so it
+// fires under --fast without invoking the PRISM binary. A command is the text
+// between `->` and its terminating `;`.
+function checkPRISMProbSum(content) {
+  var violations = [];
+  var clean = stripPrismComments(content);
+  var re = /->([\s\S]*?);/g;
+  var m;
+  while ((m = re.exec(clean)) !== null) {
+    var sum = prismLiteralProbSum(m[1]);
+    if (sum !== null && sum > 1.0 + 1e-9) {
+      violations.push({ rule: 'prob-sum-exceeds-one', message: 'transition probabilities sum to ' + sum + ' (> 1.0)' });
+    }
+  }
+  return violations;
+}
+
+function lintPRISMModels(policy) {
+  var findings = [];
+  if (!fs.existsSync(PRISM_DIR)) return findings;
+  var files;
+  try { files = fs.readdirSync(PRISM_DIR).filter(function(f) { return f.endsWith('.pm') || f.endsWith('.prism') || f.endsWith('.nm'); }).sort(); }
+  catch (_) { return findings; }
+  for (var i = 0; i < files.length; i++) {
+    var name = files[i].replace(/\.(pm|prism|nm)$/, '');
+    try {
+      var violations = checkPRISMProbSum(fs.readFileSync(path.join(PRISM_DIR, files[i]), 'utf8'));
+      findings.push({
+        framework: 'PRISM', model: name, file: files[i],
+        scenarios: null, scenariosStr: '?', sigCount: 0, fieldCount: 0, commandCount: 0,
+        violations: violations, suggestions: [], heatMap: [], pass: violations.length === 0,
+      });
+    } catch (err) {
+      findings.push({
+        framework: 'PRISM', model: name, file: files[i],
+        scenarios: null, scenariosStr: '?', sigCount: 0, fieldCount: 0, commandCount: 0,
+        violations: [{ rule: 'parse-error', message: err.message }], suggestions: [], heatMap: [], pass: false,
+      });
+    }
+  }
+  return findings;
+}
+
 // ── Output ──────────────────────────────────────────────────────────────────
 
 function formatBig(n) {
@@ -715,7 +805,7 @@ function printFindings(findings, policy) {
 
 function main() {
   var policy = loadPolicy();
-  var findings = lintAlloyModels(policy).concat(lintTLAModels(policy));
+  var findings = lintAlloyModels(policy).concat(lintTLAModels(policy)).concat(lintPRISMModels(policy));
 
   findings.sort(function(a, b) {
     if (a.pass !== b.pass) return a.pass ? 1 : -1;
@@ -748,7 +838,7 @@ function good(f) { return f.filter(function(x) { return x.pass; }).length; }
 function bad(f) { return f.filter(function(x) { return !x.pass; }).length; }
 
 // Export semantic-check helpers for unit testing without running the CLI scan.
-module.exports = { checkAlloyDanglingRefs: checkAlloyDanglingRefs, extractAlloyTypeRefs: extractAlloyTypeRefs, stripAlloyComments: stripAlloyComments, parseAlloySigs: parseAlloySigs, checkTLATrivialInvariant: checkTLATrivialInvariant, isTrivialTautology: isTrivialTautology, stripTLAComments: stripTLAComments };
+module.exports = { checkAlloyDanglingRefs: checkAlloyDanglingRefs, extractAlloyTypeRefs: extractAlloyTypeRefs, stripAlloyComments: stripAlloyComments, parseAlloySigs: parseAlloySigs, checkTLATrivialInvariant: checkTLATrivialInvariant, isTrivialTautology: isTrivialTautology, stripTLAComments: stripTLAComments, checkPRISMProbSum: checkPRISMProbSum, prismLiteralProbSum: prismLiteralProbSum, stripPrismComments: stripPrismComments };
 
 if (require.main === module) {
   main();

--- a/bin/lint-formal-models.test.cjs
+++ b/bin/lint-formal-models.test.cjs
@@ -157,3 +157,52 @@ test('stripTLAComments removes line and block comments', () => {
   assert.ok(/Foo == bar/.test(stripped) && /Baz == qux/.test(stripped));
   assert.ok(!/trailing/.test(stripped) && !/block/.test(stripped));
 });
+
+// ── PRISM transition-probability-sum detection (BENCH-017) ───────────────────
+// A command whose literal branch probabilities sum to > 1.0 is an invalid
+// distribution. Symbolic branches (p, 1-p) are un-evaluable from source and are
+// skipped, so the correct `p : … + (1-p) : …` idiom is never flagged.
+
+const { checkPRISMProbSum, prismLiteralProbSum, stripPrismComments } = require('./lint-formal-models.cjs');
+
+function probRules(content) {
+  return checkPRISMProbSum(content).filter(v => v.rule === 'prob-sum-exceeds-one').map(v => v.message);
+}
+
+test('flags a command whose literal probabilities sum to > 1.0', () => {
+  const model = 'module m\n  [] s=0 -> 0.7 : (s\'=1) + 0.5 : (s\'=2);\nendmodule';
+  assert.deepStrictEqual(probRules(model), ['transition probabilities sum to 1.2 (> 1.0)']);
+});
+
+test('flags a single out-of-range literal probability (1.5)', () => {
+  const model = "module m\n  [] s=0 -> openai_up : (s'=1) + 1.5 : (s'=0);\nendmodule";
+  assert.deepStrictEqual(probRules(model), ['transition probabilities sum to 1.5 (> 1.0)']);
+});
+
+test('does NOT flag the valid p / (1-p) idiom (symbolic, un-evaluable)', () => {
+  const model = "module m\n  [] s=0 -> openai_up : (s'=1) + (1 - openai_up) : (s'=0);\nendmodule";
+  assert.deepStrictEqual(probRules(model), []);
+});
+
+test('does NOT flag a lone 1.0 literal (sums to exactly 1.0)', () => {
+  assert.deepStrictEqual(probRules("module m\n  [] s=1 -> 1.0 : (s'=1);\nendmodule"), []);
+});
+
+test('does NOT flag literals summing to exactly 1.0', () => {
+  assert.deepStrictEqual(probRules("module m\n  [] s=0 -> 0.3 : (s'=1) + 0.7 : (s'=2);\nendmodule"), []);
+});
+
+test('does not split + inside a branch expression or update', () => {
+  // (a + b) update and (1 - p) coefficient must stay intact — no false split.
+  assert.strictEqual(prismLiteralProbSum("(1 - p) : (x'=a + b)"), null);
+});
+
+test('ignores probabilities inside comments', () => {
+  const model = "module m\n  // [] s=0 -> 0.9 : (s'=1) + 0.9 : (s'=2);\n  [] s=1 -> 1.0 : (s'=1);\nendmodule";
+  assert.deepStrictEqual(probRules(model), []);
+});
+
+test('stripPrismComments removes // and /* */ comments', () => {
+  const s = stripPrismComments('a // line\n/* block */ b');
+  assert.ok(/a/.test(s) && /b/.test(s) && !/line/.test(s) && !/block/.test(s));
+});

--- a/bin/nf-solve.cjs
+++ b/bin/nf-solve.cjs
@@ -3914,7 +3914,7 @@ function sweepFormalLint() {
     // error, an excess-complexity flag), NOT the structural budget rules
     // (max-sigs/fields/scenarios) which are expected baseline noise across the
     // real model corpus (~276 of those) and would swamp the signal.
-    const CORRUPTION_RULES = new Set(['dangling-sig-ref', 'parse-error', 'excess-variables', 'model_file_missing', 'trivial-invariant']);
+    const CORRUPTION_RULES = new Set(['dangling-sig-ref', 'parse-error', 'excess-variables', 'model_file_missing', 'trivial-invariant', 'prob-sum-exceeds-one']);
     const violations = (Array.isArray(data.violations) ? data.violations.slice() : []);
     for (const finding of (data.findings || [])) {
       for (const v of (finding.violations || [])) {


### PR DESCRIPTION
## What

Adds `checkPRISMProbSum` — a source-level PRISM check that flags a command whose literal branch probabilities sum to > 1.0 (an invalid distribution — nf-benchmark **BENCH-017**). This is the third `--fast`-native formal detector, after Alloy dangling-refs (#297) and TLA trivial-invariants (#298).

## Why

`nf-solve` had **no** source-level PRISM check at all — the existing PRISM tooling shells out to the real PRISM binary, which is skipped under `--fast`. So a corrupted probability distribution was invisible during a fast solve.

## How it stays false-positive-free

- Sums only branch coefficients that are **pure numeric literals**. Symbolic branches (`p`, `(1 - p)`) are un-evaluable from source and are skipped — so the correct PRISM `p : … + (1-p) : …` idiom (which every real model uses) is never flagged; an injected `1.5 : …` or `0.7 : … + 0.5 : …` is.
- Branch splitting is **paren-depth-aware**, so `+`/`-` inside `(1 - p)` or an `(a + b)` update never mis-splits.
- Verified **0 false positives across all real PRISM models** in the repo.

## Tests

New PRISM framework pass (`lintPRISMModels` over `.planning/formal/prism/*.pm|.prism|.nm`), wired into the findings pipeline and registered in `nf-solve` `CORRUPTION_RULES` as `prob-sum-exceeds-one`. 8 new unit tests; `bin/lint-formal-models.test.cjs` 26/26 green; both edited files pass `node --check`.

Pairs with an nf-benchmark PR retargeting BENCH-017 to a real model with a probability-breaking `find`/`replace`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)