### PR TITLE
test(formal): drift guard for the QGSDQuorum/NFQuorum duplicate

### DIFF
--- a/bin/qgsdquorum-mirror.test.cjs
+++ b/bin/qgsdquorum-mirror.test.cjs
@@ -1,0 +1,40 @@
+'use strict';
+
+// Drift guard for the QGSDQuorum ⟂ NFQuorum duplication.
+//
+// QGSDQuorum.tla is a byte-identical copy of NFQuorum.tla except its header (module
+// name, file path, source-machine comment, generated date). Its generator source
+// (src/machines/qgsd-workflow.machine.ts) was removed in the qgsd→nf rename, so it can
+// no longer be regenerated — it's a frozen orphan (registered + TLC-checked + referenced
+// by hazard-model.cjs and ~5 tests, so not cheaply removable).
+//
+// The real hazard of a frozen duplicate is SILENT DRIFT: if NFQuorum's logic changes
+// (it IS regenerated from nf-workflow.machine.ts), QGSDQuorum won't follow, and the two
+// checked models diverge without anyone noticing. This test fails the moment their
+// BODIES diverge, forcing a conscious re-sync or a full dedupe.
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+
+const TLA = path.join(__dirname, '..', '.planning', 'formal', 'tla');
+
+// Erase the known-cosmetic header differences; anything left is real logic drift.
+function normalize(s) {
+  return s
+    .replace(/QGSDQuorum/g, 'NFQuorum')
+    .replace(/qgsd-workflow/g, 'nf-workflow')
+    .replace(/^.*Generated:.*$/gm, ' * Generated: <normalized>');
+}
+
+test('QGSDQuorum.tla stays a faithful mirror of NFQuorum.tla (no silent logic drift)', () => {
+  const nf = fs.readFileSync(path.join(TLA, 'NFQuorum.tla'), 'utf8');
+  const qgsd = fs.readFileSync(path.join(TLA, 'QGSDQuorum.tla'), 'utf8');
+  assert.strictEqual(
+    normalize(qgsd), normalize(nf),
+    'QGSDQuorum.tla has drifted from NFQuorum.tla. It is a frozen orphan duplicate (its '
+    + 'generator source was removed in the qgsd→nf rename). Re-sync it to NFQuorum.tla, '
+    + 'or complete the dedupe (remove QGSDQuorum + repoint hazard-model.cjs/tests/registry).'
+  );
+});


### PR DESCRIPTION
## Handling the QGSDQuorum duplication at proportionate risk

`QGSDQuorum.tla` is a **byte-identical copy** of `NFQuorum.tla` (only 5 header lines differ) whose generator source (`src/machines/qgsd-workflow.machine.ts`) was removed in the `qgsd→nf` rename — a **frozen orphan**.

**Full removal is deferred, deliberately.** It's a ~20-file destructive refactor touching functional code (`hazard-model.cjs` maps states to `MCQGSDQuorum`), ~5 tests (`extract-annotations` reads the real file; the debug tests assert on the `'QGSDQuorum'` string), and ~13 *generated* artifacts — for a duplicate that now works and has real invariants (#318). The risk outweighs the value right now.

## What this does instead

The real hazard of a frozen duplicate is **silent drift**: `NFQuorum` *is* regenerated from `nf-workflow.machine.ts`, so its logic can change while the orphan copy stays put — two TLC-checked models diverging with nobody noticing.

This test normalizes the cosmetic header diffs (module name, paths, date, source) and asserts the **bodies stay identical**. It fails the moment they diverge, forcing a conscious re-sync or a full dedupe. Verified: passes now, and catches an injected body drift.

The full dedupe is documented in the test as scoped future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)