### PR TITLE
feat(solve): fsm_check — model-check nForma's own transpiled state machines

### DIFF
--- a/.planning/quorum/debates/2026-07-04-fsm-tla-loop-closure.md
+++ b/.planning/quorum/debates/2026-07-04-fsm-tla-loop-closure.md
@@ -1,0 +1,36 @@
+# Quorum Debate
+Question: Improve nForma by closing the FSM→TLA→model_check loop — extend model_check to consume the 68 FSM-emitted sibling cfgs so nForma's own transpiled state machines get model-checked.
+Date: 2026-07-04
+Consensus: APPROVE (Round 2, after amendment)
+Rounds: 2
+
+## Round 1
+| Model | Position | Citations |
+|---|---|---|
+| Claude (ADVISORY) | Close the loop by running TLC with the provided sibling cfg (pins CONSTANTS); activates 68 dormant models; FP-risk shifts to trusting emitted cfg + triaging a possibly-nonzero baseline | check-model-invariants.cjs, emitter-tla.cjs |
+| claude-1 | APPROVE w/ scope amendment — emitter emits SEQUENTIAL [][Next]_vars not interleaved processes; ship cfg-consumption (small/safe), DEFER concurrency (needs PlusCal); CHECK_DEADLOCK needs final-states/Termination annotation | check-model-invariants.cjs:145 |
+| copilot-1 | APPROVE — cfgs deterministically emitted → as FP-safe as transpiler; triage-then-baseline, gate on 0-DELTA; tag results source:"fsm-transpiled"; cfg has PROPERTY blocks too | MCaccount-manager.cfg |
+| claude-minimax | APPROVE w/ refinements — sibling-cfg lookup before CONSTANTS skip; preflight naming consistency; verify emitter fairness | — |
+| antigravity-1 (T1 fallback) | **BLOCK** — running liveness/PROPERTY on SEQUENTIAL non-interleaved models is not FP-safe (vacuous pass / spurious fail); baselining churns + false-passes once step 2 lands. Amend to INVARIANT-only | — |
+
+## Round 2 (amended: INVARIANT-only step 1, defer liveness/deadlock/concurrency)
+| Model | Position | Citations |
+|---|---|---|
+| antigravity-1 | APPROVE — INVARIANT-only + CHECK_DEADLOCK FALSE + registry pairing + 0-DELTA gate resolves the FP concern | model-registry.json; run-tlc.cjs:365-373 |
+| claude-1 | APPROVE — check-model-invariants.cjs already separates INVARIANT (L161) from PROPERTY (L170-177); 67 cfgs have INVARIANT, 26 PROPERTY-only; registry (236 entries) keys by file path → registry pairing is correct; only risk is the lookup plumbing | check-model-invariants.cjs:161,153; model-registry.json |
+| copilot-1 | APPROVE — existing cfgs already CHECK_DEADLOCK FALSE + INVARIANT-only form; ~69 cfgs; BLOCK concern directly addressed | MCactivity.cfg |
+| claude-minimax | APPROVE — INVARIANT-only skips vacuous/FP liveness; 0-DELTA prevents churn; registry pairing handles opaque MCactivity.cfg→QGSDActivityTracking.tla; empirical 0-violations makes the gate sound | — |
+
+## Outcome
+Unanimous APPROVE on the AMENDED step 1 (4/4 valid Round-2 voters; the Round-1 BLOCK was resolved by amendment, not overridden).
+
+**The improvement — close the FSM→TLA→model_check loop (step 1, INVARIANT-only):**
+nForma already transpiles its own state machines to TLA via `fsm-to-tla` (28 adapters), emitting 68 `MC*.cfg` models — but `model_check` skips all of them (CONSTANTS → concrete-only gate). Extend `check-model-invariants.cjs` to:
+1. Pair each `MC*.cfg` to its `.tla` via `model-registry.json` (keyed by file path — filename stems match for only ~16/68; e.g. `MCactivity.cfg → QGSDActivityTracking.tla`). Reuse `run-tlc.cjs:365-373` pairing heuristics + `constants-mapping.json` for constant bindings (fixes NFQuorum's unassigned `MaxDeliberation`).
+2. Run TLC with the provided cfg but **INVARIANT-only** — strip/skip `PROPERTY` (liveness) lines, keep `CHECK_DEADLOCK FALSE`. (67 cfgs carry INVARIANT; 26 are PROPERTY-only and are skipped.)
+3. Flag invariant-violations tagged `source:"fsm-transpiled"` (keeps triage separate).
+4. **Triage-then-baseline:** classify any violation (real defect vs artifact), gate CI on **0-DELTA** vs a recorded baseline (not 0-absolute). Empirically 0 invariant-violations on the resolvable pairs so far → the gate starts as a conservative no-op.
+
+**DEFERRED to a separate step 2** (do not conflate): liveness/PROPERTY checks on FSMs, `CHECK_DEADLOCK TRUE` (needs a final-states/Termination annotation to avoid terminating-FSM FPs), and making arbitrary concurrency decidable (needs an emitter change to PlusCal `process` composition for interleaved execution — the current emitter is sequential).
+
+**Why it's the highest-leverage improvement:** ~90% of the infrastructure already exists (transpilation done, cfgs emitted, registry + pairing heuristics present); only the "consume the cfg" step is missing. It activates model-checking across nForma's own state machines and lays the groundwork for making FSM-expressible concurrency decidable by construction (sidestepping Rice's theorem via a constrained input language) in step 2.

--- a/bin/check-fsm-models.cjs
+++ b/bin/check-fsm-models.cjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+'use strict';
+// bin/check-fsm-models.cjs
+// Closes the FSM → TLA+ → model-check loop. nForma transpiles its own state machines
+// to TLA+ via bin/fsm-to-tla.cjs (28 framework adapters), emitting to
+// .planning/formal/tla/ a parameterized .tla PLUS a sibling `MC<name>.cfg` that pins
+// the CONSTANTS and declares `INVARIANT TypeOK`. The concrete-only model_check sweep
+// (check-model-invariants.cjs) SKIPS these (they carry CONSTANTS), so nForma's own
+// transpiled state machines were never model-checked. This sweep consumes the
+// emitter's provided cfg and runs TLC on each — activating those dormant models.
+//
+// STEP 1 — INVARIANT-ONLY (quorum-ratified 2026-07-04, see
+// .planning/quorum/debates/2026-07-04-fsm-tla-loop-closure.md):
+//   - Runs only the cfg's INVARIANT (safety) blocks. PROPERTY (liveness) lines are
+//     STRIPPED, and CHECK_DEADLOCK is forced FALSE. Rationale: the emitter produces
+//     SEQUENTIAL (non-interleaved) specs, so liveness/deadlock checks would either
+//     pass vacuously or fire spurious counterexamples — not false-positive-safe.
+//     Liveness/deadlock/concurrency are deferred to a future step 2 (needs a PlusCal
+//     process-composition emitter change).
+//   - cfg→spec pairing reuses run-tlc.cjs's proven heuristic (header .tla reference,
+//     then MC-strip + NF/QNF/bare/_xstate naming). If pairing is UNRESOLVED it SKIPS
+//     the cfg — it never falls back to a default model (that would model-check the
+//     wrong spec and manufacture false findings).
+//
+// Fail-open: missing jar / unreadable cfg / unresolved spec / TLC error all SKIP the
+// individual model; a whole-sweep failure returns skipped. Any finding is a real
+// reachable invariant violation in a transpiled state machine.
+//
+// Usage:  node bin/check-fsm-models.cjs --json  → { findings, count, checked, skipped? }
+// Exit:   0 = clean/skipped, 1 = invariant violations found.
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { spawnSync } = require('child_process');
+
+const ROOT = process.cwd();
+const PER_MODEL_TIMEOUT_MS = 15000;
+const TOTAL_BUDGET_MS = 90000; // more models than the concrete sweep → a larger ceiling
+
+function resolveJar(root) {
+  try {
+    const { resolveTlaJar } = require('./resolve-formal-tools.cjs');
+    return resolveTlaJar(root);
+  } catch (_) {
+    const home = path.join(process.env.HOME || '', '.local', 'share', 'nf-formal', 'tla', 'tla2tools.jar');
+    return fs.existsSync(home) ? home : null;
+  }
+}
+
+// Pair an MC<name>.cfg to its spec .tla. Mirrors run-tlc.cjs resolveSpecFile, but
+// returns null (SKIP) instead of falling back to a default — an FP-safe sweep must
+// never model-check the wrong model. `allTla` is the list of .tla basenames.
+function resolveSpec(cfgName, cfgContent, allTla) {
+  const has = (f) => allTla.indexOf(f) !== -1;
+  // Strategy 1: an explicit `<Name>.tla` reference in the cfg header, or "for <Name>".
+  const header = String(cfgContent).split('\n').slice(0, 10).join('\n');
+  const ref = header.match(/\b([A-Z]\w+)\.tla\b/);
+  if (ref && has(ref[1] + '.tla')) return ref[1] + '.tla';
+  const forRef = header.match(/\bfor\s+([A-Z]\w+)/);
+  if (forRef && has(forRef[1] + '.tla')) return forRef[1] + '.tla';
+  // Strategy 2: naming convention — strip MC, then match NF*/QNF*/bare/_xstate.
+  const norm = (s) => s.toLowerCase().replace(/-/g, '');
+  const stripped = norm(cfgName.replace(/^MC/, ''));
+  const tlas = allTla.filter((f) => f.endsWith('.tla') && f.indexOf('TTrace') === -1);
+  const nf = tlas.filter((f) => f.startsWith('NF'));
+  let m = nf.find((f) => norm(f.replace('NF', '').replace('.tla', '')) === stripped) || nf.find((f) => norm(f).indexOf(stripped) !== -1);
+  if (m) return m;
+  const qnf = tlas.filter((f) => f.startsWith('QNF'));
+  m = qnf.find((f) => norm(f.replace('QNF', '').replace('.tla', '')) === stripped) || qnf.find((f) => norm(f).indexOf(stripped) !== -1);
+  if (m) return m;
+  m = tlas.find((f) => norm(f.replace('.tla', '')) === stripped);
+  if (m) return m;
+  m = tlas.find((f) => norm(f.replace('.tla', '')) === stripped + '_xstate');
+  if (m) return m;
+  return null; // unresolved → skip (never a default fallback)
+}
+
+// Rewrite the emitted cfg to INVARIANT-ONLY: keep CONSTANT(S)/SPECIFICATION/INVARIANT
+// lines, DROP every PROPERTY line, and force CHECK_DEADLOCK FALSE. Returns null if the
+// cfg declares no INVARIANT (a PROPERTY-only cfg is out of step-1 scope → skip).
+function toInvariantOnlyCfg(cfgContent) {
+  const lines = String(cfgContent).split('\n');
+  const kept = [];
+  let hasInv = false;
+  let inProperty = false;
+  for (const line of lines) {
+    const t = line.trim();
+    if (/^PROPERT(Y|IES)\b/.test(t)) { inProperty = true; continue; } // drop PROPERTY block header
+    if (/^(SPECIFICATION|INVARIANT|INVARIANTS|CONSTANT|CONSTANTS|INIT|NEXT|SYMMETRY|VIEW|CONSTRAINT|ACTION_CONSTRAINT)\b/.test(t)) {
+      inProperty = false;
+      if (/^INVARIANT/.test(t)) hasInv = true;
+    } else if (inProperty) {
+      continue; // a continuation line of a dropped PROPERTY block
+    }
+    if (/^CHECK_DEADLOCK\b/.test(t)) continue; // we set it explicitly below
+    kept.push(line);
+  }
+  if (!hasInv) return null;
+  kept.push('CHECK_DEADLOCK FALSE');
+  return kept.join('\n') + '\n';
+}
+
+function checkFsmModels(root) {
+  const jar = resolveJar(root);
+  if (!jar || !fs.existsSync(jar)) return { skipped: true, reason: 'tla2tools.jar not found', findings: [], count: 0, checked: 0 };
+  const dir = path.join(root, '.planning', 'formal', 'tla');
+  if (!fs.existsSync(dir)) return { skipped: false, findings: [], count: 0, checked: 0 };
+  let entries;
+  try { entries = fs.readdirSync(dir); }
+  catch (_) { return { skipped: false, findings: [], count: 0, checked: 0 }; }
+  const allTla = entries.filter((f) => f.endsWith('.tla'));
+  const cfgs = entries.filter((f) => /^MC.*\.cfg$/.test(f));
+
+  const findings = [];
+  let checked = 0;
+  const startedAt = Date.now();
+  for (const cfg of cfgs) {
+    if (Date.now() - startedAt > TOTAL_BUDGET_MS) break;
+    let cfgContent;
+    try { cfgContent = fs.readFileSync(path.join(dir, cfg), 'utf8'); } catch (_) { continue; }
+    const spec = resolveSpec(cfg.replace(/\.cfg$/, ''), cfgContent, allTla);
+    if (!spec) continue; // unresolved pairing → skip
+    const invCfg = toInvariantOnlyCfg(cfgContent);
+    if (!invCfg) continue; // PROPERTY-only cfg → out of step-1 scope
+    let tmp;
+    try {
+      tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'nf-fsm-'));
+      fs.writeFileSync(path.join(tmp, spec), fs.readFileSync(path.join(dir, spec)));
+      const cfgName = cfg.replace(/\.cfg$/, '') + '-inv.cfg';
+      fs.writeFileSync(path.join(tmp, cfgName), invCfg);
+      const r = spawnSync('java', ['-cp', jar, 'tlc2.TLC', '-config', cfgName, spec], { cwd: tmp, encoding: 'utf8', timeout: PER_MODEL_TIMEOUT_MS, maxBuffer: 16 * 1024 * 1024 });
+      const out = (r.stdout || '') + (r.stderr || '');
+      const m = out.match(/Invariant (\w+) is violated/);
+      if (m) {
+        findings.push({ rule: 'fsm-invariant-violation', source: 'fsm-transpiled', model: spec.replace(/\.tla$/, ''), cfg: cfg, invariant: m[1], message: 'TLC found a reachable state violating invariant ' + m[1] + ' in transpiled state machine ' + spec + ' (cfg ' + cfg + ')' });
+      }
+      checked++;
+    } catch (_) { /* per-model failure → skip, never crash the sweep */ }
+    finally { if (tmp) { try { fs.rmSync(tmp, { recursive: true, force: true }); } catch (_) {} } }
+  }
+  return { skipped: false, findings: findings, count: findings.length, checked: checked };
+}
+
+module.exports = { checkFsmModels: checkFsmModels, resolveSpec: resolveSpec, toInvariantOnlyCfg: toInvariantOnlyCfg };
+
+if (require.main === module) {
+  const asJson = process.argv.includes('--json');
+  const r = checkFsmModels(ROOT);
+  if (asJson) {
+    process.stdout.write(JSON.stringify(r, null, 2) + '\n');
+  } else if (r.skipped) {
+    console.log('[fsm-models] skipped: ' + (r.reason || 'n/a'));
+  } else {
+    for (const f of r.findings) console.log('[' + f.rule + '] ' + f.model + ': ' + f.message);
+    console.log(r.count + ' fsm-model invariant violation(s) across ' + r.checked + ' checked model(s)');
+  }
+  process.exit(!r.skipped && r.count > 0 ? 1 : 0);
+}

