### PR TITLE
feat(solve): fsm_check liveness — dual-gated temporal checks on transpiled FSMs

### DIFF
--- a/bin/check-fsm-models.cjs
+++ b/bin/check-fsm-models.cjs
@@ -9,14 +9,19 @@
 // transpiled state machines were never model-checked. This sweep consumes the
 // emitter's provided cfg and runs TLC on each — activating those dormant models.
 //
-// STEP 1 — INVARIANT-ONLY (quorum-ratified 2026-07-04, see
-// .planning/quorum/debates/2026-07-04-fsm-tla-loop-closure.md):
-//   - Runs only the cfg's INVARIANT (safety) blocks. PROPERTY (liveness) lines are
-//     STRIPPED, and CHECK_DEADLOCK is forced FALSE. Rationale: the emitter produces
-//     SEQUENTIAL (non-interleaved) specs, so liveness/deadlock checks would either
-//     pass vacuously or fire spurious counterexamples — not false-positive-safe.
-//     Liveness/deadlock/concurrency are deferred to a future step 2 (needs a PlusCal
-//     process-composition emitter change).
+// Safety (INVARIANT) runs on every paired model. Liveness (PROPERTY) runs ONLY under
+// the behavior-#3 dual gate — the cfg declares a PROPERTY AND the spec carries
+// fairness (WF_/SF_) — see .planning/quorum/debates/2026-07-04-fsm-tla-loop-closure.md:
+//   - Safety: cfg's INVARIANT blocks, PROPERTY stripped, CHECK_DEADLOCK FALSE. This is
+//     FP-safe on the emitter's SEQUENTIAL specs (a reachable INVARIANT violation is
+//     genuine regardless of interleaving).
+//   - Liveness: cfg's PROPERTY blocks, INVARIANT stripped, CHECK_DEADLOCK FALSE, run
+//     ONLY when the spec declares fairness. Without fairness a `<>P` fails vacuously
+//     via stuttering — the exact false-positive class the FSM-loop Round-1 BLOCK
+//     flagged; the fairness gate eliminates it (verified 0 violations / 21 fair
+//     models). Deadlock-checking and multi-process concurrency remain deferred (they
+//     need an emitter Termination annotation / PlusCal process composition — naive
+//     CHECK_DEADLOCK false-positives on legitimately-terminating FSMs).
 //   - cfg→spec pairing reuses run-tlc.cjs's proven heuristic (header .tla reference,
 //     then MC-strip + NF/QNF/bare/_xstate naming). If pairing is UNRESOLVED it SKIPS
 //     the cfg — it never falls back to a default model (that would model-check the
@@ -105,6 +110,36 @@ function toInvariantOnlyCfg(cfgContent) {
   return kept.join('\n') + '\n';
 }
 
