### PR TITLE
feat(gsd): assumption-delta drift scanner fused with formal invariants

### DIFF
--- a/bin/detect-assumption-delta.cjs
+++ b/bin/detect-assumption-delta.cjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * bin/detect-assumption-delta.cjs — deterministic scope-drift scanner.
+ *
+ * Ported from open-gsd/gsd-core's assumption-delta capability (pure-function +
+ * STDIN CLI, no framework coupling) and FUSED with nForma's formal layer: every
+ * detected drift signal carries a suggested TLA+/Alloy invariant so the finding
+ * routes straight into `nf:close-formal-gaps` instead of staying a prose note.
+ *
+ * Detects three abstraction-drift signals in phase-scope prose — a phase now
+ * describes something PLURAL / OPTIONAL / CHOSEN that a formal model likely
+ * treats as SINGULAR / REQUIRED / DERIVED:
+ *   - pluralization  (one X → several X)      → model as a set/sequence, not a scalar
+ *   - optional       (required → optional)    → domain must admit absence (∪ {NULL})
+ *   - chosen         (derived → chosen/param)  → model as a CONSTANT with an ASSUME bound
+ *
+ * Exports: detectAssumptionDelta, suggestInvariant, DEFAULT_TERMS
+ * CLI: echo "$PHASE_SECTION" | node bin/detect-assumption-delta.cjs [--json] [--terms csv]
+ *      exit 0 = signal detected, 1 = none, 2 = startup error.
+ */
+
+// Curated cue vocabulary. Bare "or" is intentionally EXCLUDED from pluralization
+// (prose-frequency false positives) — the cues name a *second/alternative* thing.
+const DEFAULT_TERMS = {
+  pluralization: ['second', 'another', 'additional', 'multiple', 'several', 'each',
+    'alternative', 'fallback', 'per-', 'plural', 'list of', 'set of', 'array of'],
+  optional: ['optional', 'optionally'],
+  chosen: ['chosen', 'configurable', 'parameter', 'parameterize', 'parameterized',
+    'tunable', 'per-project', 'per-user'],
+};
+
+const MAX_TERMS_PER_KIND = 64;
+const MAX_TERM_LEN = 40;
+
+function normalizeTerms(list) {
+  const out = [];
+  const seen = new Set();
+  for (const raw of list) {
+    if (typeof raw !== 'string') continue;
+    const t = raw.trim().toLowerCase().slice(0, MAX_TERM_LEN);
+    // Require at least one alphanumeric so punctuation-only "terms" (e.g. "-")
+    // cannot match prose punctuation as a signal.
+    if (!t || !/[a-z0-9]/.test(t) || seen.has(t)) continue;
+    seen.add(t);
+    out.push(t);
+    if (out.length >= MAX_TERMS_PER_KIND) break;
+  }
+  return out;
+}
+
+function resolveTerms(terms) {
+  const merge = (key) => {
+    const t = terms && terms[key];
+    return Array.isArray(t) ? normalizeTerms(t) : [...DEFAULT_TERMS[key]];
+  };
+  return { pluralization: merge('pluralization'), optional: merge('optional'), chosen: merge('chosen') };
+}
+
+// Minimal CommonMark-ish fenced-code stripper (```…``` and ~~~…~~~), CRLF-safe —
+// so a cue term inside a code snippet does not fire.
+function stripFencedCode(text) {
+  const lines = text.replace(/\r\n/g, '\n').split('\n');
+  const out = [];
+  let fence = null;
+  for (const line of lines) {
+    const m = line.match(/^\s*(`{3,}|~{3,})/);
+    if (fence) {
+      if (m && line.trim().startsWith(fence[0])) fence = null;
+      continue;
+    }
+    if (m) { fence = m[1]; continue; }
+    out.push(line);
+  }
+  return out.join('\n');
+}
+
+function makeSnippet(line, term) {
+  const cleaned = line.replace(/\s+/g, ' ').trim();
+  if (cleaned.length <= 120) return cleaned;
+  const idx = cleaned.toLowerCase().indexOf(term);
+  const start = Math.max(0, idx - 50);
+  return (start > 0 ? '…' : '') + cleaned.slice(start, start + 110) + '…';
+}
+
+function escapeRegex(s) { return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); }
+
+/**
+ * Suggest a formal invariant for a drift signal — the nForma fusion.
+ * @returns {{ kind, layer, hint, invariant_sketch }}
+ */
+function suggestInvariant(signal) {
+  switch (signal.kind) {
+    case 'pluralization':
+      return {
+        kind: 'pluralization', layer: 'multiplicity',
+        hint: 'This entity became plural — a formal model treating it as a scalar is now wrong. Model it as a set/sequence and bound its cardinality.',
+        invariant_sketch: 'TypeOK: the var must be a function/set domain (e.g. items \\in [Ids -> T]); add a Cardinality bound invariant.',
+      };
+    case 'optional':
+      return {
+        kind: 'optional', layer: 'nullability',
+        hint: 'This field became optional — invariants must not assume it is always present.',
+        invariant_sketch: 'Widen the domain to admit absence: x \\in T  →  x \\in T \\cup {NULL}; guard every read on x # NULL.',
+      };
+    case 'chosen':
+      return {
+        kind: 'chosen', layer: 'parameterization',
+        hint: 'This value became a free choice — model it as a CONSTANT with an ASSUME bound, not a hardcoded literal.',
+        invariant_sketch: 'Lift the literal to a CONSTANT C with ASSUME C \\in ValidRange; re-check invariants hold for all C in range.',
+      };
+    default:
+      return { kind: signal.kind, layer: 'unknown', hint: '', invariant_sketch: '' };
+  }
+}
+
+/**
+ * Detect assumption-delta signals in phase-scope prose.
+ * @param {string} text  Roadmap phase section / scope prose. Non-string → { detected:false }.
+ * @param {object} [terms]  Optional per-kind vocabulary override.
+ * @returns {{ detected, signals:Array<{kind,term,snippet,suggestion}>, terms }}
+ */
+function detectAssumptionDelta(text, terms) {
+  const effective = resolveTerms(terms);
+  if (typeof text !== 'string') return { detected: false, signals: [], terms: effective };
+  const stripped = stripFencedCode(text);
+  if (stripped.trim().length === 0) return { detected: false, signals: [], terms: effective };
+
+  const signals = [];
+  for (const kind of ['pluralization', 'optional', 'chosen']) {
+    const cueTerms = effective[kind];
+    if (cueTerms.length === 0) continue;
+    // Word-boundary anchored, case-insensitive; interior-substring matches excluded.
+    const escaped = cueTerms.map(escapeRegex).join('|');
+    const pattern = new RegExp('(^|[^a-zA-Z0-9])(' + escaped + ')([^a-zA-Z0-9]|$)', 'gi');
+    const seen = new Set();
+    for (const line of stripped.split('\n')) {
+      for (const m of line.matchAll(pattern)) {
+        const matched = (m[2] || '').toLowerCase();
+        if (!matched) continue;
+        const key = kind + ':' + matched;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        const signal = { kind, term: matched, snippet: makeSnippet(line, matched) };
+        signal.suggestion = suggestInvariant(signal);
+        signals.push(signal);
+      }
+    }
+  }
+  return { detected: signals.length > 0, signals, terms: effective };
+}
+
+// ─── CLI ───────────────────────────────────────────────────────────────────
+if (require.main === module) {
+  const argv = process.argv.slice(2);
+  const wantJson = argv.includes('--json');
+  let termsOverride;
+  const termsIdx = argv.indexOf('--terms');
+  const termsVal = termsIdx !== -1 ? argv[termsIdx + 1] : undefined;
+  if (typeof termsVal === 'string' && !termsVal.startsWith('-')) {
+    const list = termsVal.split(',').map((t) => t.trim().toLowerCase()).filter(Boolean);
+    if (list.length > 0) termsOverride = { pluralization: list };
+  }
+  const chunks = [];
+  process.stdin.setEncoding('utf-8');
+  process.stdin.on('data', (c) => chunks.push(c));
+  process.stdin.on('end', () => {
+    const result = detectAssumptionDelta(chunks.join(''), termsOverride);
+    if (wantJson) {
+      process.stdout.write(JSON.stringify(result) + '\n');
+    } else if (result.detected) {
+      process.stdout.write('Assumption-delta signals (' + result.signals.length + '):\n');
+      for (const s of result.signals) {
+        process.stdout.write('  [' + s.kind + '] "' + s.term + '" — ' + s.snippet + '\n');
+        process.stdout.write('    → formal(' + s.suggestion.layer + '): ' + s.suggestion.invariant_sketch + '\n');
+      }
+    } else {
+      process.stdout.write('No assumption-delta signals detected.\n');
+    }
+    process.exit(result.detected ? 0 : 1);
+  });
+  process.stdin.on('error', (err) => {
+    process.stderr.write('ERROR: detect-assumption-delta.cjs stdin read failed: ' + err.message + '\n');
+    process.exit(2);
+  });
+}
+
+module.exports = { detectAssumptionDelta, suggestInvariant, DEFAULT_TERMS };

--- a/bin/detect-assumption-delta.test.cjs
+++ b/bin/detect-assumption-delta.test.cjs
@@ -1,0 +1,72 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { execFileSync } = require('node:child_process');
+const path = require('node:path');
+const { detectAssumptionDelta, suggestInvariant } = require('./detect-assumption-delta.cjs');
+
+const BIN = path.join(__dirname, 'detect-assumption-delta.cjs');
+
+test('detects pluralization drift and attaches a multiplicity invariant', () => {
+  const r = detectAssumptionDelta('The wizard now supports multiple provider slots per project.');
+  assert.strictEqual(r.detected, true);
+  const plural = r.signals.find((s) => s.kind === 'pluralization');
+  assert.ok(plural, 'a pluralization signal fired');
+  assert.strictEqual(plural.suggestion.layer, 'multiplicity');
+  assert.match(plural.suggestion.invariant_sketch, /Cardinality|set|function/i);
+});
+
+test('detects optional drift → nullability invariant', () => {
+  const r = detectAssumptionDelta('The apiKey field is now optional.');
+  const s = r.signals.find((x) => x.kind === 'optional');
+  assert.ok(s);
+  assert.strictEqual(s.suggestion.layer, 'nullability');
+  assert.match(s.suggestion.invariant_sketch, /NULL/);
+});
+
+test('detects chosen/parameterization drift → parameterization invariant', () => {
+  const r = detectAssumptionDelta('The retry limit is now configurable per-project.');
+  const s = r.signals.find((x) => x.kind === 'chosen');
+  assert.ok(s);
+  assert.strictEqual(s.suggestion.layer, 'parameterization');
+  assert.match(s.suggestion.invariant_sketch, /CONSTANT|ASSUME/);
+});
+
+test('cue terms inside fenced code do NOT fire', () => {
+  const text = ['Scope: single fixed value.', '', '```', 'const opts = { multiple: true, optional: false };', '```'].join('\n');
+  assert.strictEqual(detectAssumptionDelta(text).detected, false, 'fenced code is stripped before scanning');
+});
+
+test('word-boundary: interior substrings do not match', () => {
+  // "seconds" must not fire the "second" cue; "optionally" IS a real cue.
+  const r = detectAssumptionDelta('Timeout is 30 seconds.');
+  assert.strictEqual(r.detected, false, '"seconds" is not the "second" cue');
+});
+
+test('non-string / empty input degrades to not-detected without throwing', () => {
+  assert.strictEqual(detectAssumptionDelta(null).detected, false);
+  assert.strictEqual(detectAssumptionDelta('').detected, false);
+  assert.strictEqual(detectAssumptionDelta('   ').detected, false);
+});
+
+test('suggestInvariant covers all three kinds + unknown', () => {
+  assert.strictEqual(suggestInvariant({ kind: 'pluralization' }).layer, 'multiplicity');
+  assert.strictEqual(suggestInvariant({ kind: 'optional' }).layer, 'nullability');
+  assert.strictEqual(suggestInvariant({ kind: 'chosen' }).layer, 'parameterization');
+  assert.strictEqual(suggestInvariant({ kind: 'weird' }).layer, 'unknown');
+});
+
+test('CLI: STDIN → JSON, exit 0 on detect', () => {
+  const out = execFileSync(process.execPath, [BIN, '--json'], { input: 'Add a second fallback provider.', encoding: 'utf8' });
+  const r = JSON.parse(out);
+  assert.strictEqual(r.detected, true);
+  assert.ok(r.signals[0].suggestion.invariant_sketch.length > 0);
+});
+
+test('CLI: exit 1 when no signal', () => {
+  let code = 0;
+  try { execFileSync(process.execPath, [BIN, '--json'], { input: 'A single fixed timeout.', encoding: 'utf8' }); }
+  catch (e) { code = e.status; }
+  assert.strictEqual(code, 1);
+});

--- a/core/workflows/list-phase-assumptions.md
+++ b/core/workflows/list-phase-assumptions.md
@@ -82,6 +82,16 @@ Assemble all results into a grounding summary to flow into analyze_phase:
 - Formal models touching this domain
 - Any artifacts that were "not found"
 
+**5. Scope-drift scan (deterministic — assumption-delta):**
+Pipe the phase description and any scope prose into the deterministic drift scanner. It catches abstraction drift — a phase that now describes something **plural / optional / chosen** that a formal model likely treats as **singular / required / derived** — and pairs each signal with a suggested formal invariant. Fail-open: a missing binary or non-zero exit with no JSON means "no signals" — never block.
+
+```bash
+REQ="${HOME}/.claude/nf-bin/detect-assumption-delta.cjs"; [ -f "$REQ" ] || REQ="./bin/detect-assumption-delta.cjs"
+printf '%s\n' "<phase description + scope prose>" | node "$REQ" --json 2>/dev/null || true
+```
+
+Parse the JSON `signals[]` — each is `{ kind, term, snippet, suggestion: { layer, invariant_sketch } }`. If `detected` is true, carry the signals into present_assumptions for the Scope-Drift subsection; otherwise omit that subsection entirely.
+
 Continue to analyze_phase.
 </step>
 
@@ -168,6 +178,14 @@ Present assumptions in a clear, scannable format:
 **In scope:** [what's included]
 **Out of scope:** [what's excluded]
 **Ambiguous:** [what could go either way]
+
+<!-- Only render this subsection if the step-5 scan returned detected:true. Omit it entirely otherwise. -->
+### Scope-Drift Signals → Formal Invariants
+The deterministic scan flagged abstraction drift in this phase's scope. Each signal is a candidate identity-model change that a formal model may not yet reflect:
+
+[For each signal: **[kind]** "term" — _snippet_ → **formal({layer}):** {invariant_sketch}]
+
+**Route to formal:** if any of these represent a real abstraction change, run `/nf:close-formal-gaps ${PHASE}` to land the suggested invariant(s) as TLA+/Alloy, or note explicitly that the drift is intentional and no invariant is needed.
 
 ### Risk Areas
 [List anticipated challenges — each tagged grounded/inferred]


### PR DESCRIPTION
**First best-of-both-worlds port** from `open-gsd/gsd-core` v1.7.0-rc.2 (part of the GSD-upstream-sync initiative).

Their **assumption-delta** capability is a deterministic scope-drift scanner (pure function + STDIN CLI, zero framework coupling) that flags when a phase now describes something **plural / optional / chosen** that a formal model likely treats as **singular / required / derived** — surfacing the one identity-model decision at plan time.

**nForma fusion:** each detected signal now carries a suggested TLA+/Alloy invariant (multiplicity / nullability / parameterization), so the finding routes straight into `nf:close-formal-gaps` instead of staying a prose note. GSD's drift detection × our formal layer.

```
$ echo "the config now supports multiple providers, an optional fallback, a configurable retry limit" | detect-assumption-delta
  [pluralization] "multiple" → formal(multiplicity): model as a set/function domain; add a Cardinality bound
  [optional] "optional"      → formal(nullability): widen domain x ∈ T → T ∪ {NULL}
  [chosen] "configurable"    → formal(parameterization): lift literal to CONSTANT C with ASSUME C ∈ ValidRange
```

- `bin/detect-assumption-delta.cjs` — ported pure fn + `suggestInvariant()` fusion + self-contained fenced-code stripper (no new coupling). 9 tests.
- Wired into `list-phase-assumptions`: deterministic scan step (portable `nf-bin` path, fail-open) + a conditional "Scope-Drift Signals → Formal Invariants" subsection.

**Regression gate:** `lint:isolation` ✓, `verify-hooks-sync` ✓, fixture corpus 8/8 ✓ (GSD-side change, detectors untouched), 9/9 tool tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a scope-drift scan that detects common assumption changes in phase descriptions.
  * When signals are found, the app now surfaces a new “Scope-Drift Signals → Formal Invariants” section with suggested invariant sketches and follow-up guidance.

* **Tests**
  * Added coverage for the detector, CLI output, code-block filtering, boundary matching, and empty input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->