### PR TITLE
feat(gsd): /nf:autonomous — quorum-gated, formal+harden-verified phase loop

### DIFF
--- a/commands/nf/autonomous.md
+++ b/commands/nf/autonomous.md
@@ -1,0 +1,39 @@
+---
+name: nf:autonomous
+description: Run remaining roadmap phases autonomously — discuss→plan→execute→verify, quorum-gated planning + formal/harden verify
+argument-hint: "[--from N] [--to N] [--only N] [--fully-auto] [--interactive]"
+allowed-tools:
+  - Read
+  - Bash
+  - Glob
+  - Grep
+  - Task
+  - SlashCommand
+---
+
+<objective>
+Drive every remaining milestone phase to completion with minimal supervision. For each phase: **discuss → plan → execute → verify**, advancing automatically and pausing only on real blockers.
+
+Ported from open-gsd/gsd-core's `autonomous`, fused with nForma's differentiators:
+- **Planning is quorum-gated** — `nf:plan-phase` already routes through the multi-LLM quorum (true consensus, not single-model multi-pass).
+- **Verification is formal + adversarial** — each phase must pass formal model-checking (`run-formal-verify`) AND `nf:harden` before advancing. "Verified" means formally checked + hardened, not just tests-green.
+
+Safe by default: **pauses before executing each phase** for a one-line go/no-go, pauses on every blocker, and never force-pushes. `--fully-auto` opts into unattended execution (still pauses on blockers).
+</objective>
+
+<execution_context>
+@~/.claude/nf/workflows/autonomous.md
+</execution_context>
+
+<context>
+Arguments: $ARGUMENTS
+
+Flags:
+- `--from N` / `--to N` / `--only N` — bound the phase range (default: all remaining incomplete phases).
+- `--fully-auto` — execute each phase without the pre-execute go/no-go pause (still pauses on blockers).
+- `--interactive` — run discuss inline with real questions (default: auto-answer from context where confident).
+</context>
+
+<process>
+Follow ~/.claude/nf/workflows/autonomous.md. Discover the remaining phases, then loop each through discuss→plan→execute→verify with the quorum and formal/harden gates. Pause on blockers. After the last phase: audit → complete → cleanup. Never force-push; never skip the verify gate.
+</process>

