### PR TITLE
feat(solve): model_check layer — TLC-detected reachable invariant violations

### DIFF
--- a/bin/check-model-invariants.cjs
+++ b/bin/check-model-invariants.cjs
@@ -29,15 +29,24 @@ const { spawnSync } = require('child_process');
 const ROOT = process.cwd();
 const TLA_DIR = path.join(ROOT, '.planning', 'formal', 'tla');
 
-function resolveJar() {
+function resolveJar(root) {
   try {
     const { resolveTlaJar } = require('./resolve-formal-tools.cjs');
-    return resolveTlaJar(ROOT);
+    return resolveTlaJar(root);
   } catch (_) {
     const home = path.join(process.env.HOME || '', '.local', 'share', 'nf-formal', 'tla', 'tla2tools.jar');
     return fs.existsSync(home) ? home : null;
   }
 }
+
+// Per-model TLC cap: a reachable-state safety violation on a concrete model is found
+// in well under a second; 15s is ample headroom while bounding a pathological
+// non-terminating model. TOTAL_BUDGET_MS caps cumulative wall time so a handful of
+// state-exploding models can't blow up latency — remaining models are skipped
+// (informational sweep, fail-open). Measured ~7s across nForma's 197 .tla files, so
+// the budget is never hit in practice; it's a defensive ceiling.
+const PER_MODEL_TIMEOUT_MS = 15000;
+const TOTAL_BUDGET_MS = 60000;
 
 function stripComments(c) {
   return String(c).replace(/\(\*[\s\S]*?\*\)/g, ' ').replace(/\\\*[^\n]*/g, ' ');
@@ -82,7 +91,7 @@ function analyzeModel(content) {
 }
 
 function checkModelInvariants(root) {
-  const jar = resolveJar();
+  const jar = resolveJar(root);
   if (!jar || !fs.existsSync(jar)) return { skipped: true, reason: 'tla2tools.jar not found', findings: [], count: 0 };
   const dir = path.join(root, '.planning', 'formal', 'tla');
   if (!fs.existsSync(dir)) return { skipped: false, findings: [], count: 0 };
@@ -91,25 +100,28 @@ function checkModelInvariants(root) {
   catch (_) { return { skipped: false, findings: [], count: 0 }; }
 
   const findings = [];
+  const startedAt = Date.now();
   for (const f of files) {
+    if (Date.now() - startedAt > TOTAL_BUDGET_MS) break; // defensive wall-clock ceiling
     let content;
     try { content = fs.readFileSync(path.join(dir, f), 'utf8'); } catch (_) { continue; }
     if (/\bCONSTANTS?\b/.test(stripComments(content))) continue; // parameterized — needs a hand cfg
     const { spec, invs } = analyzeModel(content);
     if (!spec || invs.length === 0) continue;
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'nf-mc-'));
+    let tmp;
     try {
+      tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'nf-mc-')); // inside try: a mkdtemp failure skips THIS model, not the loop
       const base = f.replace(/\.tla$/, '');
       fs.writeFileSync(path.join(tmp, f), content);
       fs.writeFileSync(path.join(tmp, base + '.cfg'), 'SPECIFICATION ' + spec + '\n' + invs.map(x => 'INVARIANT ' + x).join('\n') + '\n');
-      const r = spawnSync('java', ['-cp', jar, 'tlc2.TLC', '-config', base + '.cfg', f], { cwd: tmp, encoding: 'utf8', timeout: 30000, maxBuffer: 16 * 1024 * 1024 });
+      const r = spawnSync('java', ['-cp', jar, 'tlc2.TLC', '-config', base + '.cfg', f], { cwd: tmp, encoding: 'utf8', timeout: PER_MODEL_TIMEOUT_MS, maxBuffer: 16 * 1024 * 1024 });
       const out = (r.stdout || '') + (r.stderr || '');
       const m = out.match(/Invariant (\w+) is violated/);
       if (m) {
         findings.push({ rule: 'invariant-violation', model: base, invariant: m[1], message: 'TLC found a reachable state violating invariant ' + m[1] + ' in ' + f });
       }
     } catch (_) { /* per-model failure — skip, never crash the sweep */ }
-    finally { try { fs.rmSync(tmp, { recursive: true, force: true }); } catch (_) {} }
+    finally { if (tmp) { try { fs.rmSync(tmp, { recursive: true, force: true }); } catch (_) {} } }
   }
   return { skipped: false, findings: findings, count: findings.length };
 }

