### PR TITLE
fix(detectors): security-sweep token-boundary skip + FP-safe liveness fold

### DIFF
--- a/bin/nf-solve.cjs
+++ b/bin/nf-solve.cjs
@@ -3965,12 +3965,14 @@ function sweepFormalLint() {
     try {
       const lfResult = spawnTool('bin/check-liveness-fairness.cjs', []);
       if (lfResult.exitCode !== 0) {
-        // Try to parse count from stdout
+        // FP-safe: only count ACTUAL parsed violations. A nonzero exit with no
+        // parseable violations (crash / non-JSON output — the tool normally exits 0
+        // with human-readable "inconclusive" text) must add 0, never a phantom residual.
         try {
           const lfData = JSON.parse(lfResult.stdout || '{}');
-          lfViolations = (lfData.violations || []).length || 1;
+          lfViolations = (lfData.violations || []).length;
         } catch (_) {
-          lfViolations = 1;
+          lfViolations = 0;
         }
       }
     } catch (_) { /* fail-open */ }

--- a/bin/security-sweep.cjs
+++ b/bin/security-sweep.cjs
@@ -34,6 +34,12 @@ const SECRET_PATTERNS = [
 
 // Words that indicate a line is a test fixture / not a real secret
 const TEST_INDICATOR_WORDS = ['test', 'mock', 'fake', 'example', 'dummy', 'fixture', 'placeholder', 'todo'];
+// A test-indicator counts only as a real TOKEN: bounded by non-lowercase chars on both
+// sides. This skips genuine fixtures (`testKey`, `sk-test1234`, `MOCK_SECRET`) but NOT a
+// real key on a line like "latest"/"greatest"/"attestation"/"contest" — the substring
+// skip's security false negative. Case-insensitive word, case-sensitive boundaries.
+const TEST_INDICATOR_RES = TEST_INDICATOR_WORDS.map(w =>
+  new RegExp('(?<![a-z])' + w.split('').map(c => '[' + c + c.toUpperCase() + ']').join('') + '(?![a-z])'));
 
 // File patterns to exclude from scanning
 const EXCLUDE_PATTERNS = [
@@ -69,8 +75,8 @@ function scanFile(filePath, content) {
     const line = lines[i];
     const lineLower = line.toLowerCase();
 
-    // Skip lines containing test indicator words
-    if (TEST_INDICATOR_WORDS.some(w => lineLower.includes(w))) continue;
+    // Skip genuine test-fixture lines (token-boundary match — see TEST_INDICATOR_RES).
+    if (TEST_INDICATOR_RES.some(re => re.test(line))) continue;
 
     for (const pat of SECRET_PATTERNS) {
       const m = pat.pattern.exec(line);

--- a/bin/security-sweep.test.cjs
+++ b/bin/security-sweep.test.cjs
@@ -82,9 +82,18 @@ test('scanFile detects sensitive console.log', () => {
 });
 
 test('scanFile skips test fixture lines', () => {
-  // Line contains "test" so it should be skipped
+  // "testKey" (camelCase) and "sk-test" (hyphen) are genuine test-indicator tokens → skip
   const findings = scanFile('src/cfg.js', 'const testKey = "sk-test1234567890abcdefghijklmnopqr";\n');
-  assert.equal(findings.length, 0, 'should skip lines containing test indicator words');
+  assert.equal(findings.length, 0, 'should skip lines with a test-indicator token');
+});
+
+test('scanFile does NOT skip a real key just because a word contains "test" as a substring', () => {
+  // Regression: the old whole-line substring skip hid real keys on "latest"/"greatest"
+  // lines. Token-boundary matching must still flag these.
+  assert.equal(scanFile('src/x.js', 'const k = "AKIAROGUEKEY123456XY"; deployTo("latest");\n').length, 1,
+    '"latest" is not a test-indicator token — the AWS key must be flagged');
+  assert.equal(scanFile('src/x.js', 'const t = "ghp_' + 'a'.repeat(36) + '"; // the greatest\n').length, 1,
+    '"greatest" must not suppress a real GitHub token');
 });
 
 test('scanFile returns empty for clean file', () => {


### PR DESCRIPTION
Deep-research **Phase 2** — protect the 0-baseline invariant (any finding on clean code = a false positive).

## security-sweep: whole-line substring skip → token boundary (security FN)

The test-fixture skip matched a test-indicator word anywhere in the line as a substring, so a **real key was silently dropped** on any line containing `la[test]`, `grea[test]`, `at[test]ation`, `con[test]`, etc. Replaced with a **token-boundary** match (indicator bounded by non-lowercase chars):

- still skips genuine fixtures: `testKey`, `sk-test1234`, `MOCK_SECRET` ✓
- now flags real keys on `latest`/`greatest` lines ✓ (was a false negative)
- 0-baseline on nForma still **0 findings**; +2 regression tests (24 pass)

## nf-solve sweepFormalLint: FP-safe liveness fold

The liveness-fairness fold added a phantom residual of `1` on a nonzero exit with no parseable violations (`(violations||[]).length || 1`, and `catch → 1`). Now counts only actual parsed violations (0 on failure). Honest note: the tool always exits 0 with human-readable text, so this branch is currently **dead** — a defensive fix, not an active baseline break (the research over-flagged it as active).

🤖 Generated with [Claude Code](https://claude.com/claude-code)