### PR TITLE
fix(solve): restore liveness-fold nonzero-exit signal (backtrack #322)

### DIFF
--- a/bin/nf-solve.cjs
+++ b/bin/nf-solve.cjs
@@ -3965,14 +3965,17 @@ function sweepFormalLint() {
     try {
       const lfResult = spawnTool('bin/check-liveness-fairness.cjs', []);
       if (lfResult.exitCode !== 0) {
-        // FP-safe: only count ACTUAL parsed violations. A nonzero exit with no
-        // parseable violations (crash / non-JSON output — the tool normally exits 0
-        // with human-readable "inconclusive" text) must add 0, never a phantom residual.
+        // A NONZERO exit from check-liveness-fairness is itself a formal signal — the
+        // tool exits 0 in normal operation (even "inconclusive"), so nonzero means it
+        // errored on the model set (e.g. an orphaned/unresolvable formal model). Count
+        // parsed violations, or fall back to 1 for the failure itself. NOTE: do NOT
+        // "FP-safe" this to 0 — the fixture FIX-orphaned-formal-model relies on this
+        // signal, and on a clean repo the tool exits 0 so no phantom is produced.
         try {
           const lfData = JSON.parse(lfResult.stdout || '{}');
-          lfViolations = (lfData.violations || []).length;
+          lfViolations = (lfData.violations || []).length || 1;
         } catch (_) {
-          lfViolations = 0;
+          lfViolations = 1;
         }
       }
     } catch (_) { /* fail-open */ }


### PR DESCRIPTION
## Backtracking part of #322 — the benchmark caught the regression

Re-running the fixture corpus after #322 dropped it **8/8 → 7/8**: `FIX-orphaned-formal-model` no longer detected (deterministic, 3/3).

Bisected to #322's "FP-safe" `sweepFormalLint` change (nonzero exit → `lfViolations = 0`). A **nonzero exit from check-liveness-fairness is itself a formal signal** — the tool exits 0 in normal operation (even when "inconclusive"), so a nonzero exit means it *errored on the model set*, e.g. an orphaned/unresolvable model — exactly the defect that fixture seeds. My change was defensive over-reach: **no benefit on nForma** (the tool exits 0 → `lfViolations` is 0 either way, so the 0-baseline was never affected) but it **erased load-bearing detection**.

Restored the `|| 1` / `catch = 1` fold with a comment documenting why it must not be FP-safed away. **Fixture corpus back to 8/8.**

The security-sweep token-boundary fix from #322 **stays** — that one was a genuine security-FN improvement, verified independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of liveness/fairness check failures so non-zero exits are now counted more reliably.
  * When violation details can’t be parsed, the lint result now still reflects a failure instead of being undercounted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->