--- a/bin/check-model-invariants.cjs
+++ b/bin/check-model-invariants.cjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+'use strict';
+// bin/check-model-invariants.cjs
+// Model-checking sweep for BEHAVIORAL formal defects (deadlock potential, safety
+// invariant violations) that static lints cannot see — by actually running TLC.
+// This wires up nForma's existing TLC integration (resolve-formal-tools + tla2tools);
+// it is NOT a new model checker.
+//
+// Scope (keeps it fast + false-positive-free):
+//   - Only CONCRETE models (no CONSTANTS) — they need no bounding cfg, so a cfg can
+//     be auto-generated. Constant-parameterized models need hand cfgs (that's why the
+//     full TLC pass is --fast-skipped) and are left alone.
+//   - Flags ONLY genuine `Invariant X is violated` — NOT TLC's default deadlock check
+//     (which fires on models that legitimately terminate) and NOT cfg/parse errors.
+//   Verified 0 findings across nForma's real concrete models, so any finding is a
+//   real reachable safety violation.
+//
+// Fail-open: if tla2tools.jar / Java is unavailable, returns skipped (residual -1,
+// never a false 0).
+//
+// Usage:  node bin/check-model-invariants.cjs --json   → { findings, count, skipped? }
+// Exit:   0 = clean/skipped, 1 = violations.
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { spawnSync } = require('child_process');
+
+const ROOT = process.cwd();
+const TLA_DIR = path.join(ROOT, '.planning', 'formal', 'tla');
+
+function resolveJar() {
+  try {
+    const { resolveTlaJar } = require('./resolve-formal-tools.cjs');
+    return resolveTlaJar(ROOT);
+  } catch (_) {
+    const home = path.join(process.env.HOME || '', '.local', 'share', 'nf-formal', 'tla', 'tla2tools.jar');
+    return fs.existsSync(home) ? home : null;
+  }
+}
+
+function stripComments(c) {
+  return String(c).replace(/\(\*[\s\S]*?\*\)/g, ' ').replace(/\\\*[^\n]*/g, ' ');
+}
+
+// Parse the temporal SPECIFICATION def name and the safety-invariant candidate defs.
+// Spec: a def whose OWN body (not spanning other defs) contains a `[][Next]` formula;
+// prefer one literally named Spec. Invariants: nullary boolean state predicates with
+// no primes and no temporal/action operators.
+function analyzeModel(content) {
+  const c = stripComments(content);
+  const lines = c.split('\n');
+  const headRe = /^([A-Za-z_]\w*)\s*==(.*)$/;
+  let spec = null;
+  const invs = [];
+  let i = 0;
+  while (i < lines.length) {
+    const h = lines[i].match(headRe);
+    if (!h) { i++; continue; }
+    const name = h[1];
+    const parenParams = /^[A-Za-z_]\w*\s*\([^)]*\)\s*==/.test(lines[i]);
+    const bodyLines = [h[2]];
+    let j = i + 1;
+    for (; j < lines.length; j++) { if (headRe.test(lines[j]) || /^====/.test(lines[j])) break; bodyLines.push(lines[j]); }
+    const body = bodyLines.join(' ');
+    if (/\[\]\s*\[/.test(body)) {
+      if (name === 'Spec') spec = 'Spec';
+      else if (!spec) spec = name;
+    } else if (
+      !parenParams &&
+      !['Init', 'Next', 'vars', 'Spec'].includes(name) &&
+      !/'/.test(body) &&
+      !/\[\]|<>|WF_|SF_|ENABLED|UNCHANGED/.test(body) &&
+      !/CHOOSE|LET/.test(body) &&
+      /=|#|\\in|~|=>|\\A|\\E|\\subseteq/.test(body)
+    ) {
+      invs.push(name);
+    }
+    i = j;
+  }
+  return { spec, invs };
+}
+
+function checkModelInvariants(root) {
+  const jar = resolveJar();
+  if (!jar || !fs.existsSync(jar)) return { skipped: true, reason: 'tla2tools.jar not found', findings: [], count: 0 };
+  const dir = path.join(root, '.planning', 'formal', 'tla');
+  if (!fs.existsSync(dir)) return { skipped: false, findings: [], count: 0 };
+  let files;
+  try { files = fs.readdirSync(dir).filter(f => f.endsWith('.tla') && f.indexOf('_TTrace_') === -1); }
+  catch (_) { return { skipped: false, findings: [], count: 0 }; }
+
+  const findings = [];
+  for (const f of files) {
+    let content;
+    try { content = fs.readFileSync(path.join(dir, f), 'utf8'); } catch (_) { continue; }
+    if (/\bCONSTANTS?\b/.test(stripComments(content))) continue; // parameterized — needs a hand cfg
+    const { spec, invs } = analyzeModel(content);
+    if (!spec || invs.length === 0) continue;
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'nf-mc-'));
+    try {
+      const base = f.replace(/\.tla$/, '');
+      fs.writeFileSync(path.join(tmp, f), content);
+      fs.writeFileSync(path.join(tmp, base + '.cfg'), 'SPECIFICATION ' + spec + '\n' + invs.map(x => 'INVARIANT ' + x).join('\n') + '\n');
+      const r = spawnSync('java', ['-cp', jar, 'tlc2.TLC', '-config', base + '.cfg', f], { cwd: tmp, encoding: 'utf8', timeout: 30000, maxBuffer: 16 * 1024 * 1024 });
+      const out = (r.stdout || '') + (r.stderr || '');
+      const m = out.match(/Invariant (\w+) is violated/);
+      if (m) {
+        findings.push({ rule: 'invariant-violation', model: base, invariant: m[1], message: 'TLC found a reachable state violating invariant ' + m[1] + ' in ' + f });
+      }
+    } catch (_) { /* per-model failure — skip, never crash the sweep */ }
+    finally { try { fs.rmSync(tmp, { recursive: true, force: true }); } catch (_) {} }
+  }
+  return { skipped: false, findings: findings, count: findings.length };
+}
+
+module.exports = { checkModelInvariants: checkModelInvariants, analyzeModel: analyzeModel };
+
+if (require.main === module) {
+  const asJson = process.argv.includes('--json');
+  const r = checkModelInvariants(ROOT);
+  if (asJson) {
+    process.stdout.write(JSON.stringify(r, null, 2) + '\n');
+  } else if (r.skipped) {
+    console.log('[model-check] skipped: ' + r.reason);
+  } else {
+    for (const f of r.findings) console.log('[' + f.rule + '] ' + f.model + ': ' + f.message);
+    console.log(r.count + ' model-check violation(s)');
+  }
+  process.exit(!r.skipped && r.count > 0 ? 1 : 0);
+}

