### PR TITLE
fix(formal): analyzer recognises TypeInvariant + resolves .tla-defined set domains

### DIFF
--- a/bin/analyze-state-space.cjs
+++ b/bin/analyze-state-space.cjs
@@ -272,8 +272,10 @@ function extractVariables(tlaContent) {
  * @returns {Object[]} — array of { name, domain, cardinality, bounded }
  */
 function parseTypeOK(tlaContent, varNames, constants) {
-  // Extract TypeOK block
-  const typeOKMatch = tlaContent.match(/TypeOK\s*==\s*\n?([\s\S]*?)(?=\n\s*\n\s*\\?\*|^\s*\n\s*[A-Z])/m);
+  // Extract the type-invariant block. Some models name it TypeInvariant /
+  // TypeInvariantHolds instead of TypeOK (e.g. NFMCPEnv) — recognise those too, else
+  // every variable reads as "unknown" domain → a false HIGH.
+  const typeOKMatch = tlaContent.match(/(?:TypeOK|TypeInvariant(?:Holds)?)\s*==\s*\n?([\s\S]*?)(?=\n\s*\n\s*\\?\*|^\s*\n\s*[A-Z])/m);
   if (!typeOKMatch) {
     // No TypeOK — return unknowns for all variables
     return varNames.map(name => ({
@@ -288,6 +290,17 @@ function parseTypeOK(tlaContent, varNames, constants) {
   for (const c of constants) {
     if (c.type === 'integer') constMap[c.name] = c.value;
     if (c.type === 'set') constMap[c.name] = c.cardinality;
+  }
+
+  // Augment with .tla-defined domain sets/ranges (e.g. `SlotStatuses == {"A","B"}`,
+  // `Slots == 1..NumSlots`) so function/set domains referencing them resolve instead of
+  // reading as "unknown" → a false HIGH (e.g. NFMCPEnv's [Slots -> SlotStatuses]). Done
+  // after cfg constants are in the map so a range like `1..NumSlots` can resolve.
+  const strippedTla = tlaContent.replace(/\\\*.*$/gm, '');
+  for (const m of strippedTla.matchAll(/^([A-Z]\w*)\s*==\s*(\{[^}]*\}|-?\w+\s*\.\.\s*-?\w+)\s*$/gm)) {
+    if (constMap[m[1]] !== undefined) continue;
+    const card = resolveCardinality(m[2].trim(), constMap);
+    if (card !== null) constMap[m[1]] = card;
   }
 
   const results = [];

--- a/bin/analyze-state-space.test.cjs
+++ b/bin/analyze-state-space.test.cjs
@@ -76,3 +76,27 @@ test('genuinely unresolvable cfg stays conservative (no false LOW)', () => {
     assert.strictEqual(a.risk_level, 'HIGH', 'unbounded Nat is genuinely HIGH');
   } finally { fs.rmSync(root, { recursive: true, force: true }); }
 });
+
+test('recognises TypeInvariant (not just TypeOK) and resolves .tla-defined set domains', () => {
+  const tla = [
+    '---- MODULE Foo ----',
+    'VARIABLES color',
+    '',
+    'Colors == {"red", "green", "blue"}',
+    '',
+    'TypeInvariant ==',
+    '    /\\ color \\in Colors',
+    '',
+    'Init == color = "red"',
+    'Next == color\' = "green"',
+    'Spec == Init /\\ [][Next]_color',
+    '====',
+  ].join('\n');
+  const cfg = ['\\* TLC model for Foo.tla', 'SPECIFICATION Spec', 'INVARIANT TypeInvariant'].join('\n');
+  const root = tmpProject('Foo.tla', tla, 'MCFooTI.cfg', cfg);
+  try {
+    const a = analyzeModel('MCFooTI', root);
+    assert.notStrictEqual(a.risk_level, 'HIGH', 'a .tla-defined set domain must not read as unbounded');
+    assert.strictEqual(a.estimated_states, 3, 'Colors has 3 members');
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});


### PR DESCRIPTION
Deep-research formal item (the QGSDMCPEnv false HIGH). `analyze-state-space.cjs` only matched `TypeOK ==` and only resolved cfg CONSTANTS, so models that (a) name their type invariant `TypeInvariant`/`TypeInvariantHolds`, or (b) declare domains via `.tla` set/range definitions (`Colors == {"r","g","b"}`, `Slots == 1..NumSlots`) had every variable read as an "unknown" unbounded domain → a **false HIGH** → blocked from model-checking.

- `parseTypeOK` now matches `TypeOK | TypeInvariant | TypeInvariantHolds`.
- `constMap` is augmented with top-level `.tla` set-literal and range definitions (after cfg constants, so a range over a cfg constant resolves).

**Net: corpus HIGH count 18 → 17.** +1 test; analyze-state-space (5) + model-complexity (26) green; no regression on static-mapped models.

**Honest scope note**: NFMCPEnv itself stays HIGH — it *additionally* needs cfg-constant linkage for `MCMCPEnv.cfg` (`NumSlots` unresolved) and union-type domains (`CallStates == {...} \cup Outcomes`), which are separate deeper fixes. This PR is the general improvement that fully unblocks one other model and partially resolves NFMCPEnv's domains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)