### PR TITLE
feat(sast): hardcoded-secret rule — FP-safe known-format secret detection

### DIFF
--- a/bin/sast-rules.yaml
+++ b/bin/sast-rules.yaml
@@ -62,3 +62,12 @@ rules:
             - pattern-not: 'he.encode(...)'
             - pattern-not: "'...'"
             - pattern-not: '"..."'
+  - id: hardcoded-secret
+    languages: [javascript]
+    severity: ERROR
+    message: Hardcoded secret in source — a live API key or private key literal (must
+      come from env / a secrets manager). Matched by KNOWN provider formats
+      (Stripe/AWS/GitHub/Slack/PEM), which never appear in legitimate code, so this is
+      FP-safe by construction (no name/entropy heuristic that flags `tokenType="Bearer"`).
+    patterns:
+      - pattern-regex: '(sk_live_[A-Za-z0-9]{16,}|AKIA[A-Z0-9]{16}|ghp_[A-Za-z0-9]{36}|xox[baprs]-[A-Za-z0-9-]{10,}|-----BEGIN (?:RSA |EC )?PRIVATE KEY-----)'

--- a/bin/sast-sweep.test.cjs
+++ b/bin/sast-sweep.test.cjs
@@ -64,6 +64,42 @@ test('detects SQL injection, command injection, and eval (when semgrep present)'
   } finally { fs.rmSync(root, { recursive: true, force: true }); }
 });
 
+test('detects a hardcoded live secret by known provider format (when semgrep present)', { skip: !SEMGREP }, () => {
+  const root = tmpDir();
+  try {
+    // Build the Stripe-format token by concatenation so this test SOURCE file never
+    // contains a contiguous sk_live_ literal (which GitHub push protection blocks) —
+    // the contiguous secret only exists in the written fixture, where the rule scans.
+    const stripeLiteral = 'sk_' + 'live_' + '51H8xY2eZvKYlo2CabcdefghijklmnopQR'; // pragma: allowlist secret
+    writeSrc(root, 'src/leak.js', [
+      "const stripeKey = '" + stripeLiteral + "';",
+      "const awsKey = 'AKIAIOSFODNN7EXAMPLE';", // pragma: allowlist secret
+      "module.exports = { stripeKey, awsKey };",
+    ].join('\n'));
+    const r = runSast(root);
+    const rules = new Set(r.findings.map(f => f.rule));
+    assert.ok(rules.has('hardcoded-secret'), 'a sk_live_/AKIA literal is flagged');
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('the secret rule is FP-safe: env reads and secret-named non-secrets are NOT flagged (when semgrep present)', { skip: !SEMGREP }, () => {
+  const root = tmpDir();
+  try {
+    // Known-format matching (not name/entropy heuristics) means these clean lines,
+    // which trip naive secret scanners, must NOT be flagged.
+    writeSrc(root, 'src/config.js', [
+      "const stripeKey = process.env.STRIPE_SECRET_KEY;",
+      "const tokenType = 'Bearer';",
+      "const passwordLabel = 'Enter your password below';", // pragma: allowlist secret
+      "const apiKeyHeader = 'x-api-key';", // pragma: allowlist secret
+      "module.exports = { stripeKey };",
+    ].join('\n'));
+    const r = runSast(root);
+    assert.strictEqual(r.skipped, false, 'src/ is scanned — the guard is real, not vacuous');
+    assert.strictEqual(r.count, 0, 'env reads + secret-named non-secret strings must not be flagged');
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
 test('does NOT flag new Function(src) syntax checks or process.stdout.write (when semgrep present)', { skip: !SEMGREP }, () => {
   const root = tmpDir();
   try {


### PR DESCRIPTION
## Summary

Adds a `hardcoded-secret` rule to the bundled SAST ruleset, extending the `sast` layer to catch hardcoded credentials — the next detector-ready capability for the benchmark's security cluster.

**FP-safe by construction:** it matches only **known provider formats** (Stripe `sk_live_`, AWS `AKIA`, GitHub `ghp_`, Slack `xox*`, PEM private keys), which never appear in legitimate code. No name/entropy heuristic — so it does **not** flag `tokenType = "Bearer"`, `const apiKeyHeader = "x-api-key"`, or `stripeKey = process.env.STRIPE_SECRET_KEY`. Verified 0-baseline preserved on nForma's own `src/` and the nf-benchmark `vuln-app` fixture.

## Testing

- 2 new tests: detection of a real key literal, and the FP-safety guard (env reads + secret-named non-secret strings must NOT be flagged). All sast tests pass with semgrep present.
- The Stripe-format test fixture is built by string concatenation so this repo never commits a contiguous `sk_live_` literal (push-protection-safe); the contiguous secret exists only in the temp fixture the rule scans.

## Impact

Unlocks nf-benchmark **BENCH-042** "Hardcoded secret in source" (routed to `vuln-app` + `sast`), verified FAIL→PASS: `sast residual 0→1`. Companion PR in nf-benchmark. The rule is reusable for any future secret-injection challenge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)