### PR TITLE
fix(ci): regenerate .secrets.baseline line numbers (detect-secrets gate)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -414,7 +414,7 @@
         "filename": "bin/security-sweep.test.cjs",
         "hashed_secret": "3c76d2abd56878fe1834ff711a3a60e83af48849",
         "is_verified": true,
-        "line_number": 138
+        "line_number": 147
       }
     ],
     "bin/unified-mcp-server.mjs": [
@@ -470,5 +470,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-28T23:12:18Z"
+  "generated_at": "2026-07-05T14:49:34Z"
 }


### PR DESCRIPTION
Root cause of the recurring **detect-secrets (baseline check)** failure: #322 added ~9 lines to `bin/security-sweep.test.cjs`, shifting an **existing baselined secret from line 138 → 147**. detect-secrets tracks secrets by line number, so the committed baseline no longer matched the re-scan → the CI job's before/after diff flagged it as "new secrets" and failed on **every PR since #322** (the #326 pragma addressed a different line, not this shift).

Re-ran the exact CI scan to refresh the line numbers. Verified locally: re-scan == committed baseline → **stable**, so the gate passes again for all PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)