### PR TITLE
feat(gsd): gap-analysis coverage report (plan:post) fused with formal models

### DIFF
--- a/bin/gap-analysis.cjs
+++ b/bin/gap-analysis.cjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * bin/gap-analysis.cjs — post-planning requirement-coverage report (plan:post).
+ *
+ * Ported from open-gsd/gsd-core's gap-analysis gate and fused with nForma's formal layer:
+ * after a phase's PLAN.md files are generated, cross-reference every requirement ID the
+ * phase owns against the plan bodies and emit a coverage table. A requirement that is
+ * MISSING from every plan is a coverage gap; a MISSING requirement that also has a formal
+ * model (`formal_models` non-empty in requirements.json) is a HIGH-priority gap — the
+ * spec is formally pinned but nothing plans to satisfy it.
+ *
+ * Non-blocking / advisory — exit 0 always (fail-open: missing inputs → empty report).
+ *
+ * Exports: gapAnalysis, extractPlanRefs, REQ_ID_RE
+ * CLI: node bin/gap-analysis.cjs --phase <N> [--plans-dir <dir>] [--req-json <path>] [--json]
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const REQ_ID_RE = /\b[A-Z][A-Z0-9]{1,10}-[0-9]+\b/g;
+
+/** Extract every requirement-ID referenced by the PLAN.md files under a dir. */
+function extractPlanRefs(plansDir) {
+  const refs = new Set();
+  let planCount = 0;
+  let files = [];
+  try { files = fs.readdirSync(plansDir); } catch (_) { return { refs, planCount }; }
+  for (const f of files) {
+    if (!/PLAN.*\.md$/i.test(f) && f.toLowerCase() !== 'plan.md') {
+      // also descend one level (phase dir → plan subdirs)
+      const sub = path.join(plansDir, f);
+      try { if (fs.statSync(sub).isDirectory()) { for (const g of fs.readdirSync(sub)) if (/PLAN.*\.md$/i.test(g)) tryFile(path.join(sub, g)); } } catch (_) {}
+      continue;
+    }
+    tryFile(path.join(plansDir, f));
+  }
+  function tryFile(p) {
+    let txt; try { txt = fs.readFileSync(p, 'utf8'); } catch (_) { return; }
+    planCount++;
+    for (const m of txt.matchAll(REQ_ID_RE)) refs.add(m[0]);
+  }
+  return { refs, planCount };
+}
+
+/**
+ * Compute coverage rows.
+ * @param {Array<{id,formal_models?}>} requirements  the phase's requirements
+ * @param {Set<string>} planRefs  requirement IDs referenced by any plan
+ * @returns {{ rows, covered, missing, missing_formal }}
+ */
+function gapAnalysis(requirements, planRefs) {
+  const rows = [];
+  for (const r of requirements) {
+    const covered = planRefs.has(r.id);
+    const hasFormal = Array.isArray(r.formal_models) && r.formal_models.length > 0;
+    rows.push({
+      id: r.id,
+      status: covered ? 'COVERED' : 'MISSING',
+      formal: hasFormal,
+      priority: (!covered && hasFormal) ? 'HIGH' : (!covered ? 'normal' : '—'),
+    });
+  }
+  const missing = rows.filter((x) => x.status === 'MISSING');
+  return {
+    rows,
+    covered: rows.length - missing.length,
+    total: rows.length,
+    missing: missing.map((x) => x.id),
+    missing_formal: missing.filter((x) => x.formal).map((x) => x.id),
+  };
+}
+
+function loadPhaseRequirements(reqJsonPath, phase) {
+  let data;
+  try { data = JSON.parse(fs.readFileSync(reqJsonPath, 'utf8')); } catch (_) { return []; }
+  const all = Array.isArray(data.requirements) ? data.requirements : [];
+  if (phase == null) return all;
+  const want = String(phase);
+  // `phase` in requirements.json may be "3", "v0.20-03", etc. — match by suffix/equality.
+  return all.filter((r) => r.phase != null && (String(r.phase) === want || String(r.phase).endsWith('-' + want.padStart(2, '0')) || String(r.phase).endsWith(want)));
+}
+
+// ─── CLI ───────────────────────────────────────────────────────────────────
+if (require.main === module) {
+  const argv = process.argv.slice(2);
+  const get = (flag) => { const i = argv.indexOf(flag); return i !== -1 ? argv[i + 1] : undefined; };
+  const phase = get('--phase');
+  const reqJson = get('--req-json') || path.join('.planning', 'formal', 'requirements.json');
+  const plansDir = get('--plans-dir') || (phase ? path.join('.planning', 'phases') : '.planning');
+  const wantJson = argv.includes('--json');
+
+  const requirements = loadPhaseRequirements(reqJson, phase);
+  const { refs, planCount } = extractPlanRefs(plansDir);
+  const result = gapAnalysis(requirements, refs);
+
+  if (wantJson) {
+    process.stdout.write(JSON.stringify({ ...result, plan_count: planCount, phase: phase || null }, null, 2) + '\n');
+    process.exit(0);
+  }
+  if (requirements.length === 0) {
+    process.stdout.write('Gap analysis: no requirements found for phase ' + (phase || '(all)') + ' — nothing to check.\n');
+    process.exit(0);
+  }
+  process.stdout.write('## Requirement Coverage — phase ' + (phase || '(all)') + ' (' + result.covered + '/' + result.total + ' covered, ' + planCount + ' plans)\n\n');
+  process.stdout.write('| Requirement | Status | Formal | Priority |\n|---|---|---|---|\n');
+  for (const r of result.rows) {
+    process.stdout.write('| ' + r.id + ' | ' + r.status + ' | ' + (r.formal ? 'yes' : '—') + ' | ' + r.priority + ' |\n');
+  }
+  if (result.missing_formal.length) {
+    process.stdout.write('\n**⚠ HIGH-priority gaps (formally modeled but unplanned):** ' + result.missing_formal.join(', ') +
+      '\n→ these requirements have a formal model but no plan satisfies them — plan them, or reconcile via /nf:close-formal-gaps.\n');
+  }
+  process.stdout.write('\n_Advisory / non-blocking._\n');
+  process.exit(0);
+}
+
+module.exports = { gapAnalysis, extractPlanRefs, loadPhaseRequirements, REQ_ID_RE };

