### PR TITLE
feat(solve): model_check liveness — TLC-detected unsatisfiable liveness properties

### DIFF
--- a/bin/check-model-invariants.cjs
+++ b/bin/check-model-invariants.cjs
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 'use strict';
 // bin/check-model-invariants.cjs
-// Model-checking sweep for BEHAVIORAL formal defects (deadlock potential, safety
-// invariant violations) that static lints cannot see — by actually running TLC.
+// Model-checking sweep for BEHAVIORAL formal defects — safety-invariant violations
+// (a reachable state that breaks an INVARIANT) AND liveness violations (a declared
+// temporal PROPERTY that is unsatisfiable under the model's own fairness) — that
+// static lints cannot see, by actually running TLC.
 // This wires up nForma's existing TLC integration (resolve-formal-tools + tla2tools);
 // it is NOT a new model checker.
 //
@@ -52,16 +54,22 @@ function stripComments(c) {
   return String(c).replace(/\(\*[\s\S]*?\*\)/g, ' ').replace(/\\\*[^\n]*/g, ' ');
 }
 
-// Parse the temporal SPECIFICATION def name and the safety-invariant candidate defs.
-// Spec: a def whose OWN body (not spanning other defs) contains a `[][Next]` formula;
-// prefer one literally named Spec. Invariants: nullary boolean state predicates with
-// no primes and no temporal/action operators.
+// Parse the temporal SPECIFICATION def, the safety-invariant candidates, whether the
+// Spec declares fairness, and the temporal (liveness) PROPERTY candidates.
+//   spec: a def whose OWN body (not spanning other defs) contains a `[][Next]`
+//     formula; prefer one literally named Spec.
+//   invs: nullary boolean state predicates — no primes, no temporal/action operators.
+//   fairnessInSpec: the Spec body conjoins `WF_`/`SF_` directly, OR references a
+//     one-hop fairness def whose body contains `WF_`/`SF_` (the `Fairness == WF_..`
+//     idiom). This is the gate that makes a liveness check meaningful — without
+//     fairness, TLC lets the system stutter forever and EVERY `<>P` fails vacuously.
+//   liveness: nullary temporal PROPERTY defs (body contains `<>`), i.e. declared
+//     liveness properties — distinct from safety invariants and from the Spec itself.
 function analyzeModel(content) {
   const c = stripComments(content);
   const lines = c.split('\n');
   const headRe = /^([A-Za-z_]\w*)\s*==(.*)$/;
-  let spec = null;
-  const invs = [];
+  const defs = [];
   let i = 0;
   while (i < lines.length) {
     const h = lines[i].match(headRe);
@@ -71,23 +79,52 @@ function analyzeModel(content) {
     const bodyLines = [h[2]];
     let j = i + 1;
     for (; j < lines.length; j++) { if (headRe.test(lines[j]) || /^====/.test(lines[j])) break; bodyLines.push(lines[j]); }
-    const body = bodyLines.join(' ');
-    if (/\[\]\s*\[/.test(body)) {
-      if (name === 'Spec') spec = 'Spec';
-      else if (!spec) spec = name;
-    } else if (
-      !parenParams &&
-      !['Init', 'Next', 'vars', 'Spec'].includes(name) &&
-      !/'/.test(body) &&
-      !/\[\]|<>|WF_|SF_|ENABLED|UNCHANGED/.test(body) &&
-      !/CHOOSE|LET/.test(body) &&
-      /=|#|\\in|~|=>|\\A|\\E|\\subseteq/.test(body)
-    ) {
-      invs.push(name);
-    }
+    defs.push({ name: name, body: bodyLines.join(' '), parenParams: parenParams });
     i = j;
   }
-  return { spec, invs };
+
+  let spec = null;
+  let specBody = '';
+  for (const d of defs) {
+    if (/\[\]\s*\[/.test(d.body)) {
+      if (d.name === 'Spec') { spec = 'Spec'; specBody = d.body; break; }
+      if (!spec) { spec = d.name; specBody = d.body; }
+    }
+  }
+
+  // Fairness in the Spec closure: directly, or via a one-hop `Fairness == WF_..` def
+  // the Spec conjoins by name (opencode-1's refinement — fairness INSIDE the Spec,
+  // not merely a standalone operator defined elsewhere and never used).
+  let fairnessInSpec = false;
+  if (spec) {
+    if (/WF_|SF_/.test(specBody)) {
+      fairnessInSpec = true;
+    } else {
+      for (const d of defs) {
+        if (d.name !== spec && /WF_|SF_/.test(d.body) && new RegExp('\\b' + d.name + '\\b').test(specBody)) {
+          fairnessInSpec = true;
+          break;
+        }
+      }
+    }
+  }
+
+  const invs = [];
+  const liveness = [];
+  for (const d of defs) {
+    if (d.parenParams || d.name === spec || ['Init', 'Next', 'vars', 'Spec'].includes(d.name)) continue;
+    if (/<>/.test(d.body) && !/WF_|SF_/.test(d.body)) {
+      liveness.push(d.name); // temporal liveness property (eventually)
+    } else if (
+      !/'/.test(d.body) &&
+      !/\[\]|<>|WF_|SF_|ENABLED|UNCHANGED/.test(d.body) &&
+      !/CHOOSE|LET/.test(d.body) &&
+      /=|#|\\in|~|=>|\\A|\\E|\\subseteq/.test(d.body)
+    ) {
+      invs.push(d.name);
+    }
+  }
+  return { spec: spec, invs: invs, fairnessInSpec: fairnessInSpec, liveness: liveness };
 }
 
 function checkModelInvariants(root) {
@@ -106,19 +143,39 @@ function checkModelInvariants(root) {
     let content;
     try { content = fs.readFileSync(path.join(dir, f), 'utf8'); } catch (_) { continue; }
     if (/\bCONSTANTS?\b/.test(stripComments(content))) continue; // parameterized — needs a hand cfg
-    const { spec, invs } = analyzeModel(content);
-    if (!spec || invs.length === 0) continue;
+    const { spec, invs, fairnessInSpec, liveness } = analyzeModel(content);
+    if (!spec) continue;
+    const doSafety = invs.length > 0;
+    // Dual gate (copilot-1's refinement): a liveness PROPERTY is only checked when the
+    // Spec declares fairness AND a temporal property is actually present. Either alone
+    // is unsafe — fairness without a property checks nothing; a property without
+    // fairness fails vacuously via stuttering (the whole stuttering-FP class).
+    const doLiveness = fairnessInSpec && liveness.length > 0;
+    if (!doSafety && !doLiveness) continue;
     let tmp;
     try {
       tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'nf-mc-')); // inside try: a mkdtemp failure skips THIS model, not the loop
       const base = f.replace(/\.tla$/, '');
       fs.writeFileSync(path.join(tmp, f), content);
-      fs.writeFileSync(path.join(tmp, base + '.cfg'), 'SPECIFICATION ' + spec + '\n' + invs.map(x => 'INVARIANT ' + x).join('\n') + '\n');
-      const r = spawnSync('java', ['-cp', jar, 'tlc2.TLC', '-config', base + '.cfg', f], { cwd: tmp, encoding: 'utf8', timeout: PER_MODEL_TIMEOUT_MS, maxBuffer: 16 * 1024 * 1024 });
-      const out = (r.stdout || '') + (r.stderr || '');
-      const m = out.match(/Invariant (\w+) is violated/);
-      if (m) {
-        findings.push({ rule: 'invariant-violation', model: base, invariant: m[1], message: 'TLC found a reachable state violating invariant ' + m[1] + ' in ' + f });
+      if (doSafety) {
+        fs.writeFileSync(path.join(tmp, base + '.cfg'), 'SPECIFICATION ' + spec + '\n' + invs.map(x => 'INVARIANT ' + x).join('\n') + '\n');
+        const r = spawnSync('java', ['-cp', jar, 'tlc2.TLC', '-config', base + '.cfg', f], { cwd: tmp, encoding: 'utf8', timeout: PER_MODEL_TIMEOUT_MS, maxBuffer: 16 * 1024 * 1024 });
+        const out = (r.stdout || '') + (r.stderr || '');
+        const m = out.match(/Invariant (\w+) is violated/);
+        if (m) {
+          findings.push({ rule: 'invariant-violation', model: base, invariant: m[1], message: 'TLC found a reachable state violating invariant ' + m[1] + ' in ' + f });
+        }
+      }
+      if (doLiveness) {
+        const lcfg = base + '-liveness.cfg';
+        fs.writeFileSync(path.join(tmp, lcfg), 'SPECIFICATION ' + spec + '\n' + liveness.map(x => 'PROPERTY ' + x).join('\n') + '\n');
+        const r = spawnSync('java', ['-cp', jar, 'tlc2.TLC', '-config', lcfg, f], { cwd: tmp, encoding: 'utf8', timeout: PER_MODEL_TIMEOUT_MS, maxBuffer: 16 * 1024 * 1024 });
+        const out = (r.stdout || '') + (r.stderr || '');
+        // TLC's temporal-violation message is generic (doesn't name the property), so
+        // report the model + the properties checked under its own fairness assumptions.
+        if (/Temporal properties were violated/.test(out)) {
+          findings.push({ rule: 'liveness-violation', model: base, properties: liveness, message: 'TLC found the liveness propert' + (liveness.length > 1 ? 'ies' : 'y') + ' ' + liveness.join(', ') + ' unsatisfiable under the model\'s own fairness assumptions in ' + f });
+        }
       }
     } catch (_) { /* per-model failure — skip, never crash the sweep */ }
     finally { if (tmp) { try { fs.rmSync(tmp, { recursive: true, force: true }); } catch (_) {} } }

--- a/bin/check-model-invariants.test.cjs
+++ b/bin/check-model-invariants.test.cjs
@@ -63,6 +63,35 @@ const VIOLATING = [
   '====',
 ].join('\n');
 
+// Fairness (WF_x(Inc)) drives x up to 2 and holds; the property claims x eventually-
+// ALWAYS returns to 0 — contradicted by fairness → unsatisfiable liveness.
+const LIVENESS_BAD = [
+  '---- MODULE BadLive ----',
+  'EXTENDS Naturals',
+  'VARIABLES x',
+  'Init == x = 0',
+  'Inc == x < 2 /\\ x\' = x + 1',
+  'Stay == x = 2 /\\ x\' = 2',
+  'Next == Inc \\/ Stay',
+  'Spec == Init /\\ [][Next]_<<x>> /\\ WF_x(Inc)',
+  'EventuallyReturnsToZero == <>[](x = 0)',
+  '====',
+].join('\n');
+
+// Same fair spec, but a SATISFIABLE property (x eventually reaches 2) → clean.
+const LIVENESS_GOOD = [
+  '---- MODULE GoodLive ----',
+  'EXTENDS Naturals',
+  'VARIABLES x',
+  'Init == x = 0',
+  'Inc == x < 2 /\\ x\' = x + 1',
+  'Stay == x = 2 /\\ x\' = 2',
+  'Next == Inc \\/ Stay',
+  'Spec == Init /\\ [][Next]_<<x>> /\\ WF_x(Inc)',
+  'EventuallyReachesTwo == <>(x = 2)',
+  '====',
+].join('\n');
+
 // ── analyzeModel: pure cfg-generation logic (no jar needed) ──────────────────
 
 test('analyzeModel picks the temporal Spec and only nullary safety invariants', () => {
@@ -95,10 +124,38 @@ test('analyzeModel excludes temporal/liveness properties from invariants', () =>
     'Fair == WF_vars(Next)',          // fairness → not an invariant
     'TypeOK == x \\in Nat',           // nullary safety predicate → IS a candidate
   ].join('\n');
-  const { invs } = analyzeModel(m);
+  const { invs, liveness } = analyzeModel(m);
   assert.ok(invs.includes('TypeOK'));
   assert.ok(!invs.includes('Liveness'));
   assert.ok(!invs.includes('Fair'));
+  assert.ok(liveness.includes('Liveness'), 'a <>-bearing def is a liveness property candidate');
+});
+
+test('analyzeModel detects fairness conjoined directly in the Spec', () => {
+  const { fairnessInSpec, liveness } = analyzeModel(LIVENESS_BAD);
+  assert.strictEqual(fairnessInSpec, true, 'WF_x(Inc) inside the Spec body is fairness');
+  assert.ok(liveness.includes('EventuallyReturnsToZero'));
+});
+
+test('analyzeModel detects fairness via a one-hop Fairness def the Spec conjoins', () => {
+  const m = [
+    'Init == x = 0', 'Inc == x\' = x + 1', 'Next == Inc',
+    'Fairness == WF_x(Inc)',
+    'Spec == Init /\\ [][Next]_<<x>> /\\ Fairness',
+    'Prop == <>(x = 1)',
+  ].join('\n');
+  const { fairnessInSpec } = analyzeModel(m);
+  assert.strictEqual(fairnessInSpec, true, 'Spec conjoins Fairness, whose body has WF_ → fair');
+});
+
+test('analyzeModel: a Spec with NO fairness → fairnessInSpec false (the stuttering-FP gate)', () => {
+  const { fairnessInSpec, liveness } = analyzeModel([
+    'Init == x = 0', 'Next == x\' = x + 1',
+    'Spec == Init /\\ [][Next]_<<x>>',
+    'Prop == <>(x = 5)',
+  ].join('\n'));
+  assert.strictEqual(fairnessInSpec, false);
+  assert.ok(liveness.includes('Prop'), 'property is still parsed — but the gate will skip it');
 });
 
 // ── checkModelInvariants: fail-open + real TLC runs ──────────────────────────
@@ -122,6 +179,39 @@ test('a safe concrete model produces 0 findings (when TLC present)', { skip: !HA
     const r = checkModelInvariants(root);
     assert.strictEqual(r.skipped, false);
     assert.strictEqual(r.count, 0, 'a model whose invariant always holds is clean');
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('detects an unsatisfiable liveness property under fairness (when TLC present)', { skip: !HAVE_TLC }, () => {
+  const root = tmpRoot();
+  try {
+    writeModel(root, 'BadLive.tla', LIVENESS_BAD);
+    const r = checkModelInvariants(root);
+    assert.strictEqual(r.count, 1);
+    assert.strictEqual(r.findings[0].rule, 'liveness-violation');
+    assert.deepStrictEqual(r.findings[0].properties, ['EventuallyReturnsToZero']);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('a satisfiable liveness property under fairness is clean (when TLC present)', { skip: !HAVE_TLC }, () => {
+  const root = tmpRoot();
+  try {
+    writeModel(root, 'GoodLive.tla', LIVENESS_GOOD);
+    const r = checkModelInvariants(root);
+    assert.strictEqual(r.count, 0, 'a liveness property that holds under fairness is not flagged');
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('the dual gate: an unsatisfiable liveness property WITHOUT fairness is NOT flagged (stuttering-FP class)', { skip: !HAVE_TLC }, () => {
+  const root = tmpRoot();
+  try {
+    // Same property, but the Spec drops WF_x(Inc). Without fairness the system may
+    // stutter at x=0 forever, so <>[](x=0) would "hold" — but more importantly the
+    // gate refuses to even check liveness on an unfair spec. Either way: 0 findings.
+    const unfair = LIVENESS_BAD.replace(' /\\ WF_x(Inc)', '');
+    writeModel(root, 'Unfair.tla', unfair);
+    const r = checkModelInvariants(root);
+    assert.strictEqual(r.count, 0, 'no fairness → the liveness gate is closed → no finding');
   } finally { fs.rmSync(root, { recursive: true, force: true }); }
 });
 


### PR DESCRIPTION
## Summary

Behavior #3 of the "one behavior at a time" formal-detection grind (quorum-approved, unanimous 4/4). Extends the `model_check` layer to a second behavioral class: a declared temporal `PROPERTY` that is **unsatisfiable under the model's own fairness** (e.g. `<>[](x=0)` while `WF_` fairness drives `x` away from 0 forever). Static lint can't see this — it only surfaces as a TLC temporal counterexample.

## How it works

- `analyzeModel` now also derives:
  - **`fairnessInSpec`** — `WF_`/`SF_` conjoined directly in the Spec, OR via a one-hop `Fairness == WF_..` def the Spec references. (Per the quorum: fairness *inside the Spec closure*, not a standalone unused operator — opencode-1.)
  - **`liveness`** — nullary temporal-property defs (body contains `<>`).
- `checkModelInvariants` runs a liveness `PROPERTY` check under a **dual gate** (copilot-1's refinement): only when the Spec declares fairness **AND** a temporal property is present. Either alone is unsafe — fairness without a property checks nothing; a property without fairness fails vacuously via stuttering (the entire stuttering-FP class). It flags only TLC's `Temporal properties were violated`, as a `liveness-violation`.
- Safety and liveness run as **separate cfgs / TLC invocations** so their signals never interfere; a liveness-only model (no invariants) is now handled too.

## Quorum

Ratified by the same 4-model quorum that scoped behaviors #2–3 (debate: `.planning/quorum/debates/2026-07-04-behavior-2-formal-detection-petri-liveness.md`). This PR implements the liveness half with the exact FP-avoidance discipline the panel converged on.

## Testing

- 14 unit tests total (+6): fairness-in-Spec direct + one-hop, no-fairness gate, detection, satisfiable-clean, dual-gate-closed.
- `npm run lint:isolation` ✓.
- **0-baseline preserved** on the 197 real models (none pair fairness with a temporal property → the gate stays closed → no liveness FP).
- End-to-end: **nf-benchmark BENCH-102 FAIL→PASS** — "Layer model_check residual increased 0→1" (throwaway origin/main worktree). Companion: nForma-AI/nf-benchmark#22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)