### PR TITLE
feat(sast): hardcoded-absolute-path rule (FP-safe user-home path detection)

### DIFF
--- a/bin/sast-rules.yaml
+++ b/bin/sast-rules.yaml
@@ -71,3 +71,14 @@ rules:
       FP-safe by construction (no name/entropy heuristic that flags `tokenType="Bearer"`).
     patterns:
       - pattern-regex: '(sk_live_[A-Za-z0-9]{16,}|AKIA[A-Z0-9]{16}|ghp_[A-Za-z0-9]{36}|xox[baprs]-[A-Za-z0-9-]{10,}|-----BEGIN (?:RSA |EC )?PRIVATE KEY-----)'
+  - id: hardcoded-absolute-path
+    languages: [javascript]
+    severity: WARNING
+    message: Hardcoded absolute path (a user-home directory) in source — breaks
+      portability across machines and CI. Matched only for `/Users/<name>` and
+      `/home/<name>` roots, which never belong in committed source (a config/env
+      value should be used), so this is FP-safe by construction.
+    patterns:
+      # Require a quote immediately before the path so it matches a STRING LITERAL,
+      # not a `/Users/...` mention in a comment (pattern-regex is a raw-text search).
+      - pattern-regex: "['\"`]/(Users|home)/[A-Za-z0-9._-]"

--- a/bin/sast-sweep.test.cjs
+++ b/bin/sast-sweep.test.cjs
@@ -100,6 +100,22 @@ test('the secret rule is FP-safe: env reads and secret-named non-secrets are NOT
   } finally { fs.rmSync(root, { recursive: true, force: true }); }
 });
 
+test('detects a hardcoded user-home absolute path, ignores portable path.join (when semgrep present)', { skip: !SEMGREP }, () => {
+  const root = tmpDir();
+  try {
+    writeSrc(root, 'src/paths.js', [
+      "const p = require('path');",
+      "function up(dir, name) { return p.join(dir, name); }",       // portable — clean
+      "const cache = p.join('/Users/ci/uploads', 'x');",            // hardcoded /Users — flagged
+      "module.exports = { up, cache };",
+    ].join('\n'));
+    const r = runSast(root);
+    const rules = new Set(r.findings.map(f => f.rule));
+    assert.ok(rules.has('hardcoded-absolute-path'), '/Users/ absolute path flagged');
+    assert.strictEqual(r.findings.filter(f => f.rule === 'hardcoded-absolute-path').length, 1, 'only the hardcoded path, not the portable join');
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
 test('does NOT flag new Function(src) syntax checks or process.stdout.write (when semgrep present)', { skip: !SEMGREP }, () => {
   const root = tmpDir();
   try {


### PR DESCRIPTION
## Summary

Adds a `hardcoded-absolute-path` rule to the bundled SAST ruleset — matching only `/Users/<name>` and `/home/<name>` roots (user-home directories that never belong in committed source; they break portability across machines/CI).

**FP-safe by construction:** it matches only user-home path roots, so it does **not** flag portable `path.join`, relative paths, or `/tmp`/`/var` system paths. 0-baseline preserved on the `vuln-app` fixture (nForma's own `lint-isolation` already forbids these paths).

## Testing

- 1 test: detects a `/Users/ci/...` literal while ignoring portable `path.join`. `npm run lint:isolation` ✓.

## Impact

Unlocks nf-benchmark **BENCH-033** "Test with hardcoded absolute path" (routed to `vuln-app` + `sast`), verified FAIL→PASS: `sast residual 0→1`. Companion PR in nf-benchmark. This is the Step-A-opportunistic win from the benchmark coverage decision — a genuine reusable detector, not a manufactured pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new security scan rule that flags hardcoded absolute paths in JavaScript files when they use common user home directories.
* **Tests**
  * Added coverage to confirm the new rule reports one issue for a hardcoded path and does not flag portable path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->