### PR TITLE
docs(solve): record why FSM deadlock/concurrency detection is deferred

### DIFF
--- a/.planning/quorum/debates/2026-07-04-fsm-tla-loop-closure.md
+++ b/.planning/quorum/debates/2026-07-04-fsm-tla-loop-closure.md
@@ -34,3 +34,34 @@ nForma already transpiles its own state machines to TLA via `fsm-to-tla` (28 ada
 **DEFERRED to a separate step 2** (do not conflate): liveness/PROPERTY checks on FSMs, `CHECK_DEADLOCK TRUE` (needs a final-states/Termination annotation to avoid terminating-FSM FPs), and making arbitrary concurrency decidable (needs an emitter change to PlusCal `process` composition for interleaved execution — the current emitter is sequential).
 
 **Why it's the highest-leverage improvement:** ~90% of the infrastructure already exists (transpilation done, cfgs emitted, registry + pairing heuristics present); only the "consume the cfg" step is missing. It activates model-checking across nForma's own state machines and lays the groundwork for making FSM-expressible concurrency decidable by construction (sidestepping Rice's theorem via a constrained input language) in step 2.
+
+## Step 2 outcome + deadlock/concurrency boundary (empirical, post-implementation)
+
+Shipped: FSM invariant checking (#309, 62 models) and FSM liveness under the fairness
+dual gate (#310, 21 fairness-carrying models) — both 0-baseline, FP-safe.
+
+**Deadlock detection — NOT shipped (empirically not FP-safe on this corpus):**
+- Naive `CHECK_DEADLOCK TRUE` fires on **26 of 62** models. Triage: these are
+  LEGITIMATE terminal states, not defects (e.g. BugModelLookup reaching `phase="done"`,
+  which even satisfies its own `<>(phase="done")` under `WF_` fairness).
+- The corpus is HETEROGENEOUS: the deadlocking models are handwritten (QGSDEnforcement)
+  or code-scan-derived (`formal-scope-scan.cjs` → BugModelLookup/NFDispatch), NOT
+  fsm-to-tla emitter output — so there is no single emitter to fix, and they carry no
+  machine-readable terminal annotation.
+- No FP-safe heuristic separates "stuck" from "done": splitting on "declares a `<>`
+  goal" gives 14 with / 12 without, but a spec can legitimately terminate without
+  declaring a liveness goal, so the 12 are not reliably defects.
+- Crucially, deadlock is **SUBSUMED by liveness**: for a model that declares a goal
+  `<>Done` under fairness, the shipped liveness check already proves it reaches the
+  goal (a stuck-short-of-goal state fails liveness). So deadlock adds nothing FP-safe.
+- FP-safe deadlock would require per-spec Termination annotations (`Next \/ (isFinal /\
+  UNCHANGED vars)`) across 26 heterogeneous hand/scan-authored specs — high effort,
+  low marginal value, and outside a detector's scope.
+
+**Multi-process concurrency — NOT shipped (needs an emitter research spike):** the
+emitter is sequential single-process; interleaving races (semaphore/lock/shared-state)
+need PlusCal `process` composition, a separate research-grade effort.
+
+**Conclusion:** the FP-safe, decidable half of the FSM→TLA loop (safety + liveness) is
+COMPLETE. The remaining behaviors are either subsumed, FP-unsafe on the current corpus,
+or require an emitter refactor — none is a clean detector addition.

--- a/bin/nf-solve.cjs
+++ b/bin/nf-solve.cjs
@@ -4335,6 +4335,24 @@ function sweepSast() {
 //     theorem — aliasing + happens-before over a Turing-complete language); any
 //     approximation explodes the FP rate or needs annotations (the oracle again).
 // See .planning/quorum/debates/2026-07-04-behavior-4-formal-detection-boundary.md.
+//
+// fsm_check (below) extends model_check/liveness onto nForma's own transpiled state
+// machines via their sibling cfgs (INVARIANT always; liveness under the fairness dual
+// gate). Two further FSM checks are deliberately NOT built, for empirically-verified
+// reasons (see .planning/quorum/debates/2026-07-04-fsm-tla-loop-closure.md):
+//   - DEADLOCK: naive CHECK_DEADLOCK TRUE fires on 26/62 models, but those are
+//     LEGITIMATE terminal states (e.g. BugModelLookup reaching phase="done"), not
+//     defects — the corpus is heterogeneous (handwritten + code-scan-derived specs
+//     with no machine-readable terminal annotation), so no FP-safe heuristic
+//     separates "stuck" from "done". And it is SUBSUMED: for a model that declares a
+//     goal `<>Done` under fairness, the liveness check already proves it reaches the
+//     goal (a stuck-short-of-goal state fails liveness), so deadlock adds nothing
+//     FP-safe. FP-safe deadlock would require per-spec Termination annotations the
+//     corpus lacks.
+//   - MULTI-PROCESS CONCURRENCY (semaphore/lock/shared-state races): the emitter
+//     produces SEQUENTIAL single-process specs; catching interleaving races needs a
+//     PlusCal `process`-composition emitter change (a research-grade effort), not a
+//     detector tweak.
 
 // ── Model-check sweep (diagnostic) ───────────────────────────────────────────
 // Runs TLC on CONCRETE (no-CONSTANTS) TLA models with an auto-generated cfg to find


### PR DESCRIPTION
## Summary

Documentation-only. Records the **empirically-investigated boundary** for the FSM→TLA loop (following #309 invariant + #310 liveness), so the deadlock/concurrency reasoning is preserved.

I proceeded into deadlock detection autonomously and established — with data — that it isn't a clean, FP-safe addition on nForma's current formal-model corpus:

**Deadlock is not FP-safe here, and is subsumed by liveness:**
- Naive `CHECK_DEADLOCK TRUE` fires on **26 of 62** models — but triage shows these are **legitimate terminal states**, not defects (e.g. `BugModelLookup` reaching `phase="done"`, which even satisfies its own `<>(phase="done")` under `WF_` fairness).
- The deadlocking models are **handwritten** (`QGSDEnforcement`) or **code-scan-derived** (`formal-scope-scan.cjs` → `BugModelLookup`/`NFDispatch`), **not** `fsm-to-tla` emitter output — so there's no single emitter to fix, and they carry no machine-readable terminal annotation.
- No heuristic cleanly separates "stuck" from "done" (splitting on "declares a `<>` goal" gives 14 with / 12 without, but a spec can legitimately terminate without declaring a liveness goal).
- Crucially, deadlock is **subsumed by the shipped liveness check**: for a model that declares `<>Done` under fairness, liveness already proves it reaches the goal (a stuck-short-of-goal state fails liveness) — so deadlock adds nothing FP-safe.

**Multi-process concurrency** (semaphore/lock/shared-state races) needs a PlusCal `process`-composition emitter change — the emitter is sequential single-process today. That's a research spike, not a detector tweak.

**Conclusion:** the FP-safe, decidable half of the FSM→TLA loop (safety + liveness) is complete; the remaining behaviors are subsumed, FP-unsafe on this corpus, or require an emitter refactor.

Extends the behavior-#4 boundary note above `sweepModelCheck` and the FSM loop debate (`.planning/quorum/debates/2026-07-04-fsm-tla-loop-closure.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)