### PR TITLE
fix(test): repair 7 pre-existing test failures (stale expectations + fixture drift)

### DIFF
--- a/.planning/formal/alloy/install-scope.als
+++ b/.planning/formal/alloy/install-scope.als
@@ -58,9 +58,11 @@ pred SameState [s1, s2: InstallState] {
 -- We mirror the InstallIdempotent shape: both states are the post-state of an InstallOp that
 -- targets the full Runtime set at one shared scope `sc`, so they must coincide.
 -- NonUninstalled[sc] guards out the trivial Uninstalled scope (an uninstall, not an install).
--- @requirement INST-02
 pred NonUninstalled [sc: Scope] { sc != Uninstalled }
 
+-- @requirement INST-02
+-- The scope-equivalence requirement is VERIFIED by this assert (NonUninstalled is only a
+-- helper guard), so the traceability annotation belongs here, not on the pred above.
 assert AllEquivalence {
     all pre1, pre2, s1, s2: InstallState, sc: Scope |
         (NonUninstalled[sc]

--- a/bin/promote-gate-maturity.test.cjs
+++ b/bin/promote-gate-maturity.test.cjs
@@ -148,12 +148,12 @@ describe('checkAllModels', () => {
 // ── Unit tests: inferSourceLayer ────────────────────────────────────────────
 
 describe('inferSourceLayer', () => {
-  it('infers L2 for .tla files', () => {
-    assert.strictEqual(inferSourceLayer('.planning/formal/tla/QGSDQuorum.tla'), 'L2');
+  it('infers L3 for .tla files (formal specs are reasoning-layer by design)', () => {
+    assert.strictEqual(inferSourceLayer('.planning/formal/tla/QGSDQuorum.tla'), 'L3');
   });
 
-  it('infers L2 for .als files', () => {
-    assert.strictEqual(inferSourceLayer('.planning/formal/alloy/quorum-votes.als'), 'L2');
+  it('infers L3 for .als files (formal specs are reasoning-layer by design)', () => {
+    assert.strictEqual(inferSourceLayer('.planning/formal/alloy/quorum-votes.als'), 'L3');
   });
 
   it('infers L1 for evidence paths', () => {
@@ -181,7 +181,9 @@ describe('integration: real model-registry.json', () => {
 
   before(() => {
     originalContent = fs.readFileSync(REGISTRY_PATH, 'utf8');
-    registry = JSON.parse(originalContent);
+    // Registry migrated to a nested { version, last_sync, models: {...} } wrapper; the
+    // check/promote helpers operate on the unwrapped model map (as main() does).
+    registry = JSON.parse(originalContent).models;
   });
 
   afterEach(() => {
@@ -197,14 +199,17 @@ describe('integration: real model-registry.json', () => {
   });
 
   it('promotes a model to SOFT_GATE and verifies registry updated', () => {
-    const modelKeys = getModelKeys(registry);
-    const tlaModel = modelKeys.find(k => k.endsWith('.tla'));
+    // Work on a copy with a controlled starting maturity, so the test doesn't depend on
+    // whatever gate the first real .tla model happens to already sit at.
+    const reg = JSON.parse(JSON.stringify(registry));
+    const tlaModel = getModelKeys(reg).find(k => k.endsWith('.tla'));
     assert.ok(tlaModel, 'Should have at least one TLA model');
+    reg[tlaModel].gate_maturity = 'ADVISORY';
 
-    const result = promoteModel(registry, tlaModel, 'SOFT_GATE', []);
+    const result = promoteModel(reg, tlaModel, 'SOFT_GATE', []);
     assert.strictEqual(result.success, true);
-    assert.strictEqual(registry[tlaModel].gate_maturity, 'SOFT_GATE');
-    assert.ok(registry[tlaModel].source_layer, 'source_layer should be set');
+    assert.strictEqual(reg[tlaModel].gate_maturity, 'SOFT_GATE');
+    assert.ok(reg[tlaModel].source_layer, 'source_layer should be set');
   });
 });
 

--- a/test/extract-annotations.test.cjs
+++ b/test/extract-annotations.test.cjs
@@ -67,12 +67,12 @@ describe('TLA+ annotation parsing', () => {
     assert.deepStrictEqual(safety2.requirement_ids, ['STOP-03']);
   });
 
-  test('NFStopHook.tla returns 7 properties', () => {
+  test('NFStopHook.tla returns 8 properties', () => {
     const result = run('--pretty');
     const data = JSON.parse(result.stdout);
     const stopHook = data['.planning/formal/tla/NFStopHook.tla'];
     assert.ok(stopHook, 'NFStopHook.tla should be in output');
-    assert.strictEqual(stopHook.length, 7, 'Should have 7 properties');
+    assert.strictEqual(stopHook.length, 8, 'Should have 8 properties');
   });
 });
 
@@ -204,7 +204,7 @@ describe('integration', () => {
     const data = JSON.parse(result.stdout);
     const stopHook = data['.planning/formal/tla/NFStopHook.tla'];
     assert.ok(stopHook);
-    assert.strictEqual(stopHook.length, 7);
+    assert.strictEqual(stopHook.length, 8);
 
     const expectedMapping = {
       'TypeOK': ['STOP-01'],
@@ -213,7 +213,8 @@ describe('integration', () => {
       'SafetyInvariant3': ['STOP-04'],
       'LivenessProperty1': ['STOP-05'],
       'LivenessProperty2': ['STOP-06'],
-      'LivenessProperty3': ['STOP-07']
+      'LivenessProperty3': ['STOP-07'],
+      'FloorSafety': ['QUORUM-170']
     };
 
     for (const [prop, expectedIds] of Object.entries(expectedMapping)) {


### PR DESCRIPTION
Deep-research surfaced 7 tests failing on `main`. Each fixed at root cause:

## promote-gate-maturity.test.cjs (4)
- **"infers L2 for .tla/.als"** — stale test. `inferSourceLayer` *intentionally* returns `L3` for formal specs (reasoning layer; documented, and every `.als` registry entry is `L3`). Updated expectations to `L3`.
- **"--check reports current state" / "promotes a model to SOFT_GATE"** — the registry migrated to a nested `{version, last_sync, models:{...}}` wrapper; the `before`-hook passed the whole file to helpers that expect the unwrapped model map. Unwrap `.models`. The promotion test also depended on the first `.tla` model's live gate (`NFAccountManager` is already `SOFT_GATE` → correctly "not a promotion"); made it deterministic with a copy + controlled `ADVISORY` start.

## extract-annotations.test.cjs (3)
- **NFStopHook** gained the `FloorSafety` invariant (`@requirement QUORUM-170`) → **8** properties, not 7. Updated the count + added the mapping.
- **install-scope.als** — `@requirement INST-02` had drifted onto the *helper pred* `NonUninstalled` instead of the *assert* `AllEquivalence` that actually verifies scope-equivalence. Moved the annotation to the assert (restores correct traceability) — the handwritten `.als` was wrong, not the test.

Restores `.claude/rules/testing.md`'s "No known pre-existing test failures" invariant to true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)