--- a/bin/gap-analysis.test.cjs
+++ b/bin/gap-analysis.test.cjs
@@ -1,0 +1,74 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const { gapAnalysis, extractPlanRefs } = require('./gap-analysis.cjs');
+
+const BIN = path.join(__dirname, 'gap-analysis.cjs');
+
+test('gapAnalysis: COVERED vs MISSING by plan references', () => {
+  const reqs = [{ id: 'ADAPT-01' }, { id: 'ADR-01' }, { id: 'BLD-01' }];
+  const refs = new Set(['ADAPT-01', 'ADR-01']);
+  const r = gapAnalysis(reqs, refs);
+  assert.strictEqual(r.covered, 2);
+  assert.deepStrictEqual(r.missing, ['BLD-01']);
+});
+
+test('gapAnalysis fusion: a MISSING requirement with formal_models is HIGH priority', () => {
+  const reqs = [
+    { id: 'WIZ-05', formal_models: ['QGSDSetupWizard.tla'] },
+    { id: 'WIZ-06', formal_models: [] },
+  ];
+  const r = gapAnalysis(reqs, new Set()); // nothing planned
+  assert.deepStrictEqual(r.missing_formal, ['WIZ-05'], 'only the formally-modeled one is a HIGH gap');
+  const wiz05 = r.rows.find((x) => x.id === 'WIZ-05');
+  assert.strictEqual(wiz05.priority, 'HIGH');
+  const wiz06 = r.rows.find((x) => x.id === 'WIZ-06');
+  assert.strictEqual(wiz06.priority, 'normal');
+});
+
+test('extractPlanRefs pulls req-IDs from PLAN.md requirements fields + inline mentions', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gap-'));
+  try {
+    fs.writeFileSync(path.join(dir, 'PLAN.md'), 'requirements: [ADAPT-01, ADR-01]\n\nAlso touches BLD-01 inline.\n');
+    const { refs, planCount } = extractPlanRefs(dir);
+    assert.strictEqual(planCount, 1);
+    assert.ok(refs.has('ADAPT-01') && refs.has('ADR-01') && refs.has('BLD-01'));
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('extractPlanRefs descends one level into phase subdirs', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gap-'));
+  try {
+    const sub = path.join(dir, 'phase-03'); fs.mkdirSync(sub);
+    fs.writeFileSync(path.join(sub, 'PLAN.md'), 'requirements: [SUB-01]\n');
+    const { refs } = extractPlanRefs(dir);
+    assert.ok(refs.has('SUB-01'));
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('fail-open: missing plans dir → empty refs, no throw', () => {
+  const { refs, planCount } = extractPlanRefs('/no/such/dir/xyz');
+  assert.strictEqual(refs.size, 0);
+  assert.strictEqual(planCount, 0);
+});
+
+test('CLI: --json emits coverage with HIGH formal gaps, exit 0', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gap-cli-'));
+  try {
+    const reqJson = path.join(dir, 'requirements.json');
+    fs.writeFileSync(reqJson, JSON.stringify({ requirements: [
+      { id: 'XX-01', phase: '3', formal_models: ['M.tla'] },
+      { id: 'XX-02', phase: '3', formal_models: [] },
+    ] }));
+    fs.writeFileSync(path.join(dir, 'PLAN.md'), 'requirements: [XX-02]\n');
+    const out = execFileSync(process.execPath, [BIN, '--phase', '3', '--req-json', reqJson, '--plans-dir', dir, '--json'], { encoding: 'utf8' });
+    const r = JSON.parse(out);
+    assert.strictEqual(r.covered, 1);
+    assert.deepStrictEqual(r.missing_formal, ['XX-01']);
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});

--- a/core/workflows/plan-phase.md
+++ b/core/workflows/plan-phase.md
@@ -761,6 +761,17 @@ Display: `Max iterations reached. {N} issues remain:` + issue list
 
 Offer: 1) Force proceed, 2) Provide guidance and retry, 3) Abandon
 
+## 12.5 Requirement Coverage Report (plan:post)
+
+After all PLAN.md files are finalized, emit a non-blocking requirement-coverage report — cross-references every requirement the phase owns against the plan bodies. Advisory only; never blocks phase advancement. Ported from open-gsd/gsd-core's gap-analysis, fused with our formal layer.
+
+```bash
+REQ="${HOME}/.claude/nf-bin/gap-analysis.cjs"; [ -f "$REQ" ] || REQ="./bin/gap-analysis.cjs"
+node "$REQ" --phase "${PHASE}" 2>/dev/null || true
+```
+
+Surface the coverage table (COVERED / MISSING per requirement). **nForma fusion:** a MISSING requirement that also has a formal model (`formal_models` non-empty) is a **HIGH-priority gap** — the spec is formally pinned but no plan satisfies it. If any HIGH gaps appear, recommend planning them or reconciling via `/nf:close-formal-gaps ${PHASE}` before execution. Fail-open: missing requirements.json or plans → empty report, continue.
+
 ## 13. Present Final Status
 
 Route to `<offer_next>` OR `auto_advance` depending on flags/config.


### PR DESCRIPTION
**Port #4** of the GSD-upstream-sync. Their **gap-analysis** is a non-blocking plan:post gate cross-referencing every requirement a phase owns against the plan bodies → coverage table. Reimplemented natively (their gate calls a `gsd-tools` query backend we lack).

**nForma fusion:** a MISSING requirement that *also* has a formal model (`formal_models` in requirements.json) is flagged **HIGH priority** — the spec is formally pinned but no plan satisfies it — and routed to `/nf:close-formal-gaps`. A plain static coverage gate can't see this.

- `bin/gap-analysis.cjs` — pure `gapAnalysis()` + `extractPlanRefs()` + CLI. Advisory, exit 0, fail-open. 6 tests. Live: **phase 3 = 25/48 covered across 109 plans**.
- Wired into plan-phase **Step 12.5** (plan:post, non-blocking).

**Regression gate:** lint:isolation ✓, verify-hooks-sync ✓, 6/6 tool tests, plan-phase tests unchanged, fixture corpus unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)