### PR TITLE
docs(solve): FP-safe behavioral-detection set complete at three detectors

### DIFF
--- a/.planning/quorum/debates/2026-07-04-behavior-4-formal-detection-boundary.md
+++ b/.planning/quorum/debates/2026-07-04-behavior-4-formal-detection-boundary.md
@@ -1,0 +1,33 @@
+# Quorum Debate
+Question: What should behavior #4 be — is the FP-safe formal-behavioral detector set complete, and are BENCH-188 (weak invariant) + the code-concurrency candidates framework-limited?
+Date: 2026-07-04
+Consensus: APPROVE
+Rounds: 1
+
+## Round 1
+| Model | Position | Citations |
+|---|---|---|
+| Claude (ADVISORY) | The 3 FP-safe formal detectors exhaust the decidable behavioral defects; BENCH-188 is oracle-dependent (redundant with #1 if the strong property is present, else undecidable); code-concurrency is FP-prone/undecidable on arbitrary JS → declare complete, document the boundary | — |
+| codex-1 | UNAVAIL (CLI error) | — |
+| opencode-1 | UNAVAIL (relay incomplete) | — |
+| copilot-1 | APPROVE — empirically confirmed all 7 concurrency BENCHes + BENCH-188 score 0/passed:false ("No expected layer showed increased residual"); "too weak" is structurally irreducible (WeakInvariant.tla passes TLC cleanly). UPPAAL timed-automata would be a valid #4 for a DIFFERENT defect class but no remaining benchmark candidate PASSes from it | nf-benchmark/results/BENCH-188-*.json |
+| claude-1 | APPROVE — 3 detectors share decidable verification procedures; 0-baseline proves FP-safety empirically; BENCH-188 oracle-dependent; concurrency undecidable (whole-program alias + scheduling). layer-constants.cjs has no slot for a 4th behavioral detector | nf-solve.cjs:4332,4365,3963-3987; layer-constants.cjs:11-20 |
+| claude-minimax (T1 fallback) | APPROVE — 3 behaviors map to the standard taxonomy (safety/reachability/temporal), each decidable + FP-bounded. Rice's theorem applies to JS race/ABA. Considered & rejected candidate #4s: refinement/simulation (needs mapping oracle), action-precondition reachability (subsumed by #1), init-predicate satisfiability (#1 catches empty reachable set), hyperproperty/non-interference (unrealistic for corpus), SANY errors (separate lint). Redirect budget to sensitivity sweeps (SENS-01/02/03) / annotation coverage (ANNOT-01) | PR #305/#306/#307; requirements LIVE-01/02 |
+
+## Outcome
+Unanimous APPROVE (3 valid external voters — claude-1, copilot-1, claude-minimax; 0 BLOCK; codex-1 & opencode-1 UNAVAIL, claude-z-ai UNAVAIL/429). min_live_voters=2 satisfied.
+
+**The FP-safe formal-behavioral detection set is COMPLETE at three detectors:**
+1. Safety — reachable invariant-violation (model_check, TLC INVARIANT).
+2. Structural reachability — Petri unreachable-marking (petri_check, static dead-place).
+3. Temporal — unsatisfiable liveness under fairness (model_check, TLC PROPERTY, dual-gated).
+
+These map onto the standard taxonomy of finite-state model-checkable properties; each is decidable and FP-bounded by the checker's own correctness, empirically validated by 0-baseline on 197 real models + benchmark FAIL→PASS (#305/#306/#307).
+
+**FRAMEWORK-LIMITED (not shippable without breaking the 0-baseline invariant):**
+- **BENCH-188 "weak invariant"** — oracle-dependent. "Too weak" is meaningful only relative to an intended stronger property; supply it and behavior #1 already catches the violation, omit it and the judgment requires an external oracle (LLM), not a decidable check. Already documented in `nf-benchmark/docs/DETECTION-INFEASIBLE-FORMAL.md`.
+- **Code-concurrency set (BENCH-104 ABA, 048 semaphore-deadlock, 122 distributed-lock race, 031/191 test races, 152/178 shared-state races)** — sound static race/ABA detection on arbitrary JS reduces to aliasing + happens-before over a Turing-complete language (Rice's theorem); any sound approximation either explodes FP rate or needs user annotations (re-introducing the oracle). Shipping it would collapse the signal-vs-noise 0-baseline invariant.
+
+**Rejected candidate #4s** (claude-minimax): refinement/simulation checking, action-precondition reachability, init-predicate satisfiability, hyperproperty/non-interference, SANY/operator-resolution errors — all subsumed by #1, oracle-dependent, or already separate lint passes.
+
+**Action:** Do NOT chase a phantom behavior #4. Document the boundary (this file + a note in the infeasibility doc). Higher-leverage next budget: sensitivity sweeps (SENS-01/02/03) or property-annotation coverage (ANNOT-01) — both uncovered — rather than a brittle FP-prone concurrency/oracle heuristic.

--- a/bin/nf-solve.cjs
+++ b/bin/nf-solve.cjs
@@ -4321,14 +4321,31 @@ function sweepSast() {
   }
 }
 
+// ── Behavioral formal detection: the FP-safe set is COMPLETE at three detectors ──
+// model_check (safety invariant-violation + liveness) and petri_check (structural
+// unreachable-marking) cover the decidable, false-positive-free behavioral classes:
+// safety, structural-reachability, and temporal. A 4-model quorum (2026-07-04,
+// unanimous) confirmed there is NO fourth decidable, FP-safe behavioral class to add.
+// Deliberately NOT built, because a sound detector is impossible without breaking the
+// 0-baseline invariant (any finding = a real defect) these layers depend on:
+//   - "weak invariant" (benchmark BENCH-188): oracle-dependent — "too weak" only has
+//     meaning vs an intended stronger property; supply it and model_check already
+//     catches the violation, omit it and you need an LLM oracle, not a decidable check.
+//   - code-level concurrency (race/ABA/deadlock in arbitrary JS): undecidable (Rice's
+//     theorem — aliasing + happens-before over a Turing-complete language); any
+//     approximation explodes the FP rate or needs annotations (the oracle again).
+// See .planning/quorum/debates/2026-07-04-behavior-4-formal-detection-boundary.md.
+
 // ── Model-check sweep (diagnostic) ───────────────────────────────────────────
 // Runs TLC on CONCRETE (no-CONSTANTS) TLA models with an auto-generated cfg to find
-// BEHAVIORAL safety defects — reachable invariant violations (e.g. a deadlock state
-// that a NoDeadlock invariant forbids) — that the static formal_lint sweep cannot
-// see because they only manifest during state-space exploration. Same external-
-// analyzer pattern as sweepSast/run-formal-verify. Fail-open: if tla2tools.jar is
-// absent the helper reports skipped, so residual is -1 (NOT a false 0). Baseline is
-// 0 on nForma's own concrete models, so any finding is a real reachable violation.
+// BEHAVIORAL defects — reachable invariant violations (e.g. a deadlock state that a
+// NoDeadlock invariant forbids) AND unsatisfiable liveness properties (a declared
+// temporal PROPERTY that fails under the model's own fairness) — that the static
+// formal_lint sweep cannot see because they only manifest during state-space
+// exploration. Same external-analyzer pattern as sweepSast/run-formal-verify.
+// Fail-open: if tla2tools.jar is absent the helper reports skipped, so residual is
+// -1 (NOT a false 0). Baseline is 0 on nForma's own concrete models, so any finding
+// is a real reachable violation.
 function sweepModelCheck() {
   try {
     // Check the SUT's own bin (SCRIPT_DIR), NOT ROOT — the scanned project may be a


### PR DESCRIPTION
## Summary

Documentation-only. Records the quorum-ratified boundary of nf-solve's behavioral formal detection.

After shipping three FP-safe behavioral detectors — **model_check** (reachable safety-invariant violation incl. deadlock, #305; + unsatisfiable liveness, #307) and **petri_check** (structural unreachable-marking, #306) — a 4-model quorum (unanimous, 3/3 valid voters) confirmed there is **no fourth decidable, FP-safe behavioral class** to add in this corpus.

Adds a boundary note above `sweepModelCheck` and records the debate. It explains why two tempting detectors are **deliberately not built**:

- **"weak invariant"** (BENCH-188) — oracle-dependent. "Too weak" only has meaning relative to an intended stronger property; supply it and model_check already catches the violation, omit it and you need an LLM oracle, not a decidable check.
- **code-level concurrency** (race/ABA/deadlock in arbitrary JS) — undecidable (Rice's theorem: aliasing + happens-before over a Turing-complete language). Any approximation explodes the false-positive rate or needs annotations.

Both would break the **0-baseline invariant** (any finding = a real defect) that makes these layers actionable without triage. This marks the point where progress is bounded by the framework's soundness boundary, not by more effort.

Debate: `.planning/quorum/debates/2026-07-04-behavior-4-formal-detection-boundary.md`. Companion doc: nForma-AI/nf-benchmark#23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)