### PR TITLE
fix(ci): bump install-virgin timeout 30s→120s (flaky cancelledByParent)

### DIFF
--- a/test/install-virgin.test.cjs
+++ b/test/install-virgin.test.cjs
@@ -69,7 +69,11 @@ function runInstall(tmpDir, runtime) {
     '--config-dir', tmpDir,
   ], {
     stdio: 'pipe',
-    timeout: 30000,
+    // The installer does real filesystem work (~30s locally); slower CI runners
+    // (esp. macOS) exceed a 30s cap → execFileSync ETIMEDOUT → the before-hook fails →
+    // every subtest reports cancelledByParent (a flaky red, not a real failure). The
+    // ci-install job budget is 10min, so 120s per runtime install is safe headroom.
+    timeout: 120000,
     env: {
       ...process.env,
       // Prevent any env var overrides from affecting test


### PR DESCRIPTION
The `install-virgin` before-hooks run the real installer via `execFileSync` with a **30s** timeout, but the installer does ~30s of filesystem work locally — so slower CI runners (esp. macOS/Node 22) exceed 30s → `execFileSync` ETIMEDOUT → the before-hook fails → every subtest reports **`cancelledByParent`**. A flaky red, not a real failure (suite passes 54/0 locally). Seen on #329 and #331.

Bumped to **120s**. The `ci-install` job budget is `timeout-minutes: 10`, so 120s × 3 runtimes stays well within budget. No logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the installer test timeout to allow more time for completion in slower environments, improving reliability in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->