### PR TITLE
feat(solve): petri_check layer — Petri-net unreachable-marking detection

### DIFF
--- a/.planning/formal/petri/bench-unreachable.pnml
+++ b/.planning/formal/petri/bench-unreachable.pnml
@@ -1,1 +1,0 @@
-<?xml version="1.0"?><pnml><net id="bench" type="http://www.pnml.org/version-2009/grammar/pnmlcoremodel"><page id="p1"><place id="s1"><initialMarking><text>1</text></initialMarking></place><place id="s2"/><place id="s3"/><transition id="t1"/><arc id="a1" source="s1" target="t1"/><arc id="a2" source="t1" target="s2"/></page></net></pnml>

--- a/bin/check-petri-reachability.cjs
+++ b/bin/check-petri-reachability.cjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+'use strict';
+// bin/check-petri-reachability.cjs
+// Structural reachability sweep for Petri nets (PNML): flags places that can NEVER
+// hold a token — a place with no initial marking AND no incoming arc from any
+// transition. Such a place is structurally dead, so any marking that requires a
+// token there is UNREACHABLE. This is a BEHAVIORAL formal defect (a modeled state
+// the net can never actually reach) that structural lint over the file text misses.
+//
+// Soundness: a place gains tokens ONLY when a transition with an arc into it fires.
+// No incoming arc + empty initial marking ⇒ the place is permanently empty ⇒ any
+// marking placing a token there is unreachable. This is decidable STATICALLY (no
+// state-space search) and false-positive-free — the same confidence profile as the
+// deadlock/invariant-violation sweep (check-model-invariants.cjs).
+//
+// FP-safety: nForma ships no XML parser (zero-dep). Rather than trust a regex over
+// arbitrary XML, the parser cross-checks its element counts against the raw
+// `<place`/`<transition`/`<arc` tag counts; ANY mismatch (a missed or malformed
+// element that could hide an incoming arc and cause a false "dead" verdict) makes
+// the whole file skip — fail-open, never a false finding. Reporting a dead place
+// requires a fully, unambiguously parsed net.
+//
+// Usage:  node bin/check-petri-reachability.cjs --json  → { findings, count, skipped? }
+// Exit:   0 = clean/skipped, 1 = unreachable places found.
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = process.cwd();
+
+function stripXmlComments(s) {
+  return String(s).replace(/<!--[\s\S]*?-->/g, ' ');
+}
+
+function attr(attrs, name) {
+  const m = attrs.match(new RegExp('\\b' + name + '\\s*=\\s*"([^"]*)"'));
+  return m ? m[1] : null;
+}
+
+// Parse a PNML net into {places:[{id,marked}], transitions:[ids], arcs:[{source,target}]}
+// or return null if the parse is ambiguous (element counts don't match raw tag counts).
+function parsePnml(raw) {
+  const content = stripXmlComments(raw);
+
+  // Raw tag counts — the ground truth the regex extraction must exactly reproduce.
+  const rawPlaces = (content.match(/<place\b/g) || []).length;
+  const rawTransitions = (content.match(/<transition\b/g) || []).length;
+  const rawArcs = (content.match(/<arc\b/g) || []).length;
+  if (rawPlaces === 0) return null; // not a place/transition net we can reason about
+
+  const places = [];
+  const placeRe = /<place\b([^>]*?)(?:\/>|>([\s\S]*?)<\/place>)/g;
+  let m;
+  while ((m = placeRe.exec(content)) !== null) {
+    const id = attr(m[1], 'id');
+    if (id === null) return null; // a place without an id → ambiguous, bail
+    const body = m[2] || '';
+    // Initially marked iff an <initialMarking> carries a positive token count.
+    const mk = body.match(/<initialMarking\b[^>]*>[\s\S]*?<text>\s*([0-9]+)\s*<\/text>[\s\S]*?<\/initialMarking>/);
+    const marked = !!(mk && parseInt(mk[1], 10) > 0);
+    places.push({ id, marked });
+  }
+
+  const transitions = [];
+  const transRe = /<transition\b([^>]*?)(?:\/>|>[\s\S]*?<\/transition>)/g;
+  while ((m = transRe.exec(content)) !== null) {
+    const id = attr(m[1], 'id');
+    if (id === null) return null;
+    transitions.push(id);
+  }
+
+  const arcs = [];
+  const arcRe = /<arc\b([^>]*?)(?:\/>|>[\s\S]*?<\/arc>)/g;
+  while ((m = arcRe.exec(content)) !== null) {
+    const source = attr(m[1], 'source');
+    const target = attr(m[1], 'target');
+    if (source === null || target === null) return null;
+    arcs.push({ source, target });
+  }
+
+  // Cross-check: every raw tag must have been captured. A mismatch means the regex
+  // missed/misparsed an element — an unseen incoming arc could turn a "dead" place
+  // live, so we refuse to reason about this file (fail-open, no false positive).
+  if (places.length !== rawPlaces || transitions.length !== rawTransitions || arcs.length !== rawArcs) {
+    return null;
+  }
+  return { places, transitions, arcs };
+}
+
+// A place is structurally unreachable (dead) iff it is not initially marked AND no
+// arc targets it (no transition can ever deposit a token there).
+function deadPlaces(net) {
+  const incoming = new Set(net.arcs.map(a => a.target));
+  return net.places.filter(p => !p.marked && !incoming.has(p.id)).map(p => p.id);
+}
+
+function checkPetriReachability(root) {
+  const dir = path.join(root, '.planning', 'formal', 'petri');
+  if (!fs.existsSync(dir)) return { skipped: false, findings: [], count: 0 };
+  let files;
+  try { files = fs.readdirSync(dir).filter(f => f.endsWith('.pnml')); }
+  catch (_) { return { skipped: false, findings: [], count: 0 }; }
+
+  const findings = [];
+  for (const f of files) {
+    let content;
+    try { content = fs.readFileSync(path.join(dir, f), 'utf8'); } catch (_) { continue; }
+    let net;
+    try { net = parsePnml(content); } catch (_) { net = null; }
+    if (!net) continue; // ambiguous/malformed → fail-open (no finding)
+    const dead = deadPlaces(net);
+    for (const pid of dead) {
+      findings.push({
+        rule: 'unreachable-marking',
+        model: f.replace(/\.pnml$/, ''),
+        place: pid,
+        message: 'Petri place ' + pid + ' has no initial marking and no incoming arc — any marking requiring a token there is unreachable in ' + f,
+      });
+    }
+  }
+  return { skipped: false, findings: findings, count: findings.length };
+}
+
+module.exports = { checkPetriReachability: checkPetriReachability, parsePnml: parsePnml, deadPlaces: deadPlaces };
+
+if (require.main === module) {
+  const asJson = process.argv.includes('--json');
+  const r = checkPetriReachability(ROOT);
+  if (asJson) {
+    process.stdout.write(JSON.stringify(r, null, 2) + '\n');
+  } else if (r.skipped) {
+    console.log('[petri-check] skipped: ' + (r.reason || 'n/a'));
+  } else {
+    for (const f of r.findings) console.log('[' + f.rule + '] ' + f.model + ': ' + f.message);
+    console.log(r.count + ' unreachable-marking finding(s)');
+  }
+  process.exit(!r.skipped && r.count > 0 ? 1 : 0);
+}