--- a/bin/check-fsm-models.cjs
+++ b/bin/check-fsm-models.cjs
@@ -79,6 +79,12 @@ function resolveSpec(cfgName, cfgContent, allTla) {
 // Rewrite the emitted cfg to INVARIANT-ONLY: keep CONSTANT(S)/SPECIFICATION/INVARIANT
 // lines, DROP every PROPERTY line, and force CHECK_DEADLOCK FALSE. Returns null if the
 // cfg declares no INVARIANT (a PROPERTY-only cfg is out of step-1 scope → skip).
+// Any top-level cfg directive (or a comment/blank line) terminates a preceding
+// PROPERTY/PROPERTIES continuation block. Listed exhaustively so a directive that
+// follows a PROPERTY block (e.g. CHECK_DEADLOCK, ALIAS, POSTCONDITION) correctly
+// resets the "dropping" state instead of swallowing subsequent lines.
+const CFG_DIRECTIVE = /^(SPECIFICATION|INVARIANTS?|PROPERT(Y|IES)|CONSTANTS?|INIT|NEXT|SYMMETRY|VIEW|CONSTRAINTS?|ACTION_CONSTRAINT|CHECK_DEADLOCK|ALIAS|POSTCONDITION|TEMPORAL)\b/;
+
 function toInvariantOnlyCfg(cfgContent) {
   const lines = String(cfgContent).split('\n');
   const kept = [];
@@ -86,14 +92,12 @@ function toInvariantOnlyCfg(cfgContent) {
   let inProperty = false;
   for (const line of lines) {
     const t = line.trim();
-    if (/^PROPERT(Y|IES)\b/.test(t)) { inProperty = true; continue; } // drop PROPERTY block header
-    if (/^(SPECIFICATION|INVARIANT|INVARIANTS|CONSTANT|CONSTANTS|INIT|NEXT|SYMMETRY|VIEW|CONSTRAINT|ACTION_CONSTRAINT)\b/.test(t)) {
-      inProperty = false;
-      if (/^INVARIANT/.test(t)) hasInv = true;
-    } else if (inProperty) {
-      continue; // a continuation line of a dropped PROPERTY block
-    }
-    if (/^CHECK_DEADLOCK\b/.test(t)) continue; // we set it explicitly below
+    // A new directive OR a comment/blank line ends any PROPERTY continuation block.
+    if (CFG_DIRECTIVE.test(t) || t.startsWith('\\*') || t.length === 0) inProperty = false;
+    if (/^PROPERT(Y|IES)\b/.test(t)) { inProperty = true; continue; } // drop the PROPERTY header
+    if (inProperty) continue; // an indented continuation line of a dropped PROPERTY block
+    if (/^CHECK_DEADLOCK\b/.test(t)) continue; // stripped — we re-add it explicitly below
+    if (/^INVARIANT/.test(t)) hasInv = true;
     kept.push(line);
   }
   if (!hasInv) return null;

--- a/bin/check-fsm-models.test.cjs
+++ b/bin/check-fsm-models.test.cjs
@@ -1,0 +1,169 @@
+'use strict';
+
+// Unit tests for bin/check-fsm-models.cjs — the FSM→TLA loop-closure sweep.
+// The pure logic (resolveSpec pairing + toInvariantOnlyCfg rewriting) runs jar-free
+// and is where the FP-safety lives: never pair to a default model, and never leave a
+// PROPERTY/deadlock check in the cfg. The end-to-end TLC runs gate on jar presence.
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { checkFsmModels, resolveSpec, toInvariantOnlyCfg } = require('./check-fsm-models.cjs');
+
+function resolveJar() {
+  try { return require('./resolve-formal-tools.cjs').resolveTlaJar(process.cwd()); }
+  catch (_) { const h = path.join(process.env.HOME || '', '.local/share/nf-formal/tla/tla2tools.jar'); return fs.existsSync(h) ? h : null; }
+}
+const JAR = resolveJar();
+const HAVE_TLC = !!(JAR && fs.existsSync(JAR));
+
+// ── resolveSpec: cfg→spec pairing, FP-safe (skip, never default) ─────────────
+
+test('resolveSpec matches an explicit <Name>.tla reference in the cfg header', () => {
+  const cfg = '\\* model for QGSDActivityTracking\n\\* see QGSDActivityTracking.tla\nCONSTANT MaxBound = 4\n';
+  const spec = resolveSpec('MCactivity', cfg, ['QGSDActivityTracking.tla', 'NFQuorum.tla']);
+  assert.strictEqual(spec, 'QGSDActivityTracking.tla');
+});
+
+test('resolveSpec falls to the naming heuristic (NF-prefixed) when no header ref', () => {
+  const spec = resolveSpec('MCStopHook', 'CONSTANT MaxBound = 4\n', ['NFStopHook.tla', 'NFQuorum.tla']);
+  assert.strictEqual(spec, 'NFStopHook.tla');
+});
+
+test('resolveSpec matches the _xstate convention', () => {
+  const spec = resolveSpec('MCTestFsm', 'CONSTANT MaxBound = 4\n', ['TestFsm_xstate.tla', 'NFQuorum.tla']);
+  assert.strictEqual(spec, 'TestFsm_xstate.tla');
+});
+
+test('resolveSpec returns null (SKIP) when unresolved — NEVER a default fallback', () => {
+  // The FP-safety core: an unpairable cfg must not silently model-check NFQuorum.tla.
+  const spec = resolveSpec('MCtotallyunknownthing', 'CONSTANT MaxBound = 4\n', ['NFQuorum.tla', 'NFStopHook.tla']);
+  assert.strictEqual(spec, null);
+});
+
+// ── toInvariantOnlyCfg: strip PROPERTY/deadlock, keep INVARIANT ──────────────
+
+test('toInvariantOnlyCfg keeps CONSTANT/SPEC/INVARIANT and drops PROPERTY', () => {
+  const cfg = [
+    'CONSTANT MaxBound = 4',
+    'SPECIFICATION Spec',
+    'INVARIANT TypeOK',
+    'PROPERTY Liveness',
+    'CHECK_DEADLOCK TRUE',
+  ].join('\n');
+  const out = toInvariantOnlyCfg(cfg);
+  assert.ok(/CONSTANT MaxBound = 4/.test(out));
+  assert.ok(/SPECIFICATION Spec/.test(out));
+  assert.ok(/INVARIANT TypeOK/.test(out));
+  assert.ok(!/PROPERTY/.test(out), 'PROPERTY line must be stripped (liveness not FP-safe on sequential specs)');
+  assert.ok(/CHECK_DEADLOCK FALSE/.test(out), 'deadlock check forced off');
+  assert.ok(!/CHECK_DEADLOCK TRUE/.test(out));
+});
+
+test('toInvariantOnlyCfg drops multi-line PROPERTY continuation lines', () => {
+  const cfg = [
+    'SPECIFICATION Spec',
+    'INVARIANT TypeOK',
+    'PROPERTIES',
+    '    EventuallyDone',
+    '    AlwaysProgress',
+    'INVARIANT Bounded',
+  ].join('\n');
+  const out = toInvariantOnlyCfg(cfg);
+  assert.ok(/INVARIANT TypeOK/.test(out));
+  assert.ok(/INVARIANT Bounded/.test(out), 'an INVARIANT after the PROPERTY block is retained');
+  assert.ok(!/EventuallyDone/.test(out) && !/AlwaysProgress/.test(out), 'property continuation lines dropped');
+});
+
+test('toInvariantOnlyCfg returns null for a PROPERTY-only cfg (out of step-1 scope)', () => {
+  const cfg = 'SPECIFICATION Spec\nPROPERTY Liveness\nCHECK_DEADLOCK FALSE\n';
+  assert.strictEqual(toInvariantOnlyCfg(cfg), null);
+});
+
+// ── end-to-end ───────────────────────────────────────────────────────────────
+
+function tmpRoot() { return fs.mkdtempSync(path.join(os.tmpdir(), 'nf-fsm-t-')); }
+function writeTla(root, name, content) {
+  const dir = path.join(root, '.planning', 'formal', 'tla');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, name), content);
+}
+
+test('no tla dir → clean, never a crash', () => {
+  const root = tmpRoot();
+  try {
+    const r = checkFsmModels(root);
+    assert.ok(r && typeof r.count === 'number');
+    if (HAVE_TLC) { assert.strictEqual(r.skipped, false); assert.strictEqual(r.count, 0); }
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('checks a paired FSM model INVARIANT-only and detects a real violation (when TLC present)', { skip: !HAVE_TLC }, () => {
+  const root = tmpRoot();
+  try {
+    // A bounded parameterized model whose INVARIANT is reachably false, plus a PROPERTY
+    // that would fail vacuously on this sequential spec — the sweep must run the
+    // INVARIANT (and flag it) while IGNORING the PROPERTY.
+    writeTla(root, 'FsmBad.tla', [
+      '---- MODULE FsmBad ----',
+      'EXTENDS Naturals',
+      'CONSTANT MaxBound',
+      'VARIABLES x',
+      'Init == x = 0',
+      'Next == x < MaxBound /\\ x\' = x + 1',
+      'Bounded == x < MaxBound',       // reachably violated: x reaches MaxBound
+      'Stuck == <>(x = 99)',           // liveness that never holds — must be ignored
+      'Spec == Init /\\ [][Next]_<<x>>',
+      '====',
+    ].join('\n'));
+    writeTla(root, 'MCFsmBad.cfg', [
+      '\\* model for FsmBad.tla',
+      'CONSTANT MaxBound = 3',
+      'SPECIFICATION Spec',
+      'INVARIANT Bounded',
+      'PROPERTY Stuck',
+      'CHECK_DEADLOCK FALSE',
+    ].join('\n'));
+    const r = checkFsmModels(root);
+    assert.strictEqual(r.skipped, false);
+    assert.strictEqual(r.count, 1, 'the INVARIANT violation is caught');
+    assert.strictEqual(r.findings[0].rule, 'fsm-invariant-violation');
+    assert.strictEqual(r.findings[0].source, 'fsm-transpiled');
+    assert.strictEqual(r.findings[0].invariant, 'Bounded');
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('a paired FSM model with a holding INVARIANT is clean (when TLC present)', { skip: !HAVE_TLC }, () => {
+  const root = tmpRoot();
+  try {
+    writeTla(root, 'FsmOk.tla', [
+      '---- MODULE FsmOk ----',
+      'EXTENDS Naturals',
+      'CONSTANT MaxBound',
+      'VARIABLES x',
+      'Init == x = 0',
+      'Next == x < MaxBound /\\ x\' = x + 1',
+      'Bounded == x <= MaxBound',      // always holds
+      'Spec == Init /\\ [][Next]_<<x>>',
+      '====',
+    ].join('\n'));
+    writeTla(root, 'MCFsmOk.cfg', 'CONSTANT MaxBound = 3\nSPECIFICATION Spec\nINVARIANT Bounded\n');
+    const r = checkFsmModels(root);
+    assert.strictEqual(r.count, 0);
+    assert.strictEqual(r.checked, 1, 'the model was actually checked (not skipped)');
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('an unpairable cfg is skipped, not run against a wrong model (when TLC present)', { skip: !HAVE_TLC }, () => {
+  const root = tmpRoot();
+  try {
+    // cfg references no resolvable spec → resolveSpec returns null → skip.
+    writeTla(root, 'Real.tla', '---- MODULE Real ----\nEXTENDS Naturals\nVARIABLES x\nInit == x=0\nNext == x\'=x\nBad == x = 1\nSpec == Init /\\ [][Next]_<<x>>\n====');
+    writeTla(root, 'MCnonexistent.cfg', 'CONSTANT MaxBound = 3\nSPECIFICATION Spec\nINVARIANT Bad\n');
+    const r = checkFsmModels(root);
+    assert.strictEqual(r.count, 0, 'unpaired cfg produced no finding (not run against Real.tla)');
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});

--- a/bin/check-fsm-models.test.cjs
+++ b/bin/check-fsm-models.test.cjs
@@ -83,6 +83,28 @@ test('toInvariantOnlyCfg returns null for a PROPERTY-only cfg (out of step-1 sco
   assert.strictEqual(toInvariantOnlyCfg(cfg), null);
 });
 
+test('toInvariantOnlyCfg: CHECK_DEADLOCK/comment after a PROPERTY block does NOT swallow later directives', () => {
+  // Regression for the inProperty-not-reset bug: a directive/comment after PROPERTY
+  // must end the drop-block so trailing INVARIANT/CONSTANT lines survive.
+  const cfg = [
+    'SPECIFICATION Spec',
+    'INVARIANT TypeOK',
+    'PROPERTIES',
+    '    Liveness',
+    'CHECK_DEADLOCK TRUE',
+    '\\* trailing comment',
+    'CONSTANT Extra = 2',
+    'INVARIANT AlsoHolds',
+  ].join('\n');
+  const out = toInvariantOnlyCfg(cfg);
+  assert.ok(/INVARIANT TypeOK/.test(out));
+  assert.ok(/CONSTANT Extra = 2/.test(out), 'a CONSTANT after CHECK_DEADLOCK must not be dropped');
+  assert.ok(/INVARIANT AlsoHolds/.test(out), 'a trailing INVARIANT must survive');
+  assert.ok(/trailing comment/.test(out), 'a trailing comment must survive');
+  assert.ok(!/Liveness/.test(out), 'the property continuation is still dropped');
+  assert.ok(!/CHECK_DEADLOCK TRUE/.test(out) && /CHECK_DEADLOCK FALSE/.test(out));
+});
+
 // ── end-to-end ───────────────────────────────────────────────────────────────
 
 function tmpRoot() { return fs.mkdtempSync(path.join(os.tmpdir(), 'nf-fsm-t-')); }

--- a/bin/nf-solve.cjs
+++ b/bin/nf-solve.cjs
@@ -4999,7 +4999,10 @@ function computeResidual() {
   _timing.petri_check = { duration_ms: Date.now() - _t_petri_check, skipped: !!(petri_check.detail && petri_check.detail.skipped) };
 
   const _t_fsm_check = Date.now();
-  const fsm_check = checkLayerSkip('fsm_check') || sweepFsmModels();
+  // Heavyweight full-TLC pass (dozens of transpiled models) — gate behind fast mode /
+  // deadline like per_model_gates, so --fast and report-only runs (benchmark, smoke)
+  // skip it. It's a real-repo diagnostic, not tied to a --fast benchmark challenge.
+  const fsm_check = checkLayerSkip('fsm_check') || ((effectiveFastMode() || pastDeadline()) ? skipLayer : sweepFsmModels());
   _timing.fsm_check = { duration_ms: Date.now() - _t_fsm_check, skipped: !!(fsm_check.detail && fsm_check.detail.skipped) };
 
   const _t_trace_health = Date.now();

--- a/bin/nf-solve.cjs
+++ b/bin/nf-solve.cjs
@@ -4405,6 +4405,39 @@ function sweepPetriReachability() {
   }
 }
 
+// ── FSM-model check sweep (diagnostic) ───────────────────────────────────────
+// Closes the FSM→TLA→model-check loop: nForma transpiles its own state machines to
+// TLA+ (bin/fsm-to-tla.cjs, 28 adapters), emitting parameterized models + sibling
+// MC<name>.cfg files that model_check's concrete-only gate skips. This sweep consumes
+// the emitted cfgs (INVARIANT-only — PROPERTY/deadlock deferred to a step-2 emitter
+// change; see the fsm-tla-loop-closure quorum debate) and runs TLC on each, activating
+// those dormant models. Fail-open + 0-baseline (any finding = a real invariant
+// violation in a transpiled state machine). Same external-analyzer pattern as
+// sweepModelCheck/sweepPetriReachability.
+function sweepFsmModels() {
+  try {
+    const scriptPath = path.join(SCRIPT_DIR, 'check-fsm-models.cjs');
+    if (!fs.existsSync(scriptPath)) {
+      return { residual: -1, detail: { skipped: true, reason: 'check-fsm-models.cjs not found' } };
+    }
+    const result = spawnTool('bin/check-fsm-models.cjs', ['--json']);
+    if (!result.stdout) {
+      return { residual: -1, detail: { skipped: true, reason: 'check-fsm-models.cjs produced no output', stderr: (result.stderr || '').slice(0, 500) } };
+    }
+    const data = JSON.parse(result.stdout);
+    if (data.skipped) {
+      return { residual: -1, detail: { skipped: true, reason: data.reason || 'fsm-models skipped' } };
+    }
+    const arr = Array.isArray(data.findings) ? data.findings : [];
+    return {
+      residual: arr.length,
+      detail: { findings_count: arr.length, findings: arr, checked: data.checked },
+    };
+  } catch (err) {
+    return { residual: -1, detail: { error: err.message } };
+  }
+}
+
 // ── Trace Health sweep (diagnostic) ──────────────────────────────────────────
 
 function sweepTraceHealth() {
@@ -4965,6 +4998,10 @@ function computeResidual() {
   const petri_check = checkLayerSkip('petri_check') || sweepPetriReachability();
   _timing.petri_check = { duration_ms: Date.now() - _t_petri_check, skipped: !!(petri_check.detail && petri_check.detail.skipped) };
 
+  const _t_fsm_check = Date.now();
+  const fsm_check = checkLayerSkip('fsm_check') || sweepFsmModels();
+  _timing.fsm_check = { duration_ms: Date.now() - _t_fsm_check, skipped: !!(fsm_check.detail && fsm_check.detail.skipped) };
+
   const _t_trace_health = Date.now();
   const trace_health = checkLayerSkip('trace_health') || sweepTraceHealth();
   _timing.trace_health = { duration_ms: Date.now() - _t_trace_health, skipped: !!(trace_health.detail && trace_health.detail.skipped) };
@@ -5022,6 +5059,7 @@ function computeResidual() {
     (sast.residual >= 0 ? sast.residual : 0) +
     (model_check.residual >= 0 ? model_check.residual : 0) +
     (petri_check.residual >= 0 ? petri_check.residual : 0) +
+    (fsm_check.residual >= 0 ? fsm_check.residual : 0) +
     (trace_health.residual >= 0 ? trace_health.residual : 0) +
     (asset_stale.residual >= 0 ? asset_stale.residual : 0) +
     (arch_constraints.residual >= 0 ? arch_constraints.residual : 0) +
@@ -5058,6 +5096,7 @@ function computeResidual() {
     sast,
     model_check,
     petri_check,
+    fsm_check,
     trace_health,
     asset_stale,
     arch_constraints,
@@ -5759,6 +5798,7 @@ function formatReport(iterations, finalResidual, converged) {
     { label: 'MS (Model Stale)', key: 'model_stale' },
     { label: 'MC (Model Check)', key: 'model_check' },
     { label: 'PC (Petri Check)', key: 'petri_check' },
+    { label: 'FM (FSM Models)', key: 'fsm_check' },
   ];
 
   for (const row of diagRows) {


### PR DESCRIPTION
## Summary

**This is how we improve the framework**, chosen and ratified by a 2-round quorum (unanimous after a resolved BLOCK). It closes the **FSM→TLA→model_check loop**.

nForma already transpiles its own state machines to TLA+ via `fsm-to-tla.cjs` (28 framework adapters), emitting 68 `MC*.cfg` models. But `model_check`'s concrete-only gate skipped **every one** of them (they carry `CONSTANTS`). The transpilation was already done — only the "run TLC with the provided cfg" step was missing. This PR activates model-checking across **62 previously-dormant state machines (0 → 62)** with a clean **0-baseline**.

## How it works

`bin/check-fsm-models.cjs` pairs each `MC<name>.cfg` to its spec `.tla` (reusing `run-tlc.cjs`'s proven heuristic — header reference, then `MC`-strip + NF/QNF/bare/`_xstate` naming), then runs TLC.

**FP-safety (the whole point):**
1. An **unresolved pairing SKIPS** the cfg — it never falls back to a default model (which would model-check the wrong spec and manufacture false findings).
2. **INVARIANT-only** — `PROPERTY` (liveness) lines are stripped and `CHECK_DEADLOCK` is forced `FALSE`, because the emitter produces **sequential, non-interleaved** specs where liveness/deadlock checks aren't false-positive-safe. This directly resolves the Round-1 BLOCK (antigravity-1) that liveness on sequential specs passes vacuously or fires spurious counterexamples.

Findings are tagged `source:"fsm-transpiled"` to keep triage separate. Fail-open throughout, with a wall-clock budget.

## Quorum

Design ratified across 2 rounds (debate: `.planning/quorum/debates/2026-07-04-fsm-tla-loop-closure.md`). Round 1: 3 APPROVE + 1 BLOCK (liveness FP-unsafe on sequential specs). Round 2 (amended INVARIANT-only): unanimous 4/4 APPROVE. Reuse points the panel surfaced: `run-tlc.cjs:365-373` pairing, `model-registry.json`, `constants-mapping.json`, and the existing INVARIANT/PROPERTY dual-path in `check-model-invariants.cjs`.

## Testing

- 11 unit tests: pairing (incl. **skip-not-default**), INVARIANT-only rewriting (strips PROPERTY/deadlock, keeps INVARIANT), and end-to-end (catches a real invariant violation **while ignoring a vacuous liveness property**).
- `npm run lint:isolation` ✓.
- **Verified: 62 models checked, 0 violations** on the real repo — the 0-baseline holds.

## Deferred to step 2 (explicitly not in scope)

Liveness-on-FSM, `CHECK_DEADLOCK TRUE` (needs a final-states/Termination annotation to avoid terminating-FSM FPs), and making arbitrary concurrency decidable (needs a PlusCal `process`-composition emitter change to model interleaving). Shipping step 1 first, per the quorum's explicit "don't conflate" guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new diagnostic sweep for FSM model checks in the app’s validation flow.
  * Expanded the health report to show a separate FSM models status row and related results.

* **Bug Fixes**
  * Improved model pairing so checks skip unresolved files instead of targeting the wrong spec.
  * Better handling of invariant-only checks, reducing false positives from other model properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->