### PR TITLE
feat(solve): require-graph code-consistency detection (dangling + circular)

### DIFF
--- a/bin/check-require-graph.cjs
+++ b/bin/check-require-graph.cjs
@@ -22,9 +22,14 @@ const path = require('path');
 const { spawnSync } = require('child_process');
 
 // Git-tracked first-party JS/CJS source (skip tests, vendored, and build output).
+// Surfaces git failures (spawn error, nonzero exit, maxBuffer overflow) rather
+// than returning [] — a silent failure would report 0 findings and masquerade as
+// a clean tree, defeating the "0 findings ⇒ clean" invariant this check relies on.
 function trackedCodeFiles(root) {
   const res = spawnSync('git', ['ls-files'], { cwd: root, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
-  if (res.status !== 0 || !res.stdout) return [];
+  if (res.error) throw new Error('check-require-graph: failed to spawn git: ' + res.error.message);
+  if (res.status !== 0) throw new Error('check-require-graph: `git ls-files` exited with status ' + res.status + (res.stderr ? ': ' + String(res.stderr).trim() : ''));
+  if (!res.stdout) return [];
   return res.stdout.split('\n').filter(Boolean).filter(function (f) {
     return /\.c?js$/.test(f) &&
       !/node_modules\//.test(f) &&
@@ -147,7 +152,15 @@ module.exports = { analyze: analyze, findings: findings, relRequires: relRequire
 if (require.main === module) {
   const root = process.cwd();
   const asJson = process.argv.includes('--json');
-  const fnd = findings(root);
+  let fnd;
+  try {
+    fnd = findings(root);
+  } catch (err) {
+    // Distinct exit 2 (not 0=clean, not 1=violations) with NO stdout, so nf-solve's
+    // sweep sees "no output" → residual -1 (skipped) rather than a false "0 = clean".
+    process.stderr.write(String((err && err.message) || err) + '\n');
+    process.exit(2);
+  }
   if (asJson) {
     process.stdout.write(JSON.stringify({ findings: fnd, count: fnd.length }, null, 2) + '\n');
   } else {

--- a/bin/check-require-graph.cjs
+++ b/bin/check-require-graph.cjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+'use strict';
+// bin/check-require-graph.cjs
+// Source-decidable code-consistency checks over the JS/CJS require graph:
+//   - dangling-require: a relative require('./x') that resolves to no file on disk
+//   - circular-require: a cycle in the module require graph (A → B → A)
+//
+// --fast-native: pure fs + `git ls-files`, no code execution, no external server
+// (deliberately NOT coderlm — a core detection residual must be deterministic and
+// cannot silently vanish when an optional, fail-open symbol server is down).
+//
+// Verified 0 findings on clean nForma + nf-benchmark trees, so any finding is a
+// genuine corruption signal (the baseline residual is 0).
+//
+// Usage:
+//   node bin/check-require-graph.cjs           # human-readable
+//   node bin/check-require-graph.cjs --json    # { findings: [...], count: N }
+// Exit: 0 = clean, 1 = violations found.
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+// Git-tracked first-party JS/CJS source (skip tests, vendored, and build output).
+function trackedCodeFiles(root) {
+  const res = spawnSync('git', ['ls-files'], { cwd: root, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+  if (res.status !== 0 || !res.stdout) return [];
+  return res.stdout.split('\n').filter(Boolean).filter(function (f) {
+    return /\.c?js$/.test(f) &&
+      !/node_modules\//.test(f) &&
+      !/\.(test|spec)\./.test(f) &&
+      !/(^|\/)dist\//.test(f);
+  });
+}
+
+// Strip comments so a require in a comment/JSDoc is never counted. Preserves the
+// char before `//` so a `://` inside a URL string isn't treated as a comment.
+function stripComments(s) {
+  return String(s)
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/(^|[^:])\/\/[^\n]*/g, '$1 ');
+}
+
+const REQ_RE = /\brequire\(\s*(['"])(\.\.?\/[^'"]+)\1\s*\)/g;
+
+// Relative require specifiers in a file. Placeholder/example specs (found in doc
+// strings and lint-rule messages, e.g. require('./bin/...')) are skipped — a real
+// module path never contains an ellipsis or template/glob metacharacters. This is
+// what keeps the check false-positive-free on prose-heavy source.
+function relRequires(content) {
+  const clean = stripComments(content);
+  const out = [];
+  let m;
+  while ((m = REQ_RE.exec(clean)) !== null) {
+    const spec = m[2];
+    if (/\.\.\.|[<>${}*`]/.test(spec)) continue;
+    out.push(spec);
+  }
+  return out;
+}
+
+// Resolve a relative require the way Node's CJS loader does: exact path, then
+// common extensions, then a directory index. Returns the resolved abs path or null.
+function resolveRel(root, fromFile, spec) {
+  const base = path.resolve(root, path.dirname(fromFile), spec);
+  const cands = [base, base + '.js', base + '.cjs', base + '.json', base + '.mjs', base + '.node',
+    path.join(base, 'index.js'), path.join(base, 'index.cjs'), path.join(base, 'index.json')];
+  for (let i = 0; i < cands.length; i++) {
+    try { if (fs.statSync(cands[i]).isFile()) return cands[i]; } catch (_) { /* not this candidate */ }
+  }
+  return null;
+}
+
+// DFS cycle detection over the first-party require graph. Only edges to files that
+// are themselves in the graph are followed (external/node_modules deps ignored).
+// Cycles are de-duplicated by their node set so a 2-node cycle isn't reported twice.
+function detectCycles(root, graph) {
+  const WHITE = 0, GRAY = 1, BLACK = 2;
+  const color = new Map();
+  const stack = [];
+  const cycles = [];
+  const seen = new Set();
+  function dfs(node) {
+    color.set(node, GRAY);
+    stack.push(node);
+    const deps = graph.get(node) || [];
+    for (let i = 0; i < deps.length; i++) {
+      const dep = deps[i];
+      if (!graph.has(dep)) continue;
+      const c = color.get(dep) || WHITE;
+      if (c === WHITE) {
+        dfs(dep);
+      } else if (c === GRAY) {
+        const idx = stack.indexOf(dep);
+        const cyc = stack.slice(idx).concat(dep).map(function (p) { return path.relative(root, p); });
+        const key = cyc.slice(0, cyc.length - 1).sort().join('|');
+        if (!seen.has(key)) { seen.add(key); cycles.push(cyc); }
+      }
+    }
+    stack.pop();
+    color.set(node, BLACK);
+  }
+  const nodes = Array.from(graph.keys());
+  for (let i = 0; i < nodes.length; i++) {
+    if ((color.get(nodes[i]) || WHITE) === WHITE) dfs(nodes[i]);
+  }
+  return cycles;
+}
+
+// Build the require graph and collect dangling requires + cycles.
+function analyze(root) {
+  const files = trackedCodeFiles(root);
+  const graph = new Map();
+  const dangling = [];
+  for (let i = 0; i < files.length; i++) {
+    const f = files[i];
+    const abs = path.resolve(root, f);
+    let content;
+    try { content = fs.readFileSync(abs, 'utf8'); } catch (_) { continue; }
+    const deps = [];
+    const specs = relRequires(content);
+    for (let j = 0; j < specs.length; j++) {
+      const resolved = resolveRel(root, f, specs[j]);
+      if (!resolved) dangling.push({ file: f, spec: specs[j] });
+      else deps.push(resolved);
+    }
+    graph.set(abs, deps);
+  }
+  return { dangling: dangling, cycles: detectCycles(root, graph), files_scanned: files.length };
+}
+
+// Flatten to a uniform findings list (the shape nf-solve's sweep aggregates).
+function findings(root) {
+  const a = analyze(root);
+  const out = [];
+  for (let i = 0; i < a.dangling.length; i++) {
+    out.push({ rule: 'dangling-require', file: a.dangling[i].file, message: 'require("' + a.dangling[i].spec + '") resolves to no file' });
+  }
+  for (let i = 0; i < a.cycles.length; i++) {
+    out.push({ rule: 'circular-require', file: a.cycles[i][0], message: 'circular require: ' + a.cycles[i].join(' -> ') });
+  }
+  return out;
+}
+
+module.exports = { analyze: analyze, findings: findings, relRequires: relRequires, resolveRel: resolveRel, detectCycles: detectCycles, stripComments: stripComments, trackedCodeFiles: trackedCodeFiles };
+
+if (require.main === module) {
+  const root = process.cwd();
+  const asJson = process.argv.includes('--json');
+  const fnd = findings(root);
+  if (asJson) {
+    process.stdout.write(JSON.stringify({ findings: fnd, count: fnd.length }, null, 2) + '\n');
+  } else {
+    for (let i = 0; i < fnd.length; i++) console.log('[' + fnd[i].rule + '] ' + fnd[i].file + ': ' + fnd[i].message);
+    console.log(fnd.length + ' code-graph violation(s)');
+  }
+  process.exit(fnd.length > 0 ? 1 : 0);
+}

--- a/bin/check-require-graph.test.cjs
+++ b/bin/check-require-graph.test.cjs
@@ -108,6 +108,15 @@ test('a 3-node cycle is detected', () => {
   } finally { fs.rmSync(root, { recursive: true, force: true }); }
 });
 
+test('a non-git directory THROWS rather than reporting a false-clean result', () => {
+  // A silent git failure returning [] would masquerade as a clean tree and
+  // defeat the "0 findings ⇒ clean" invariant (CodeRabbit #301). It must throw.
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rg-nogit-'));
+  try {
+    assert.throws(() => findings(root), /git ls-files.*exited with status|failed to spawn git/);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
 test('a DAG (diamond, no cycle) is NOT flagged', () => {
   const root = tmpRepo();
   try {

--- a/bin/check-require-graph.test.cjs
+++ b/bin/check-require-graph.test.cjs
@@ -1,0 +1,121 @@
+'use strict';
+
+// Unit tests for bin/check-require-graph.cjs — source-decidable code-consistency
+// (dangling relative requires + circular require cycles). These are the code-layer
+// analog of the formal dangling-ref / trivial-invariant checks: purely static,
+// --fast-native, and false-positive-free (baseline is 0 on a clean tree).
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const cp = require('child_process');
+
+const { findings, analyze, relRequires, resolveRel, detectCycles, stripComments } = require('./check-require-graph.cjs');
+
+function tmpRepo() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rg-test-'));
+  cp.execSync('git init -q', { cwd: root });
+  return root;
+}
+function write(root, rel, content) {
+  const abs = path.join(root, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content);
+}
+function commit(root) { cp.execSync('git add -A', { cwd: root }); }
+function rules(root, kind) { return findings(root).filter(f => f.rule === kind); }
+
+test('detects a dangling relative require', () => {
+  const root = tmpRepo();
+  try {
+    write(root, 'a.cjs', "const x = require('./missing-module.cjs');\nmodule.exports = {};");
+    commit(root);
+    const d = rules(root, 'dangling-require');
+    assert.strictEqual(d.length, 1);
+    assert.match(d[0].message, /missing-module\.cjs/);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('detects a circular require cycle', () => {
+  const root = tmpRepo();
+  try {
+    write(root, 'a.cjs', "require('./b.cjs'); module.exports = {};");
+    write(root, 'b.cjs', "require('./a.cjs'); module.exports = {};");
+    commit(root);
+    const c = rules(root, 'circular-require');
+    assert.strictEqual(c.length, 1, 'a 2-node cycle is reported exactly once');
+    assert.match(c[0].message, /a\.cjs.*b\.cjs.*a\.cjs/);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('a valid require to an existing file is NOT flagged', () => {
+  const root = tmpRepo();
+  try {
+    write(root, 'a.cjs', "const b = require('./b.cjs'); module.exports = {};");
+    write(root, 'b.cjs', "module.exports = { x: 1 };");
+    commit(root);
+    assert.deepStrictEqual(findings(root), []);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('resolves via extension and directory index like Node', () => {
+  const root = tmpRepo();
+  try {
+    write(root, 'a.cjs', "require('./b'); require('./dir');");
+    write(root, 'b.js', "module.exports = {};");
+    write(root, 'dir/index.cjs', "module.exports = {};");
+    commit(root);
+    assert.deepStrictEqual(rules(root, 'dangling-require'), []);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('does NOT flag a require inside a comment', () => {
+  const root = tmpRepo();
+  try {
+    write(root, 'a.cjs', "// require('./missing.cjs')\n/* require('./also-missing.cjs') */\nmodule.exports = {};");
+    commit(root);
+    assert.deepStrictEqual(rules(root, 'dangling-require'), []);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('does NOT flag placeholder/example specs (ellipsis, template)', () => {
+  // The recurring lint-rule-message false positive: require('./bin/...') as prose.
+  assert.deepStrictEqual(relRequires("const m = \"require('./bin/...')\";"), []);
+  assert.deepStrictEqual(relRequires("require(`./${name}.cjs`)"), []);
+  // A concrete spec IS extracted.
+  assert.deepStrictEqual(relRequires("require('./real-module.cjs')"), ['./real-module.cjs']);
+});
+
+test('ignores requires to node_modules / bare specifiers', () => {
+  const root = tmpRepo();
+  try {
+    write(root, 'a.cjs', "require('fs'); require('some-pkg'); module.exports = {};");
+    commit(root);
+    assert.deepStrictEqual(findings(root), [], 'only relative specifiers are graph edges');
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('a 3-node cycle is detected', () => {
+  const root = tmpRepo();
+  try {
+    write(root, 'a.cjs', "require('./b.cjs'); module.exports = {};");
+    write(root, 'b.cjs', "require('./c.cjs'); module.exports = {};");
+    write(root, 'c.cjs', "require('./a.cjs'); module.exports = {};");
+    commit(root);
+    assert.strictEqual(rules(root, 'circular-require').length, 1);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('a DAG (diamond, no cycle) is NOT flagged', () => {
+  const root = tmpRepo();
+  try {
+    write(root, 'a.cjs', "require('./b.cjs'); require('./c.cjs'); module.exports = {};");
+    write(root, 'b.cjs', "require('./d.cjs'); module.exports = {};");
+    write(root, 'c.cjs', "require('./d.cjs'); module.exports = {};");
+    write(root, 'd.cjs', "module.exports = {};");
+    commit(root);
+    assert.deepStrictEqual(rules(root, 'circular-require'), []);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});

--- a/bin/nf-solve.cjs
+++ b/bin/nf-solve.cjs
@@ -4260,6 +4260,34 @@ function sweepSecurity() {
   }
 }
 
+// ── Require-Graph sweep (diagnostic) ─────────────────────────────────────────
+// Source-decidable code-consistency: dangling relative requires + circular
+// require cycles. --fast-native (delegates to check-require-graph.cjs; pure fs +
+// git, no execution, no external server). Baseline is 0 on a clean tree, so any
+// finding is a genuine corruption — the residual IS the findings count.
+function sweepRequireGraph() {
+  try {
+    const scriptPath = path.join(ROOT, 'bin', 'check-require-graph.cjs');
+    if (!fs.existsSync(scriptPath)) {
+      return { residual: -1, detail: { skipped: true, reason: 'check-require-graph.cjs not found' } };
+    }
+    const result = spawnTool('bin/check-require-graph.cjs', ['--json']);
+    // Exit code 1 = violations found (still valid JSON on stdout); only a missing
+    // stdout / crash is a real failure.
+    if (!result.stdout) {
+      return { residual: -1, detail: { skipped: true, reason: 'check-require-graph.cjs produced no output', stderr: (result.stderr || '').slice(0, 500) } };
+    }
+    const data = JSON.parse(result.stdout);
+    const arr = Array.isArray(data.findings) ? data.findings : [];
+    return {
+      residual: arr.length,
+      detail: { findings_count: arr.length, findings: arr },
+    };
+  } catch (err) {
+    return { residual: -1, detail: { error: err.message } };
+  }
+}
+
 // ── Trace Health sweep (diagnostic) ──────────────────────────────────────────
 
 function sweepTraceHealth() {
@@ -4804,6 +4832,10 @@ function computeResidual() {
   const security = checkLayerSkip('security') || sweepSecurity();
   _timing.security = { duration_ms: Date.now() - _t_security, skipped: !!(security.detail && security.detail.skipped) };
 
+  const _t_require_graph = Date.now();
+  const require_graph = checkLayerSkip('require_graph') || sweepRequireGraph();
+  _timing.require_graph = { duration_ms: Date.now() - _t_require_graph, skipped: !!(require_graph.detail && require_graph.detail.skipped) };
+
   const _t_trace_health = Date.now();
   const trace_health = checkLayerSkip('trace_health') || sweepTraceHealth();
   _timing.trace_health = { duration_ms: Date.now() - _t_trace_health, skipped: !!(trace_health.detail && trace_health.detail.skipped) };
@@ -4857,6 +4889,7 @@ function computeResidual() {
     (p_to_f.residual >= 0 ? p_to_f.residual : 0) +
     (config_health.residual >= 0 ? config_health.residual : 0) +
     (security.residual >= 0 ? security.residual : 0) +
+    (require_graph.residual >= 0 ? require_graph.residual : 0) +
     (trace_health.residual >= 0 ? trace_health.residual : 0) +
     (asset_stale.residual >= 0 ? asset_stale.residual : 0) +
     (arch_constraints.residual >= 0 ? arch_constraints.residual : 0) +
@@ -4889,6 +4922,7 @@ function computeResidual() {
     req_quality,
     config_health,
     security,
+    require_graph,
     trace_health,
     asset_stale,
     arch_constraints,


### PR DESCRIPTION
## What

Adds a source-decidable, `--fast`-native **require-graph** analyzer (`bin/check-require-graph.cjs`) and wires it into nf-solve as a new `require_graph` residual layer. It detects:
- **dangling-require** — a relative `require('./x')` resolving to no file (BENCH-037)
- **circular-require** — a cycle in the first-party module require graph (BENCH-043)

This is the code-layer analog of the formal dangling-ref / trivial-invariant detectors — the "require-graph subsystem" direction chosen after the formal-models clean-win track was exhausted.

## Design

- **Self-contained** (pure `fs` + `git ls-files`), *not* delegating to the coderlm symbol server. A core detection residual must be **deterministic** and cannot silently vanish when an optional, fail-open external server is down. (coderlm's symbol resolution remains a candidate for the fuzzier export/import-mismatch check later.)
- Wired as an **informational** diagnostic layer (like `security`) — **not** added to the automatable total, so it cannot shift idempotency/convergence invariants. The residual is the findings count.

## False-positive discipline

Verified **0 findings on clean nForma + nf-benchmark trees**, so any finding is genuine corruption. Placeholder/example specs (`require('./bin/...')` in lint-rule messages, template literals) are skipped; comments stripped; only relative specifiers are graph edges; cycles de-duplicated by node set.

## Verification

- 9 unit tests (dangling, 2/3-node circular, DAG-safe, comment-safe, placeholder-safe, node_modules-ignored, Node-style resolution).
- End-to-end through nf-solve's real residual vector: baseline `require_graph.residual` = 0 → **0→1** on an injected dangling require (finding correctly identified).
- Pairs with nf-benchmark BENCH-037 (dangling) + BENCH-043 (circular), both proven 0→2 end-to-end.
- `lint:isolation` passes; both files pass `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new check for unresolved relative imports and circular dependencies in JavaScript/CommonJS files.
  * The diagnostics now include this require-graph sweep in overall health reporting.

* **Bug Fixes**
  * Requires inside comments are ignored, reducing false positives.
  * Existing path resolution now follows common Node.js-style file and index lookup behavior.

* **Tests**
  * Added coverage for missing files, cycle detection, valid imports, and ignored comment/template cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->