### PR TITLE
fix(formal): link FSM-transpiled cfg CONSTANTS so the state-space guard stops false-blocking

### DIFF
--- a/bin/analyze-state-space.cjs
+++ b/bin/analyze-state-space.cjs
@@ -677,13 +677,21 @@ function analyzeCrossModel(registry, models) {
 function buildModuleToCfgMap() {
   const map = {}; // moduleName -> [cfgPath, ...]
 
+  // Derive the tla dir from the CURRENT ROOT, not the module-load-time TLA_DIR const —
+  // analyzeModel() overrides ROOT per call, and the cfg map must follow it (previously
+  // it read the stale dir, so a per-call projectRoot only half-worked).
+  const TLA_DIR = path.join(ROOT, '.planning', 'formal', 'tla');
   if (!fs.existsSync(TLA_DIR)) return map;
 
   const cfgFiles = fs.readdirSync(TLA_DIR).filter(f => f.endsWith('.cfg'));
 
   for (const cfgFile of cfgFiles) {
     const baseName = cfgFile.replace('.cfg', '');
-    const moduleName = CFG_TO_MODULE[baseName];
+    // Static map first; fall back to deriving the module for FSM-transpiled MC* cfgs
+    // (68 exist, only ~13 are hand-listed). Without this the derived cfg is dropped,
+    // its CONSTANTS never link, and 0..MaxN domains read as unbounded → HIGH → the
+    // state-space guard falsely blocks every transpiled model (the 46 "crash" failures).
+    const moduleName = CFG_TO_MODULE[baseName] || deriveModuleFromCfg(path.join(TLA_DIR, cfgFile), baseName);
 
     if (moduleName) {
       if (!map[moduleName]) map[moduleName] = [];
@@ -692,6 +700,29 @@ function buildModuleToCfgMap() {
   }
 
   return map;
+}
+
+/**
+ * Derive the TLA+ module name for a .cfg not in the static CFG_TO_MODULE table.
+ * Mirrors check-fsm-models.cjs resolveSpec: (1) the cfg header's `.tla` reference,
+ * (2) MC-prefix strip, (3) the cfg basename — each gated on the .tla file existing.
+ * Returns null if none resolve (the cfg is then skipped, as before).
+ */
+function deriveModuleFromCfg(cfgPath, baseName) {
+  const TLA_DIR = path.join(ROOT, '.planning', 'formal', 'tla'); // follow current ROOT
+  try {
+    const header = fs.readFileSync(cfgPath, 'utf8').split('\n').slice(0, 12).join('\n');
+    // (a) explicit `Foo.tla` reference in the header
+    const m = header.match(/\b([A-Z]\w+)\.tla\b/);
+    if (m && m[1] !== baseName && fs.existsSync(path.join(TLA_DIR, m[1] + '.tla'))) return m[1];
+    // (b) prose `... for NFConvergenceTest` (module named without the .tla suffix)
+    const f = header.match(/\bfor\s+([A-Z]\w+)/);
+    if (f && f[1] !== baseName && fs.existsSync(path.join(TLA_DIR, f[1] + '.tla'))) return f[1];
+  } catch (_) { /* fall through */ }
+  const stripped = baseName.replace(/^MC/, '');
+  if (stripped && stripped !== baseName && fs.existsSync(path.join(TLA_DIR, stripped + '.tla'))) return stripped;
+  if (fs.existsSync(path.join(TLA_DIR, baseName + '.tla'))) return baseName;
+  return null;
 }
 
 /**
@@ -887,6 +918,16 @@ function analyzeModel(configName, projectRoot) {
         }
       }
     } catch (_) { /* fall through */ }
+
+    // Strategy 3: MC-prefix strip (MCFoo → Foo.tla) — consistent with the cfg-map
+    // derivation, so a transpiled cfg without a header .tla ref resolves its own spec
+    // instead of falling through to the wrong NFQuorum.tla default.
+    if (!specFile) {
+      const stripped = configName.replace(/^MC/, '');
+      if (stripped && stripped !== configName && fs.existsSync(path.join(tlaDir, stripped + '.tla'))) {
+        specFile = stripped + '.tla';
+      }
+    }
 
     // Fallback
     if (!specFile) {

--- a/bin/analyze-state-space.test.cjs
+++ b/bin/analyze-state-space.test.cjs
@@ -1,0 +1,78 @@
+'use strict';
+
+// Tests for the cfg→module derivation fallback in analyze-state-space.cjs.
+// Regression guard for the state-space-guard false-block: FSM-transpiled MC* cfgs that
+// are NOT in the static CFG_TO_MODULE table must still have their CONSTANTS linked, so
+// bounded ranges like 0..MaxN resolve instead of reading as unbounded → HIGH → blocked.
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { analyzeModel } = require('./analyze-state-space.cjs');
+
+function tmpProject(tlaName, tlaBody, cfgName, cfgBody) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ss-'));
+  const dir = path.join(root, '.planning', 'formal', 'tla');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, tlaName), tlaBody);
+  fs.writeFileSync(path.join(dir, cfgName), cfgBody);
+  return root;
+}
+
+const TLA = [
+  '---- MODULE Foo ----',
+  'EXTENDS Naturals',
+  'CONSTANTS MaxN',
+  'VARIABLES x',
+  '',
+  'TypeOK ==',
+  '    /\\ x \\in 0..MaxN',
+  '',
+  'Init == x = 0',
+  'Next == x\' = x',
+  'Spec == Init /\\ [][Next]_x',
+  '====',
+].join('\n');
+
+test('cfg NOT in the static map: header ".tla" reference links CONSTANTS → bounded, not HIGH', () => {
+  const cfg = ['\\* TLC model for Foo.tla', 'SPECIFICATION Spec', 'CONSTANTS', '    MaxN = 4', 'INVARIANT TypeOK'].join('\n');
+  const root = tmpProject('Foo.tla', TLA, 'MCFooLookup.cfg', cfg);
+  try {
+    const a = analyzeModel('MCFooLookup', root);
+    assert.notStrictEqual(a.risk_level, 'HIGH', 'MaxN=4 resolves → 0..4 bounded, not falsely HIGH');
+    assert.strictEqual(a.estimated_states, 5, '0..4 = 5 states');
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('cfg header prose "for Foo" (no .tla suffix) also links CONSTANTS', () => {
+  const cfg = ['\\* TLC configuration for Foo', 'SPECIFICATION Spec', 'CONSTANT MaxN = 3', 'INVARIANT TypeOK'].join('\n');
+  const root = tmpProject('Foo.tla', TLA, 'MCFooProse.cfg', cfg);
+  try {
+    const a = analyzeModel('MCFooProse', root);
+    assert.notStrictEqual(a.risk_level, 'HIGH');
+    assert.strictEqual(a.estimated_states, 4, '0..3 = 4 states');
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('MC-prefix strip resolves when the module file matches the stripped basename', () => {
+  const cfg = ['\\* no useful header here', 'SPECIFICATION Spec', 'CONSTANTS', '    MaxN = 2', 'INVARIANT TypeOK'].join('\n');
+  const root = tmpProject('Foo.tla', TLA, 'MCFoo.cfg', cfg); // MCFoo → strip MC → Foo.tla exists
+  try {
+    const a = analyzeModel('MCFoo', root);
+    assert.notStrictEqual(a.risk_level, 'HIGH');
+    assert.strictEqual(a.estimated_states, 3, '0..2 = 3 states');
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('genuinely unresolvable cfg stays conservative (no false LOW)', () => {
+  // Unbounded Nat domain with no bounding constant — must remain HIGH.
+  const tla = TLA.replace('/\\ x \\in 0..MaxN', '/\\ x \\in Nat');
+  const cfg = ['\\* TLC model for Foo.tla', 'SPECIFICATION Spec', 'INVARIANT TypeOK'].join('\n');
+  const root = tmpProject('Foo.tla', tla, 'MCFooUnbounded.cfg', cfg);
+  try {
+    const a = analyzeModel('MCFooUnbounded', root);
+    assert.strictEqual(a.risk_level, 'HIGH', 'unbounded Nat is genuinely HIGH');
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});


### PR DESCRIPTION
## Root cause

`failure-taxonomy.json` records **46 formal "crash" failures**, every one a run-tlc `state-space guard blocked … (HIGH risk, ~null states)`. The benchmark quorum flagged this as the formal loop's real bottleneck — models never reach property-checking.

It's a **false block**. `buildModuleToCfgMap` maps cfg→module via the static `CFG_TO_MODULE` table, which lists only **~13 of the 68** FSM-transpiled `MC*.cfg` files. The other 55 are dropped from the map, so their `CONSTANTS` never link — e.g. `modelsFound \in 0..MaxModels` with `MaxModels = 4` **in the cfg** reads as an *unbounded* domain → `risk_level: HIGH` → the preflight guard refuses to run the model. But these models are small and terminate (`fsm_check` runs 62 of them INVARIANT-only in <1s). The guard blocked runnable models.

## Fix

Derive the module for any cfg missing from the static table (mirrors `check-fsm-models.cjs` `resolveSpec`): cfg-header `.tla` reference → header `for <Name>` → MC-prefix strip, each gated on the `.tla` existing. Plus two consistency fixes surfaced along the way:

- **`TLA_DIR` now follows the per-call `ROOT` override** in `analyzeModel` (it was a load-time `const`, so `projectRoot` only half-worked — the cfg map read the stale dir).
- **MC-strip added to `analyzeModel`'s own spec resolver**, so a headerless MC cfg resolves its spec instead of falling through to the wrong `NFQuorum.tla` default.

## Effect

**24 of 38 previously-blocked models now correctly estimate as bounded and run.** The remaining 14 are genuine (unbounded `Seq(...)` logs, or `TypeOK` referencing a constant the cfg doesn't bind) — separate model fixes, not this linkage bug.

## Tests

4 new tests (temp-project derivation: header `.tla`, prose `for`, MC-strip, and a genuinely-unbounded `Nat` correctly stays HIGH). No regression: run-tlc (12) + model-complexity-profile (22) green; static-mapped models unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)