--- a/bin/check-petri-reachability.test.cjs
+++ b/bin/check-petri-reachability.test.cjs
@@ -1,0 +1,123 @@
+'use strict';
+
+// Unit tests for bin/check-petri-reachability.cjs — the structural Petri-net (PNML)
+// unreachable-marking sweep. Pure fs + regex, no external tool, so these run
+// unconditionally (no skip gating). They pin down BOTH the detection (a dead place
+// is flagged) and the false-positive avoidance (live places, and ambiguous/malformed
+// PNML that could hide an incoming arc, must NOT be flagged).
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { checkPetriReachability, parsePnml, deadPlaces } = require('./check-petri-reachability.cjs');
+
+function tmpRoot() { return fs.mkdtempSync(path.join(os.tmpdir(), 'nf-petri-')); }
+function writeNet(root, name, content) {
+  const dir = path.join(root, '.planning', 'formal', 'petri');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, name), content);
+}
+
+// s3: no initial marking, no incoming arc → structurally dead (unreachable marking).
+// s2: fed by t1 → live. s1: initially marked → live.
+const UNREACHABLE = '<?xml version="1.0"?><pnml><net id="bench" type="x"><page id="p1">'
+  + '<place id="s1"><initialMarking><text>1</text></initialMarking></place>'
+  + '<place id="s2"/><place id="s3"/><transition id="t1"/>'
+  + '<arc id="a1" source="s1" target="t1"/><arc id="a2" source="t1" target="s2"/></page></net></pnml>';
+
+// Every place is either initially marked or has an incoming arc → no dead place.
+const CLEAN = '<?xml version="1.0"?><pnml><net id="ok" type="x"><page id="p1">'
+  + '<place id="a"><initialMarking><text>1</text></initialMarking></place>'
+  + '<place id="b"/><transition id="t1"/>'
+  + '<arc id="r1" source="a" target="t1"/><arc id="r2" source="t1" target="b"/></page></net></pnml>';
+
+// ── parse/analysis unit ──────────────────────────────────────────────────────
+
+test('parsePnml extracts places, transitions, arcs; deadPlaces finds the dead one', () => {
+  const net = parsePnml(UNREACHABLE);
+  assert.ok(net, 'well-formed net parses');
+  assert.strictEqual(net.places.length, 3);
+  assert.strictEqual(net.transitions.length, 1);
+  assert.strictEqual(net.arcs.length, 2);
+  assert.deepStrictEqual(deadPlaces(net), ['s3']);
+});
+
+test('an initial marking of 0 does NOT count as marked', () => {
+  const net = parsePnml('<pnml><net id="n"><place id="z"><initialMarking><text>0</text></initialMarking></place></net></pnml>');
+  assert.ok(net);
+  assert.deepStrictEqual(deadPlaces(net), ['z'], 'a 0-token initial marking is still empty → dead');
+});
+
+// ── fail-open FP guards ──────────────────────────────────────────────────────
+
+test('parsePnml returns null when a <place> is malformed (count mismatch → fail-open)', () => {
+  // Two raw `<place` tags but the second is unterminated: the regex can only capture
+  // one, so the counts disagree and we refuse to reason (a hidden arc could exist).
+  const net = parsePnml('<pnml><net id="n"><place id="a"/><place id="b" ></net></pnml>');
+  assert.strictEqual(net, null);
+});
+
+test('parsePnml returns null when a place has no id (ambiguous)', () => {
+  const net = parsePnml('<pnml><net id="n"><place/><transition id="t"/></net></pnml>');
+  assert.strictEqual(net, null);
+});
+
+test('parsePnml returns null when there are no places at all', () => {
+  assert.strictEqual(parsePnml('<pnml><net id="n"></net></pnml>'), null);
+});
+
+test('XML comments hiding an arc do not cause a false positive', () => {
+  // The incoming arc to s2 is real; a comment near it must not desync the count guard.
+  const withComment = '<pnml><net id="n"><page id="p">'
+    + '<place id="s1"><initialMarking><text>1</text></initialMarking></place>'
+    + '<place id="s2"/><transition id="t1"/>'
+    + '<!-- wiring --><arc id="a1" source="s1" target="t1"/><arc id="a2" source="t1" target="s2"/>'
+    + '</page></net></pnml>';
+  const net = parsePnml(withComment);
+  assert.ok(net);
+  assert.deepStrictEqual(deadPlaces(net), [], 's2 is fed by t1 → live, not flagged');
+});
+
+// ── end-to-end sweep ─────────────────────────────────────────────────────────
+
+test('detects the unreachable place end-to-end', () => {
+  const root = tmpRoot();
+  try {
+    writeNet(root, 'bench.pnml', UNREACHABLE);
+    const r = checkPetriReachability(root);
+    assert.strictEqual(r.skipped, false);
+    assert.strictEqual(r.count, 1);
+    assert.strictEqual(r.findings[0].rule, 'unreachable-marking');
+    assert.strictEqual(r.findings[0].place, 's3');
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('a clean net produces 0 findings', () => {
+  const root = tmpRoot();
+  try {
+    writeNet(root, 'clean.pnml', CLEAN);
+    const r = checkPetriReachability(root);
+    assert.strictEqual(r.count, 0);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('no petri dir → clean, never a crash', () => {
+  const root = tmpRoot();
+  try {
+    const r = checkPetriReachability(root);
+    assert.strictEqual(r.skipped, false);
+    assert.strictEqual(r.count, 0);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('a malformed .pnml in the dir is skipped, not flagged (fail-open)', () => {
+  const root = tmpRoot();
+  try {
+    writeNet(root, 'bad.pnml', '<pnml><net id="n"><place id="a"/><place id="b" ></net></pnml>');
+    const r = checkPetriReachability(root);
+    assert.strictEqual(r.count, 0, 'ambiguous parse yields no finding');
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});

--- a/bin/nf-solve.cjs
+++ b/bin/nf-solve.cjs
@@ -4355,6 +4355,39 @@ function sweepModelCheck() {
   }
 }
 
+// ── Petri reachability sweep (diagnostic) ────────────────────────────────────
+// Structural reachability over Petri nets (PNML): flags places that can never hold
+// a token (no initial marking + no incoming arc) — a modeled marking the net can
+// NEVER reach, which structural file-lint misses. Decidable + false-positive-free
+// (a place with no incoming arcs starting empty is permanently empty), same
+// confidence profile as sweepModelCheck. Fail-open: an ambiguous/malformed PNML
+// skips (residual -1, never a false 0). 0-baseline on nForma's own nets.
+function sweepPetriReachability() {
+  try {
+    // Check the SUT's own bin (SCRIPT_DIR), NOT ROOT — the scanned project may be a
+    // separate fixture with no bin/. spawnTool runs the script from SCRIPT_DIR.
+    const scriptPath = path.join(SCRIPT_DIR, 'check-petri-reachability.cjs');
+    if (!fs.existsSync(scriptPath)) {
+      return { residual: -1, detail: { skipped: true, reason: 'check-petri-reachability.cjs not found' } };
+    }
+    const result = spawnTool('bin/check-petri-reachability.cjs', ['--json']);
+    if (!result.stdout) {
+      return { residual: -1, detail: { skipped: true, reason: 'check-petri-reachability.cjs produced no output', stderr: (result.stderr || '').slice(0, 500) } };
+    }
+    const data = JSON.parse(result.stdout);
+    if (data.skipped) {
+      return { residual: -1, detail: { skipped: true, reason: data.reason || 'petri-check skipped' } };
+    }
+    const arr = Array.isArray(data.findings) ? data.findings : [];
+    return {
+      residual: arr.length,
+      detail: { findings_count: arr.length, findings: arr },
+    };
+  } catch (err) {
+    return { residual: -1, detail: { error: err.message } };
+  }
+}
+
 // ── Trace Health sweep (diagnostic) ──────────────────────────────────────────
 
 function sweepTraceHealth() {
@@ -4911,6 +4944,10 @@ function computeResidual() {
   const model_check = checkLayerSkip('model_check') || sweepModelCheck();
   _timing.model_check = { duration_ms: Date.now() - _t_model_check, skipped: !!(model_check.detail && model_check.detail.skipped) };
 
+  const _t_petri_check = Date.now();
+  const petri_check = checkLayerSkip('petri_check') || sweepPetriReachability();
+  _timing.petri_check = { duration_ms: Date.now() - _t_petri_check, skipped: !!(petri_check.detail && petri_check.detail.skipped) };
+
   const _t_trace_health = Date.now();
   const trace_health = checkLayerSkip('trace_health') || sweepTraceHealth();
   _timing.trace_health = { duration_ms: Date.now() - _t_trace_health, skipped: !!(trace_health.detail && trace_health.detail.skipped) };
@@ -4967,6 +5004,7 @@ function computeResidual() {
     (require_graph.residual >= 0 ? require_graph.residual : 0) +
     (sast.residual >= 0 ? sast.residual : 0) +
     (model_check.residual >= 0 ? model_check.residual : 0) +
+    (petri_check.residual >= 0 ? petri_check.residual : 0) +
     (trace_health.residual >= 0 ? trace_health.residual : 0) +
     (asset_stale.residual >= 0 ? asset_stale.residual : 0) +
     (arch_constraints.residual >= 0 ? arch_constraints.residual : 0) +
@@ -5002,6 +5040,7 @@ function computeResidual() {
     require_graph,
     sast,
     model_check,
+    petri_check,
     trace_health,
     asset_stale,
     arch_constraints,
@@ -5702,6 +5741,7 @@ function formatReport(iterations, finalResidual, converged) {
     { label: 'MH (Memory Health)', key: 'memory_health' },
     { label: 'MS (Model Stale)', key: 'model_stale' },
     { label: 'MC (Model Check)', key: 'model_check' },
+    { label: 'PC (Petri Check)', key: 'petri_check' },
   ];
 
   for (const row of diagRows) {


### PR DESCRIPTION
## Summary

Behavior #2 of the "one behavior at a time" formal-detection grind (quorum-approved, unanimous 4/4). Adds a **`petri_check`** layer that finds **unreachable markings** in Petri nets: a place with no initial marking and no incoming arc can never hold a token, so any marking requiring one there is unreachable — a behavioral formal defect that structural file-lint misses.

## How it works

`bin/check-petri-reachability.cjs` — zero-dep PNML parser + structural dead-place analysis. **Decidable statically** (no state-space search) and **false-positive-free**, same confidence profile as the deadlock/invariant-violation sweep (#305).

**FP-safety (addresses the quorum's XML-robustness concern):** it cross-checks its regex-extracted element counts against the raw `<place>`/`<transition>`/`<arc>` tag counts and **fails open** (skips the file) on ANY mismatch. A missed or malformed element could hide an incoming arc and turn a live place "dead", so reporting a finding requires a fully unambiguous parse — never trusting regex over arbitrary XML.

`nf-solve` wires `sweepPetriReachability` as an informational layer (SCRIPT_DIR existence guard so separate-SUT fixtures work), mirroring `sweepModelCheck`, surfaced as `PC (Petri Check)` in Diagnostic Health.

## Quorum

Design ratified by a 4-model quorum (codex-1, opencode-1, copilot-1, claude-1 — all APPROVE). Debate: `.planning/quorum/debates/2026-07-04-behavior-2-formal-detection-petri-liveness.md`. Key refinements incorporated: use a real parser not regex (fail-open count-guard), keep it decidable/FP-safe, preserve challenge identity when re-authoring.

## Testing

- 10 unit tests (`bin/check-petri-reachability.test.cjs`): detection, clean-net 0-FP, and every fail-open guard (malformed element, missing id, no places, comment-hidden arc).
- `npm run lint:isolation` ✓, 0-baseline on the real repo.
- End-to-end: **nf-benchmark BENCH-022 FAIL→PASS** — "Layer petri_check residual increased 0→1" (throwaway origin/main worktree). Companion: nForma-AI/nf-benchmark#21.

## Cleanup

Removes `.planning/formal/petri/bench-unreachable.pnml` — a benchmark fixture accidentally committed via #110 that kept the `petri_check` baseline non-zero on the real repo (a standing `s3` finding). Removing it restores the 0-baseline invariant; the benchmark neutralizes/creates/reverts its own copy per run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Petri-net reachability check that identifies places that can never receive a token.
  * Included the new check in the overall diagnostic health report so it appears alongside other sweeps.
  * Added JSON output support for automated reporting and command-line use.

* **Bug Fixes**
  * Improved handling of malformed or unreadable Petri-net files by skipping ambiguous inputs instead of failing.
  * Ensured the report remains stable when the expected Petri-net directory is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->