### PR TITLE
feat(solve): export/import-mismatch detection in the require-graph check

### DIFF
--- a/bin/check-require-graph.cjs
+++ b/bin/check-require-graph.cjs
@@ -113,6 +113,80 @@ function detectCycles(root, graph) {
 }
 
 // Build the require graph and collect dangling requires + cycles.
+// Static export key set of a CJS module, or null when the exports are opaque
+// (dynamic) and the key set can't be determined from source. Opaque cases:
+//   module.exports = <non-object-literal>   (a var, call, function, class)
+//   module.exports = { ...spread }          (spread pulls in unknown keys)
+// Object-literal keys and `exports.X = ` / `module.exports.X = ` are collected.
+// Returning null (not an empty set) means "don't judge this module" — the guard
+// that keeps export-mismatch false-positive-free on dynamic-export modules.
+function staticExports(content) {
+  const c = stripComments(content);
+  const keys = new Set();
+  let sawObjectLiteral = false;
+  const meIdx = c.search(/module\.exports\s*=/);
+  if (meIdx !== -1) {
+    const after = c.slice(c.indexOf('=', meIdx) + 1).trimStart();
+    if (after[0] === '{') {
+      sawObjectLiteral = true;
+      const start = c.indexOf('{', meIdx);
+      let depth = 0, end = -1;
+      for (let i = start; i < c.length; i++) { if (c[i] === '{') depth++; else if (c[i] === '}') { depth--; if (depth === 0) { end = i; break; } } }
+      const body = end > start ? c.slice(start + 1, end) : '';
+      if (/\.\.\./.test(body)) return null; // spread → unknown keys
+      const km = body.match(/(\w+)\s*(?::|,|$)/g) || [];
+      for (let i = 0; i < km.length; i++) { const m = km[i].match(/(\w+)/); if (m) keys.add(m[1]); }
+    } else {
+      return null; // module.exports = <expression> → opaque
+    }
+  }
+  const propRe = /(?:module\.)?exports\.(\w+)\s*=/g;
+  let m;
+  while ((m = propRe.exec(c)) !== null) keys.add(m[1]);
+  if (!sawObjectLiteral && keys.size === 0) return null; // no static exports found → opaque
+  return keys;
+}
+
+// `const { a, b } = require('./rel')` destructuring targets. The negative
+// lookahead `(?!\s*\.)` excludes `require('./rel').sub` (destructuring off a
+// sub-object, e.g. nForma's `._pure` internals) — those keys are not top-level
+// exports, so judging them would be a false positive.
+const DESTRUCTURE_RE = /(?:const|let|var)\s*\{([^}]+)\}\s*=\s*require\(\s*(['"])(\.\.?\/[^'"]+)\2\s*\)(?!\s*\.)/g;
+
+// export/import mismatch: a destructured key that the required first-party module
+// (with a determinable static export set) does not export — e.g. a typo'd export
+// key breaking a downstream consumer (BENCH-039). Modules with opaque/dynamic
+// exports are skipped. Verified 0 baseline false positives across the corpus.
+function checkExportImportMismatch(root, files) {
+  const exportsByAbs = new Map();
+  for (let i = 0; i < files.length; i++) {
+    const abs = path.resolve(root, files[i]);
+    try { exportsByAbs.set(abs, staticExports(fs.readFileSync(abs, 'utf8'))); } catch (_) { /* unreadable */ }
+  }
+  const mismatches = [];
+  for (let i = 0; i < files.length; i++) {
+    let content;
+    try { content = stripComments(fs.readFileSync(path.resolve(root, files[i]), 'utf8')); } catch (_) { continue; }
+    let m;
+    DESTRUCTURE_RE.lastIndex = 0;
+    while ((m = DESTRUCTURE_RE.exec(content)) !== null) {
+      const resolved = resolveRel(root, files[i], m[3]);
+      if (!resolved || resolved.endsWith('.json')) continue;
+      const exp = exportsByAbs.get(resolved);
+      if (!exp) continue; // opaque module — can't judge
+      const parts = m[1].split(',');
+      for (let p = 0; p < parts.length; p++) {
+        const key = parts[p].trim().split(':')[0].trim();
+        if (!/^\w+$/.test(key)) continue; // skip rest/spread/computed
+        if (!exp.has(key)) {
+          mismatches.push({ file: files[i], key: key, spec: m[3] });
+        }
+      }
+    }
+  }
+  return mismatches;
+}
+
 function analyze(root) {
   const files = trackedCodeFiles(root);
   const graph = new Map();
@@ -131,7 +205,7 @@ function analyze(root) {
     }
     graph.set(abs, deps);
   }
-  return { dangling: dangling, cycles: detectCycles(root, graph), files_scanned: files.length };
+  return { dangling: dangling, cycles: detectCycles(root, graph), mismatches: checkExportImportMismatch(root, files), files_scanned: files.length };
 }
 
 // Flatten to a uniform findings list (the shape nf-solve's sweep aggregates).
@@ -144,10 +218,14 @@ function findings(root) {
   for (let i = 0; i < a.cycles.length; i++) {
     out.push({ rule: 'circular-require', file: a.cycles[i][0], message: 'circular require: ' + a.cycles[i].join(' -> ') });
   }
+  for (let i = 0; i < (a.mismatches || []).length; i++) {
+    const mm = a.mismatches[i];
+    out.push({ rule: 'export-mismatch', file: mm.file, message: 'destructures { ' + mm.key + ' } from require("' + mm.spec + '") which does not export it' });
+  }
   return out;
 }
 
-module.exports = { analyze: analyze, findings: findings, relRequires: relRequires, resolveRel: resolveRel, detectCycles: detectCycles, stripComments: stripComments, trackedCodeFiles: trackedCodeFiles };
+module.exports = { analyze: analyze, findings: findings, relRequires: relRequires, resolveRel: resolveRel, detectCycles: detectCycles, stripComments: stripComments, trackedCodeFiles: trackedCodeFiles, staticExports: staticExports, checkExportImportMismatch: checkExportImportMismatch };
 
 if (require.main === module) {
   const root = process.cwd();

--- a/bin/check-require-graph.test.cjs
+++ b/bin/check-require-graph.test.cjs
@@ -128,3 +128,73 @@ test('a DAG (diamond, no cycle) is NOT flagged', () => {
     assert.deepStrictEqual(rules(root, 'circular-require'), []);
   } finally { fs.rmSync(root, { recursive: true, force: true }); }
 });
+
+// ── export/import mismatch (BENCH-039) ──────────────────────────────────────
+// A destructured key the required first-party module doesn't export (e.g. a
+// typo'd export key breaking a consumer). Opaque/dynamic-export modules and
+// `require(...).sub` destructuring are skipped to stay false-positive-free.
+
+const { staticExports, checkExportImportMismatch } = require('./check-require-graph.cjs');
+
+function mismatchRules(root) { return findings(root).filter(f => f.rule === 'export-mismatch').map(f => f.message); }
+
+test('flags a destructured key the required module does not export', () => {
+  const root = tmpRepo();
+  try {
+    write(root, 'mod.cjs', 'module.exports = { foo: 1, bar: 2 };');
+    write(root, 'consumer.cjs', "const { fooo } = require('./mod.cjs');");
+    commit(root);
+    const m = mismatchRules(root);
+    assert.strictEqual(m.length, 1);
+    assert.match(m[0], /fooo.*does not export/);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('does NOT flag a correctly destructured export', () => {
+  const root = tmpRepo();
+  try {
+    write(root, 'mod.cjs', 'module.exports = { foo: 1, bar: 2 };');
+    write(root, 'consumer.cjs', "const { foo, bar } = require('./mod.cjs');");
+    commit(root);
+    assert.deepStrictEqual(mismatchRules(root), []);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('does NOT judge a module with opaque/dynamic exports', () => {
+  const root = tmpRepo();
+  try {
+    write(root, 'dyn.cjs', 'module.exports = buildApi();');
+    write(root, 'spread.cjs', 'module.exports = { ...base, x: 1 };');
+    write(root, 'c1.cjs', "const { anything } = require('./dyn.cjs');");
+    write(root, 'c2.cjs', "const { whatever } = require('./spread.cjs');");
+    commit(root);
+    assert.deepStrictEqual(mismatchRules(root), [], 'opaque/spread exports must not be judged');
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('does NOT flag destructuring off a sub-object (require(...).sub)', () => {
+  const root = tmpRepo();
+  try {
+    write(root, 'mod.cjs', 'module.exports._pure = { helper: 1 };');
+    write(root, 'consumer.cjs', "const { helper } = require('./mod.cjs')._pure;");
+    commit(root);
+    assert.deepStrictEqual(mismatchRules(root), [], 'keys live in the sub-object, not top-level exports');
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('recognizes exports.X = and module.exports.X = keys', () => {
+  const root = tmpRepo();
+  try {
+    write(root, 'mod.cjs', 'exports.alpha = 1;\nmodule.exports.beta = 2;');
+    write(root, 'consumer.cjs', "const { alpha, beta } = require('./mod.cjs');");
+    commit(root);
+    assert.deepStrictEqual(mismatchRules(root), []);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('staticExports returns null for opaque, a key set for object literals', () => {
+  assert.strictEqual(staticExports('module.exports = something;'), null);
+  assert.strictEqual(staticExports('module.exports = { ...x };'), null);
+  const keys = staticExports('module.exports = { a: 1, b };');
+  assert.ok(keys.has('a') && keys.has('b'));
+});


### PR DESCRIPTION
## What

Adds a third code-consistency check to `check-require-graph.cjs` (after dangling + circular require): a destructured key `const { k } = require('./mod')` that the required first-party module **does not export** — e.g. a typo'd export key silently breaking a downstream consumer (nf-benchmark BENCH-039).

Emitted as an `export-mismatch` finding, so it flows into the existing `require_graph` residual (count-based — no `CORRUPTION_RULES` change).

## False-positive discipline (0 baseline, verified)

Measured **0 mismatches across nForma's 423 destructured keys + nf-benchmark** — any finding is a real inconsistency. Guards:
- **Opaque/dynamic exports are skipped** — `module.exports = <expr>` and `{ ...spread }` return `null` ("don't judge"); only object-literal keys and `exports.X =` / `module.exports.X =` are collected.
- **`require('./mod').sub` destructuring is excluded** (negative lookahead) — those keys live in a sub-object (nForma's `._pure` internals convention), not top-level exports. (This was the single probe false positive; excluding it → 0.)
- Rest/spread/computed destructure targets skipped.

## Verification

6 new unit tests (typo flagged, correct import clean, opaque/spread skipped, sub-object skipped, `exports.X` recognized, `staticExports` null-vs-set); 16/16 `check-require-graph` tests green; `lint:isolation` clean; baseline `check-require-graph` on main = 0. End-to-end vs BENCH-039 (typo `validateIR`→`validateIRR` in `bin/adapters/ir.cjs`): **0→29** export-mismatch findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new check that flags mismatched `require()` destructuring when a file asks for named exports that aren’t actually available.
  * Expanded export detection to recognize common export styles and ignore dynamic or opaque cases safely.

* **Bug Fixes**
  * Improved accuracy for module import validation, including support for valid nested and direct export patterns.
  * Avoids false warnings when exports can’t be determined statically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->