+// Build a LIVENESS cfg: keep SPECIFICATION / CONSTANT(S) / PROPERTY, DROP INVARIANT
+// (isolate the temporal signal), force CHECK_DEADLOCK FALSE. Returns null if the cfg
+// declares no PROPERTY. Only used under the dual gate (spec must also carry fairness).
+function toLivenessCfg(cfgContent) {
+  const lines = String(cfgContent).split('\n');
+  const kept = [];
+  let hasProp = false;
+  let inInvariant = false;
+  for (const line of lines) {
+    const t = line.trim();
+    if (CFG_DIRECTIVE.test(t) || t.startsWith('\\*') || t.length === 0) inInvariant = false;
+    if (/^INVARIANTS?\b/.test(t)) { inInvariant = true; continue; } // drop INVARIANT header
+    if (inInvariant) continue; // continuation of a dropped INVARIANT block
+    if (/^CHECK_DEADLOCK\b/.test(t)) continue;
+    if (/^PROPERT(Y|IES)\b/.test(t)) hasProp = true;
+    kept.push(line);
+  }
+  if (!hasProp) return null;
+  kept.push('CHECK_DEADLOCK FALSE');
+  return kept.join('\n') + '\n';
+}
+
+// The liveness dual gate (behavior #3): a temporal PROPERTY is only checkable when the
+// spec declares fairness. Without WF_/SF_ the system may stutter forever, so every
+// `<>P` fails vacuously — not false-positive-safe. This is exactly the restriction
+// that resolved the FSM-loop Round-1 BLOCK (no liveness on unfair sequential specs).
+function specHasFairness(specContent) {
+  return /\bWF_|\bSF_/.test(String(specContent));
+}
+
 function checkFsmModels(root) {
   const jar = resolveJar(root);
   if (!jar || !fs.existsSync(jar)) return { skipped: true, reason: 'tla2tools.jar not found', findings: [], count: 0, checked: 0 };
@@ -126,18 +161,36 @@ function checkFsmModels(root) {
     const spec = resolveSpec(cfg.replace(/\.cfg$/, ''), cfgContent, allTla);
     if (!spec) continue; // unresolved pairing → skip
     const invCfg = toInvariantOnlyCfg(cfgContent);
-    if (!invCfg) continue; // PROPERTY-only cfg → out of step-1 scope
+    // Liveness is dual-gated (behavior #3): cfg has a PROPERTY AND the spec carries
+    // fairness. Both must hold, or we don't emit a liveness check at all.
+    let specContent = null;
+    try { specContent = fs.readFileSync(path.join(dir, spec), 'utf8'); } catch (_) { continue; }
+    const liveCfg = specHasFairness(specContent) ? toLivenessCfg(cfgContent) : null;
+    if (!invCfg && !liveCfg) continue; // nothing checkable in step-1/2 scope
     let tmp;
     try {
       tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'nf-fsm-'));
-      fs.writeFileSync(path.join(tmp, spec), fs.readFileSync(path.join(dir, spec)));
-      const cfgName = cfg.replace(/\.cfg$/, '') + '-inv.cfg';
-      fs.writeFileSync(path.join(tmp, cfgName), invCfg);
-      const r = spawnSync('java', ['-cp', jar, 'tlc2.TLC', '-config', cfgName, spec], { cwd: tmp, encoding: 'utf8', timeout: PER_MODEL_TIMEOUT_MS, maxBuffer: 16 * 1024 * 1024 });
-      const out = (r.stdout || '') + (r.stderr || '');
-      const m = out.match(/Invariant (\w+) is violated/);
-      if (m) {
-        findings.push({ rule: 'fsm-invariant-violation', source: 'fsm-transpiled', model: spec.replace(/\.tla$/, ''), cfg: cfg, invariant: m[1], message: 'TLC found a reachable state violating invariant ' + m[1] + ' in transpiled state machine ' + spec + ' (cfg ' + cfg + ')' });
+      fs.writeFileSync(path.join(tmp, spec), specContent);
+      const base = cfg.replace(/\.cfg$/, '');
+      if (invCfg) {
+        const cfgName = base + '-inv.cfg';
+        fs.writeFileSync(path.join(tmp, cfgName), invCfg);
+        const r = spawnSync('java', ['-cp', jar, 'tlc2.TLC', '-config', cfgName, spec], { cwd: tmp, encoding: 'utf8', timeout: PER_MODEL_TIMEOUT_MS, maxBuffer: 16 * 1024 * 1024 });
+        const out = (r.stdout || '') + (r.stderr || '');
+        const m = out.match(/Invariant (\w+) is violated/);
+        if (m) {
+          findings.push({ rule: 'fsm-invariant-violation', source: 'fsm-transpiled', model: spec.replace(/\.tla$/, ''), cfg: cfg, invariant: m[1], message: 'TLC found a reachable state violating invariant ' + m[1] + ' in transpiled state machine ' + spec + ' (cfg ' + cfg + ')' });
+        }
+      }
+      if (liveCfg) {
+        const cfgName = base + '-live.cfg';
+        fs.writeFileSync(path.join(tmp, cfgName), liveCfg);
+        // -workers 1: TLC's older liveness checker has known multi-worker bugs (see run-tlc.cjs).
+        const r = spawnSync('java', ['-cp', jar, 'tlc2.TLC', '-config', cfgName, spec, '-workers', '1'], { cwd: tmp, encoding: 'utf8', timeout: PER_MODEL_TIMEOUT_MS, maxBuffer: 16 * 1024 * 1024 });
+        const out = (r.stdout || '') + (r.stderr || '');
+        if (/Temporal properties were violated/.test(out)) {
+          findings.push({ rule: 'fsm-liveness-violation', source: 'fsm-transpiled', model: spec.replace(/\.tla$/, ''), cfg: cfg, message: 'TLC found a declared liveness property unsatisfiable under the model\'s own fairness in transpiled state machine ' + spec + ' (cfg ' + cfg + ')' });
+        }
       }
       checked++;
     } catch (_) { /* per-model failure → skip, never crash the sweep */ }
@@ -146,7 +199,7 @@ function checkFsmModels(root) {
   return { skipped: false, findings: findings, count: findings.length, checked: checked };
 }
 
-module.exports = { checkFsmModels: checkFsmModels, resolveSpec: resolveSpec, toInvariantOnlyCfg: toInvariantOnlyCfg };
+module.exports = { checkFsmModels: checkFsmModels, resolveSpec: resolveSpec, toInvariantOnlyCfg: toInvariantOnlyCfg, toLivenessCfg: toLivenessCfg, specHasFairness: specHasFairness };
 
 if (require.main === module) {
   const asJson = process.argv.includes('--json');

--- a/bin/check-fsm-models.cjs
+++ b/bin/check-fsm-models.cjs
@@ -185,8 +185,10 @@ function checkFsmModels(root) {
       if (liveCfg) {
         const cfgName = base + '-live.cfg';
         fs.writeFileSync(path.join(tmp, cfgName), liveCfg);
-        // -workers 1: TLC's older liveness checker has known multi-worker bugs (see run-tlc.cjs).
-        const r = spawnSync('java', ['-cp', jar, 'tlc2.TLC', '-config', cfgName, spec, '-workers', '1'], { cwd: tmp, encoding: 'utf8', timeout: PER_MODEL_TIMEOUT_MS, maxBuffer: 16 * 1024 * 1024 });
+        // -workers 1: TLC's older liveness checker has known multi-worker bugs (see
+        // run-tlc.cjs). Options BEFORE the spec positional — TLC wants the spec module
+        // last, so a trailing flag is fragile across versions.
+        const r = spawnSync('java', ['-cp', jar, 'tlc2.TLC', '-workers', '1', '-config', cfgName, spec], { cwd: tmp, encoding: 'utf8', timeout: PER_MODEL_TIMEOUT_MS, maxBuffer: 16 * 1024 * 1024 });
         const out = (r.stdout || '') + (r.stderr || '');
         if (/Temporal properties were violated/.test(out)) {
           findings.push({ rule: 'fsm-liveness-violation', source: 'fsm-transpiled', model: spec.replace(/\.tla$/, ''), cfg: cfg, message: 'TLC found a declared liveness property unsatisfiable under the model\'s own fairness in transpiled state machine ' + spec + ' (cfg ' + cfg + ')' });

--- a/bin/check-fsm-models.test.cjs
+++ b/bin/check-fsm-models.test.cjs
@@ -11,7 +11,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const { checkFsmModels, resolveSpec, toInvariantOnlyCfg } = require('./check-fsm-models.cjs');
+const { checkFsmModels, resolveSpec, toInvariantOnlyCfg, toLivenessCfg, specHasFairness } = require('./check-fsm-models.cjs');
 
 function resolveJar() {
   try { return require('./resolve-formal-tools.cjs').resolveTlaJar(process.cwd()); }
@@ -105,6 +105,28 @@ test('toInvariantOnlyCfg: CHECK_DEADLOCK/comment after a PROPERTY block does NOT
   assert.ok(!/CHECK_DEADLOCK TRUE/.test(out) && /CHECK_DEADLOCK FALSE/.test(out));
 });
 
+// ── toLivenessCfg + specHasFairness (behavior-#3 dual gate) ──────────────────
+
+test('toLivenessCfg keeps PROPERTY/CONSTANT/SPEC, drops INVARIANT', () => {
+  const cfg = 'CONSTANT MaxBound = 4\nSPECIFICATION Spec\nINVARIANT TypeOK\nPROPERTY EventuallyDone\n';
+  const out = toLivenessCfg(cfg);
+  assert.ok(/PROPERTY EventuallyDone/.test(out));
+  assert.ok(/CONSTANT MaxBound = 4/.test(out));
+  assert.ok(/SPECIFICATION Spec/.test(out));
+  assert.ok(!/INVARIANT TypeOK/.test(out), 'INVARIANT is stripped to isolate the temporal signal');
+  assert.ok(/CHECK_DEADLOCK FALSE/.test(out));
+});
+
+test('toLivenessCfg returns null when there is no PROPERTY', () => {
+  assert.strictEqual(toLivenessCfg('SPECIFICATION Spec\nINVARIANT TypeOK\n'), null);
+});
+
+test('specHasFairness detects WF_/SF_ and rejects specs without them', () => {
+  assert.strictEqual(specHasFairness('Spec == Init /\\ [][Next]_vars /\\ WF_vars(Next)'), true);
+  assert.strictEqual(specHasFairness('Spec == Init /\\ [][Next]_vars /\\ SF_x(A)'), true);
+  assert.strictEqual(specHasFairness('Spec == Init /\\ [][Next]_vars'), false);
+});
+
 // ── end-to-end ───────────────────────────────────────────────────────────────
 
 function tmpRoot() { return fs.mkdtempSync(path.join(os.tmpdir(), 'nf-fsm-t-')); }
@@ -176,6 +198,64 @@ test('a paired FSM model with a holding INVARIANT is clean (when TLC present)', 
     const r = checkFsmModels(root);
     assert.strictEqual(r.count, 0);
     assert.strictEqual(r.checked, 1, 'the model was actually checked (not skipped)');
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('detects an unsatisfiable liveness property on a fairness-carrying FSM (when TLC present)', { skip: !HAVE_TLC }, () => {
+  const root = tmpRoot();
+  try {
+    // WF_ fairness drives x up to 2 and holds; the property claims x eventually-always
+    // returns to 0 — unsatisfiable. The cfg carries both INVARIANT and PROPERTY.
+    writeTla(root, 'FsmLive.tla', [
+      '---- MODULE FsmLive ----',
+      'EXTENDS Naturals',
+      'CONSTANT MaxBound',
+      'VARIABLES x',
+      'Init == x = 0',
+      'Inc == x < MaxBound /\\ x\' = x + 1',
+      'Stay == x = MaxBound /\\ x\' = MaxBound',
+      'Next == Inc \\/ Stay',
+      'Bounded == x <= MaxBound',
+      'BackToZero == <>[](x = 0)',
+      'Spec == Init /\\ [][Next]_<<x>> /\\ WF_x(Inc)',
+      '====',
+    ].join('\n'));
+    writeTla(root, 'MCFsmLive.cfg', [
+      '\\* model for FsmLive.tla',
+      'CONSTANT MaxBound = 2',
+      'SPECIFICATION Spec',
+      'INVARIANT Bounded',
+      'PROPERTY BackToZero',
+    ].join('\n'));
+    const r = checkFsmModels(root);
+    const rules = new Set(r.findings.map(f => f.rule));
+    assert.ok(rules.has('fsm-liveness-violation'), 'the unsatisfiable liveness property is flagged');
+    assert.ok(!rules.has('fsm-invariant-violation'), 'the INVARIANT holds → not flagged');
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('the liveness dual gate: an unsatisfiable property WITHOUT fairness is NOT flagged (when TLC present)', { skip: !HAVE_TLC }, () => {
+  const root = tmpRoot();
+  try {
+    // Same property, but the Spec drops WF_x(Inc). No fairness → liveness gate closed
+    // → no liveness finding (the stuttering-FP class the Round-1 BLOCK flagged).
+    writeTla(root, 'FsmUnfair.tla', [
+      '---- MODULE FsmUnfair ----',
+      'EXTENDS Naturals',
+      'CONSTANT MaxBound',
+      'VARIABLES x',
+      'Init == x = 0',
+      'Inc == x < MaxBound /\\ x\' = x + 1',
+      'Stay == x = MaxBound /\\ x\' = MaxBound',
+      'Next == Inc \\/ Stay',
+      'Bounded == x <= MaxBound',
+      'BackToZero == <>[](x = 0)',
+      'Spec == Init /\\ [][Next]_<<x>>',
+      '====',
+    ].join('\n'));
+    writeTla(root, 'MCFsmUnfair.cfg', 'CONSTANT MaxBound = 2\nSPECIFICATION Spec\nINVARIANT Bounded\nPROPERTY BackToZero\n');
+    const r = checkFsmModels(root);
+    assert.ok(!r.findings.some(f => f.rule === 'fsm-liveness-violation'), 'no fairness → liveness not checked → no finding');
   } finally { fs.rmSync(root, { recursive: true, force: true }); }
 });
 


### PR DESCRIPTION
## Summary

Step 2 of the FSM→TLA loop (following #309). Extends `fsm_check` to run TLC **liveness (PROPERTY)** checks on nForma's transpiled state machines — under the behavior-#3 **dual gate**: only when the cfg declares a `PROPERTY` **AND** the resolved spec carries fairness (`WF_`/`SF_`).

This is precisely the restriction that resolved the FSM-loop Round-1 BLOCK: without fairness a `<>P` fails vacuously via stuttering, so the fairness gate eliminates that entire false-positive class. It **activates liveness checking across 21 of nForma's own fairness-carrying state machines** — verified **0 violations** (the 0-baseline holds).

## How it works

- `toLivenessCfg` keeps `SPECIFICATION`/`CONSTANT`/`PROPERTY`, strips `INVARIANT` (isolates the temporal signal), forces `CHECK_DEADLOCK FALSE`. `specHasFairness` gates on `WF_`/`SF_`.
- Liveness runs with `-workers 1` (older TLC liveness has known multi-worker bugs, per `run-tlc.cjs`), reusing the spec already copied for the INVARIANT run.
- Flags `Temporal properties were violated` as `fsm-liveness-violation` (distinct from `fsm-invariant-violation`), tagged `source:"fsm-transpiled"`.

## Testing

- 17 tests total (+5): `toLivenessCfg` rewriting, the `specHasFairness` gate, end-to-end detection of an unsatisfiable liveness property on a fairness-carrying FSM, and the **dual-gate FP guard** (same property with **no** fairness → **not** flagged).
- `npm run lint:isolation` ✓; **62 models checked, 0 violations** on the real repo.

## Why deadlock is still deferred (empirical)

I probed naive `CHECK_DEADLOCK TRUE`: **26 of 62 models "deadlock"** — but triage shows these are **legitimate terminal states**, not defects (e.g. `BugModelLookup` reaching `phase="done"`, which even has a *satisfied* `<>(phase="done")` under fairness). Shipping naive deadlock detection would break the 0-baseline invariant. FP-safe deadlock detection needs an emitter **Termination-disjunct** annotation (so reaching a declared final state isn't a deadlock) — deferred. Multi-process concurrency (semaphore/lock races) still needs PlusCal `process` composition — deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added liveness checking alongside existing model validation when the specification includes fairness and the configuration includes a property.
  * Generates a dedicated liveness-focused configuration automatically and runs the additional check only when appropriate.

* **Bug Fixes**
  * Prevents unnecessary liveness runs when fairness or a property is missing.
  * Improves reporting so liveness violations are captured separately from invariant issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->