### PR TITLE
fix(ci): allowlist AWS-key test fixture so detect-secrets baseline check passes

### DIFF
--- a/bin/security-sweep.test.cjs
+++ b/bin/security-sweep.test.cjs
@@ -90,7 +90,7 @@ test('scanFile skips test fixture lines', () => {
 test('scanFile does NOT skip a real key just because a word contains "test" as a substring', () => {
   // Regression: the old whole-line substring skip hid real keys on "latest"/"greatest"
   // lines. Token-boundary matching must still flag these.
-  assert.equal(scanFile('src/x.js', 'const k = "AKIAROGUEKEY123456XY"; deployTo("latest");\n').length, 1,
+  assert.equal(scanFile('src/x.js', 'const k = "AKIAROGUEKEY123456XY"; deployTo("latest");\n').length, 1, // pragma: allowlist secret
     '"latest" is not a test-indicator token — the AWS key must be flagged');
   assert.equal(scanFile('src/x.js', 'const t = "ghp_' + 'a'.repeat(36) + '"; // the greatest\n').length, 1,
     '"greatest" must not suppress a real GitHub token');


### PR DESCRIPTION
My #322 security-sweep regression test added a **literal** `AKIAROGUEKEY123456XY` fixture (deliberately — to prove a real key on a `latest` line is flagged). It wasn't in `.secrets.baseline`, so the **detect-secrets (baseline check)** CI job failed on #322 and *every PR after it* (visible on #324/#325).

Added `// pragma: allowlist secret` to that line. `detect-secrets scan --baseline` now reports **0 unbaselined secrets**; the test still passes (24/0). Unblocks the gate for all future PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)