### PR TITLE
fix(install): copy bundled sast-rules.yaml into nf-bin/

### DIFF
--- a/bin/install-helpers.cjs
+++ b/bin/install-helpers.cjs
@@ -17,6 +17,11 @@ const path = require('path');
 // filter is the generic `*.cjs` match; these are the non-.cjs runtime files).
 const NF_BIN_RUNTIME_MJS = new Set(['unified-mcp-server.mjs']);
 
+// Bundled non-code DATA files a runtime script loads by path relative to itself
+// (e.g. sast-sweep.cjs resolves sast-rules.yaml via __dirname). Without this they
+// never land in nf-bin/ and the installed sweep silently fails to find its ruleset.
+const NF_BIN_RUNTIME_DATA = new Set(['sast-rules.yaml']);
+
 // True for a plain object (excludes null, arrays, and primitives). Shared guard so the
 // "deref a non-object" crash class (providers entries, preset entries, preset.env) is
 // closed in ONE place rather than pasted per call-site.
@@ -31,6 +36,7 @@ function shouldCopyToNfBin(entry) {
   if (entry === 'providers.json') return false;
   if (entry.endsWith('.cjs')) return true;
   if (NF_BIN_RUNTIME_MJS.has(entry)) return true;
+  if (NF_BIN_RUNTIME_DATA.has(entry)) return true;
   return false;
 }
 

--- a/bin/install-helpers.test.cjs
+++ b/bin/install-helpers.test.cjs
@@ -780,6 +780,16 @@ test('GUARD-01: shouldCopyToNfBin should return false (not throw) for non-string
   }
 });
 
+// The SAST sweep loads its bundled ruleset (sast-rules.yaml) via __dirname, so the
+// nf-bin copy loop MUST install it alongside sast-sweep.cjs — otherwise the installed
+// sweep fails-open to "no ruleset" and never detects. Other .yaml are NOT copied.
+test('shouldCopyToNfBin copies sast-rules.yaml (bundled runtime data), not arbitrary .yaml', () => {
+  assert.equal(shouldCopyToNfBin('sast-rules.yaml'), true);
+  assert.equal(shouldCopyToNfBin('sast-sweep.cjs'), true);
+  assert.equal(shouldCopyToNfBin('policy.yaml'), false);
+  assert.equal(shouldCopyToNfBin('providers.json'), false);
+});
+
 // GUARD-03: mcpArgsNeedMigration — a bare relative filename resolves under CWD, not
 // nf-bin, so it MUST be flagged for migration. Also: a path that merely CONTAINS the
 // filename as a substring but does not END with it (e.g. a .bak sibling) must NOT be


### PR DESCRIPTION
## What

`shouldCopyToNfBin()` matched only `*.cjs` (plus the `unified-mcp-server.mjs` allowlist), so the SAST sweep's **bundled ruleset** (`bin/sast-rules.yaml`, which `sast-sweep.cjs` loads via `__dirname`) was never installed into `~/.claude/nf-bin/`. The installed sweep then fails-open to "no ruleset" and never detects.

## Fix

Add a `NF_BIN_RUNTIME_DATA` allowlist (`sast-rules.yaml`) — the same pattern used for the runtime `.mjs`. Arbitrary `.yaml` (e.g. `policy.yaml`) is still not copied.

Verified: after `install.js`, `~/.claude/nf-bin/sast-rules.yaml` is present and the installed sweep resolves it. +1 unit test; 41/41 install-helpers tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)