--- a/core/workflows/autonomous.md
+++ b/core/workflows/autonomous.md
@@ -1,0 +1,68 @@
+# Workflow: autonomous
+
+Drive every remaining milestone phase to completion: **discuss → plan → execute → verify**, per phase, advancing automatically. Quorum-gated planning + formal/harden-gated verification. Pause only on real blockers. Ported from open-gsd/gsd-core's autonomous mode and fused with nForma's quorum + formal layers.
+
+<step name="preflight">
+Establish the run and the phase range.
+
+```bash
+STATE=$(node ~/.claude/nf/bin/nf-tools.cjs state 2>/dev/null || true)
+ROADMAP=$(node ~/.claude/nf/bin/nf-tools.cjs roadmap analyze 2>/dev/null || true)
+```
+
+- Parse `$ARGUMENTS` for `--from N`, `--to N`, `--only N`, `--fully-auto`, `--interactive`.
+- From `$ROADMAP.phases`, build the ordered list of **incomplete** phases — those whose `disk_status` is not `"complete"` (or `roadmap_complete` is false), sorted by `number`. Apply `--only N` (single phase), else `--from`/`--to` bounds, else all remaining incomplete phases.
+- If the roadmap or state cannot be read, STOP with: `Cannot read roadmap/state — run /nf:progress to diagnose.` (never guess a phase range).
+- If there are no incomplete phases: report "milestone already complete" and route to the milestone-close step.
+
+Display the run plan:
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ nForma ► AUTONOMOUS RUN
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ Phases: {list}          Mode: {pause-before-execute | fully-auto}
+ Gates:  plan=quorum · verify=formal+harden · pause-on-blocker
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+Continue to phase_loop.
+</step>
+
+<step name="phase_loop">
+For each phase P in the range, in order, run the sub-steps below. Do NOT parallelize phases — each depends on the prior phase's committed state.
+
+**A. Discuss** — build context.
+- `--interactive`: run `/nf:discuss-phase P` inline (ask the user the real questions).
+- default: if a CONTEXT.md already exists for P, skip; otherwise run `/nf:discuss-phase P --auto` (answer from roadmap/requirements where confident; escalate genuine ambiguity as a blocker rather than guessing).
+
+**B. Plan** — quorum-gated. Dispatch `/nf:plan-phase P` (planning already routes through the multi-LLM quorum). This also runs the plan:pre schema-gate and the plan:post gap-analysis. **If gap-analysis reports HIGH-priority gaps** (a requirement with a formal model but no plan), surface them and treat as a blocker unless the user waives — a formally-pinned requirement must not be silently skipped.
+
+**C. Go/no-go** — unless `--fully-auto`, pause with a one-line summary of what will execute and wait for the user's go/no-go before any code changes. On `--fully-auto`, skip this pause (still honor the blocker protocol below).
+
+**D. Execute** — dispatch `/nf:execute-phase P`. Use the Task tool to spawn (per the plan-phase note — never substitute a Skill/MCP tool call for a sub-agent).
+
+**E. Verify (formal + adversarial gate)** — a phase is NOT done until all three pass:
+  1. `/nf:verify-work P` — goal-backward verification.
+  2. Formal check — run `run-formal-verify` on any models this phase touched; a reachable invariant violation is a blocker.
+  3. `/nf:harden P` — adversarial hardening loop to convergence.
+  If any gate fails: attempt one remediation pass (`/nf:solve` for a detected residual, or continue the `/nf:harden` loop). If it still fails, STOP and surface as a blocker — do NOT advance a failing phase.
+
+**F. Advance** — on all-green, mark the phase complete and continue to the next P. Report a one-line phase summary (`Phase P ✓ — plan(quorum) · execute · verify(formal+harden)`).
+
+Continue to milestone_close when the range is exhausted.
+</step>
+
+<step name="blocker_protocol">
+A blocker is anything the loop cannot safely resolve on its own: a genuine ambiguity in discuss, a HIGH formal-gap the user hasn't waived, a failing verify/formal/harden gate after one remediation pass, a merge conflict, or any destructive/irreversible action.
+
+On a blocker: STOP the loop, print `⏸ BLOCKED at Phase P — {reason}` with the concrete state and 2–3 options, and hand control back. Never force past a blocker, never force-push, never fabricate a passing verify.
+</step>
+
+<step name="milestone_close">
+When all phases in the range are complete (and the range covers the milestone's remaining phases):
+1. `/nf:audit-milestone` — cross-phase integration + coverage audit.
+2. If the audit is clean, `/nf:complete-milestone`; otherwise surface the audit findings as a blocker.
+3. `/nf:cleanup` — tidy worktrees/artifacts.
+
+Report the final summary: phases completed, gates passed, anything deferred. Stop.
+</step>


### PR DESCRIPTION
**Port #5 — the flagship** of the GSD-upstream-sync. Drives every remaining roadmap phase to completion — **discuss → plan → execute → verify** — advancing automatically, pausing only on real blockers. The "run nForma unattended, *with our rigor*" lever.

**The fusion that beats upstream:**
- **Planning is quorum-gated** — upstream's `--converge` is single-model multi-pass; `nf:plan-phase` already routes through the real **multi-LLM quorum**.
- **Verification is formal + adversarial** — a phase isn't done until `nf:verify-work` **AND** `run-formal-verify` (TLA+/Alloy) **AND** `nf:harden` all pass.
- A plan:post **HIGH gap** (formally-modeled requirement with no plan) blocks unless waived — a formally-pinned requirement is never silently skipped.

**Safe by default:** pauses before executing each phase for a go/no-go (`--fully-auto` opts out), pauses on every blocker, never force-pushes, never fabricates a passing verify. Bounded by `--from/--to/--only`. Ends with audit → complete → cleanup.

Uses real `nf-tools` verbs (`state`, `roadmap analyze`) verified live; phases run sequentially.

**Regression gate:** lint:isolation ✓, verify-hooks-sync ✓, skill lints ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)