--- a/bin/check-model-invariants.test.cjs
+++ b/bin/check-model-invariants.test.cjs
@@ -1,0 +1,171 @@
+'use strict';
+
+// Unit tests for bin/check-model-invariants.cjs — the TLC-backed model-check sweep.
+// These are SKIP-AWARE: when tla2tools.jar / Java isn't available the sweep returns
+// { skipped: true } and the detection assertions are skipped rather than failing.
+// Where TLC IS present, they assert a clean baseline (a safe concrete model produces
+// 0 findings) and real detection of a reachable safety-invariant violation.
+//
+// analyzeModel() (pure cfg-generation logic) is tested unconditionally — it needs no
+// jar and is where the false-positive-avoidance rules live (spec/invariant selection).
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { checkModelInvariants, analyzeModel } = require('./check-model-invariants.cjs');
+
+function resolveJar() {
+  try {
+    const { resolveTlaJar } = require('./resolve-formal-tools.cjs');
+    return resolveTlaJar(process.cwd());
+  } catch (_) {
+    const home = path.join(process.env.HOME || '', '.local', 'share', 'nf-formal', 'tla', 'tla2tools.jar');
+    return fs.existsSync(home) ? home : null;
+  }
+}
+const JAR = resolveJar();
+const HAVE_TLC = !!(JAR && fs.existsSync(JAR));
+
+function tmpRoot() { return fs.mkdtempSync(path.join(os.tmpdir(), 'nf-mc-t-')); }
+function writeModel(root, name, content) {
+  const dir = path.join(root, '.planning', 'formal', 'tla');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, name), content);
+}
+
+const SAFE = [
+  '---- MODULE Safe ----',
+  'EXTENDS Naturals',
+  'VARIABLES x',
+  'Init == x = 0',
+  'Bump == x < 3 /\\ x\' = x + 1',
+  'Next == Bump',
+  'Bounded == x <= 3',
+  'vars == <<x>>',
+  'Spec == Init /\\ [][Next]_vars',
+  '====',
+].join('\n');
+
+const VIOLATING = [
+  '---- MODULE Bad ----',
+  'EXTENDS Naturals',
+  'VARIABLES lockA, lockB',
+  'Init == lockA = 0 /\\ lockB = 0',
+  'AcquireA == lockA = 0 /\\ lockA\' = 1 /\\ lockB\' = lockB',
+  'AcquireB == lockB = 0 /\\ lockB\' = 1 /\\ lockA\' = lockA',
+  'Next == AcquireA \\/ AcquireB',
+  'NoDeadlock == ~(lockA = 1 /\\ lockB = 1)',
+  'vars == <<lockA, lockB>>',
+  'Spec == Init /\\ [][Next]_vars',
+  '====',
+].join('\n');
+
+// ── analyzeModel: pure cfg-generation logic (no jar needed) ──────────────────
+
+test('analyzeModel picks the temporal Spec and only nullary safety invariants', () => {
+  const { spec, invs } = analyzeModel(SAFE);
+  assert.strictEqual(spec, 'Spec', 'the [][Next]_vars def is the SPECIFICATION');
+  assert.ok(invs.includes('Bounded'), 'a nullary boolean state predicate is an invariant candidate');
+  // Init/Next/vars and the action defs (primed) must NOT be treated as invariants.
+  assert.ok(!invs.includes('Init'));
+  assert.ok(!invs.includes('Next'));
+  assert.ok(!invs.includes('Bump'), 'a primed (action) def is not a safety invariant');
+  assert.ok(!invs.includes('vars'));
+});
+
+test('analyzeModel prefers a def literally named Spec over another [][ def', () => {
+  const m = [
+    'Init == x = 0', 'Next == x\' = x',
+    'Other == Init /\\ [][Next]_vars',
+    'Spec == Init /\\ [][Next]_vars',
+    'Inv == x = 0',
+  ].join('\n');
+  const { spec } = analyzeModel(m);
+  assert.strictEqual(spec, 'Spec');
+});
+
+test('analyzeModel excludes temporal/liveness properties from invariants', () => {
+  const m = [
+    'Init == x = 0', 'Next == x\' = x + 1',
+    'Spec == Init /\\ [][Next]_vars',
+    'Liveness == <>(x = 5)',          // temporal → not a safety invariant
+    'Fair == WF_vars(Next)',          // fairness → not an invariant
+    'TypeOK == x \\in Nat',           // nullary safety predicate → IS a candidate
+  ].join('\n');
+  const { invs } = analyzeModel(m);
+  assert.ok(invs.includes('TypeOK'));
+  assert.ok(!invs.includes('Liveness'));
+  assert.ok(!invs.includes('Fair'));
+});
+
+// ── checkModelInvariants: fail-open + real TLC runs ──────────────────────────
+
+test('fail-open: no .tla dir → clean (skipped:false, count:0), never a crash', () => {
+  const root = tmpRoot();
+  try {
+    const r = checkModelInvariants(root);
+    assert.ok(r && typeof r.count === 'number');
+    if (HAVE_TLC) {
+      assert.strictEqual(r.skipped, false);
+      assert.strictEqual(r.count, 0);
+    }
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('a safe concrete model produces 0 findings (when TLC present)', { skip: !HAVE_TLC }, () => {
+  const root = tmpRoot();
+  try {
+    writeModel(root, 'Safe.tla', SAFE);
+    const r = checkModelInvariants(root);
+    assert.strictEqual(r.skipped, false);
+    assert.strictEqual(r.count, 0, 'a model whose invariant always holds is clean');
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('detects a reachable invariant violation (when TLC present)', { skip: !HAVE_TLC }, () => {
+  const root = tmpRoot();
+  try {
+    writeModel(root, 'Bad.tla', VIOLATING);
+    const r = checkModelInvariants(root);
+    assert.strictEqual(r.skipped, false);
+    assert.strictEqual(r.count, 1);
+    assert.strictEqual(r.findings[0].rule, 'invariant-violation');
+    assert.strictEqual(r.findings[0].invariant, 'NoDeadlock');
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('parameterized (CONSTANTS) models are skipped, not flagged (when TLC present)', { skip: !HAVE_TLC }, () => {
+  const root = tmpRoot();
+  try {
+    // A CONSTANTS model needs a hand cfg to bound it; auto-cfg would error. It must
+    // be silently skipped (concrete-only scope), never a false finding or a crash.
+    const param = [
+      '---- MODULE Param ----',
+      'CONSTANTS N',
+      'VARIABLES x',
+      'Init == x = 0',
+      'Next == x\' = (x + 1) % N',
+      'Inv == x < N',
+      'vars == <<x>>',
+      'Spec == Init /\\ [][Next]_vars',
+      '====',
+    ].join('\n');
+    writeModel(root, 'Param.tla', param);
+    const r = checkModelInvariants(root);
+    assert.strictEqual(r.skipped, false);
+    assert.strictEqual(r.count, 0, 'CONSTANTS model is out of scope → not flagged');
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('_TTrace_ error-trace models are ignored (when TLC present)', { skip: !HAVE_TLC }, () => {
+  const root = tmpRoot();
+  try {
+    // A leftover _TTrace_ file from a prior TLC run must never be re-checked.
+    writeModel(root, 'Bad_TTrace_123.tla', VIOLATING);
+    const r = checkModelInvariants(root);
+    assert.strictEqual(r.count, 0, '_TTrace_ files are skipped by name');
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});

--- a/bin/nf-solve.cjs
+++ b/bin/nf-solve.cjs
@@ -4321,6 +4321,40 @@ function sweepSast() {
   }
 }
 
+// ── Model-check sweep (diagnostic) ───────────────────────────────────────────
+// Runs TLC on CONCRETE (no-CONSTANTS) TLA models with an auto-generated cfg to find
+// BEHAVIORAL safety defects — reachable invariant violations (e.g. a deadlock state
+// that a NoDeadlock invariant forbids) — that the static formal_lint sweep cannot
+// see because they only manifest during state-space exploration. Same external-
+// analyzer pattern as sweepSast/run-formal-verify. Fail-open: if tla2tools.jar is
+// absent the helper reports skipped, so residual is -1 (NOT a false 0). Baseline is
+// 0 on nForma's own concrete models, so any finding is a real reachable violation.
+function sweepModelCheck() {
+  try {
+    // Check the SUT's own bin (SCRIPT_DIR), NOT ROOT — the scanned project may be a
+    // separate fixture with no bin/. spawnTool runs the script from SCRIPT_DIR.
+    const scriptPath = path.join(SCRIPT_DIR, 'check-model-invariants.cjs');
+    if (!fs.existsSync(scriptPath)) {
+      return { residual: -1, detail: { skipped: true, reason: 'check-model-invariants.cjs not found' } };
+    }
+    const result = spawnTool('bin/check-model-invariants.cjs', ['--json']);
+    if (!result.stdout) {
+      return { residual: -1, detail: { skipped: true, reason: 'check-model-invariants.cjs produced no output', stderr: (result.stderr || '').slice(0, 500) } };
+    }
+    const data = JSON.parse(result.stdout);
+    if (data.skipped) {
+      return { residual: -1, detail: { skipped: true, reason: data.reason || 'model-check skipped' } };
+    }
+    const arr = Array.isArray(data.findings) ? data.findings : [];
+    return {
+      residual: arr.length,
+      detail: { findings_count: arr.length, findings: arr },
+    };
+  } catch (err) {
+    return { residual: -1, detail: { error: err.message } };
+  }
+}
+
 // ── Trace Health sweep (diagnostic) ──────────────────────────────────────────
 
 function sweepTraceHealth() {
@@ -4873,6 +4907,10 @@ function computeResidual() {
   const sast = checkLayerSkip('sast') || sweepSast();
   _timing.sast = { duration_ms: Date.now() - _t_sast, skipped: !!(sast.detail && sast.detail.skipped) };
 
+  const _t_model_check = Date.now();
+  const model_check = checkLayerSkip('model_check') || sweepModelCheck();
+  _timing.model_check = { duration_ms: Date.now() - _t_model_check, skipped: !!(model_check.detail && model_check.detail.skipped) };
+
   const _t_trace_health = Date.now();
   const trace_health = checkLayerSkip('trace_health') || sweepTraceHealth();
   _timing.trace_health = { duration_ms: Date.now() - _t_trace_health, skipped: !!(trace_health.detail && trace_health.detail.skipped) };
@@ -4928,6 +4966,7 @@ function computeResidual() {
     (security.residual >= 0 ? security.residual : 0) +
     (require_graph.residual >= 0 ? require_graph.residual : 0) +
     (sast.residual >= 0 ? sast.residual : 0) +
+    (model_check.residual >= 0 ? model_check.residual : 0) +
     (trace_health.residual >= 0 ? trace_health.residual : 0) +
     (asset_stale.residual >= 0 ? asset_stale.residual : 0) +
     (arch_constraints.residual >= 0 ? arch_constraints.residual : 0) +
@@ -4962,6 +5001,7 @@ function computeResidual() {
     security,
     require_graph,
     sast,
+    model_check,
     trace_health,
     asset_stale,
     arch_constraints,
@@ -5661,6 +5701,7 @@ function formatReport(iterations, finalResidual, converged) {
     { label: 'DH (Debt Health)', key: 'debt_health' },
     { label: 'MH (Memory Health)', key: 'memory_health' },
     { label: 'MS (Model Stale)', key: 'model_stale' },
+    { label: 'MC (Model Check)', key: 'model_check' },
   ];
 
   for (const row of diagRows) {


### PR DESCRIPTION
## Summary

Adds a **`model_check`** diagnostic layer to `nf-solve` that catches **behavioral** formal defects — reachable safety-invariant violations (e.g. a deadlock state) that only manifest during state-space exploration and that the static `formal_lint` sweep cannot see.

This wires up nForma's existing TLC integration (`resolve-formal-tools` + `tla2tools.jar`); it is **not** a new model checker.

## How it works

`bin/check-model-invariants.cjs`:
- Reuses `resolveTlaJar` for jar location.
- For each **concrete** (no-`CONSTANTS`) non-`_TTrace_` TLA model, auto-generates a `.cfg`: `SPECIFICATION` = the `[][Next]_vars` def (preferring one literally named `Spec`); `INVARIANT` = nullary boolean state predicates (no primes / temporal ops / params).
- Runs TLC and flags **only** genuine `Invariant X is violated` — **not** TLC's default deadlock check (which fires on legitimately-terminating models) nor parse/cfg errors.
- **Fail-open**: if the jar is absent, reports skipped → residual `-1`, never a false `0`.
- Concrete-only by design: parameterized models need hand-written cfgs (that's why the full TLC pass is `--fast`-skipped) and are left untouched.

Verified **0 findings** across nForma's own concrete models, so any finding is a real reachable violation.

`nf-solve` wires `sweepModelCheck()` as an informational diagnostic layer (SCRIPT_DIR existence guard so separate-SUT fixtures work), mirroring `sweepSast` exactly, and surfaces it in the Diagnostic Health report (`MC (Model Check)`).

## Testing

- 8 skip-aware unit tests (`bin/check-model-invariants.test.cjs`): `analyzeModel` cfg-generation logic runs jar-free; TLC runs gate on jar presence. Covers safe-model-clean, reachable-violation-detected, CONSTANTS-skipped, `_TTrace_`-ignored, and temporal/liveness exclusion.
- `npm run lint:isolation` ✓
- 0-baseline confirmed on the real repo.
- End-to-end: **nf-benchmark BENCH-025 (deadlock) FAIL→PASS** — "Layer model_check residual increased 0→1 — mutation detected" (verified in a throwaway `origin/main` worktree). Companion challenge relabel PR in nf-benchmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new model-checking diagnostic that scans formal models for reachable safety issues.
  * The solver report now includes a dedicated “Model Check” health row with its result count.

* **Bug Fixes**
  * Improved resilience when model-checking tools or inputs are unavailable by skipping safely instead of failing.
  * Ignored unsupported or inapplicable models to avoid false positives and crashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->