### PR TITLE
feat(plan): planning FV-gate — formal fails become quorum hypotheses

### DIFF
--- a/bin/extract-fv-fails.cjs
+++ b/bin/extract-fv-fails.cjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * bin/extract-fv-fails.cjs — turn formal-verification FAIL results into plan-time hypotheses.
+ *
+ * Part of the planning FV-gate (PLAN-01/02/03): after `run-formal-verify.cjs --only=tla`
+ * writes check-results.ndjson, extract every `result: "fail"` entry so the plan-checker
+ * and quorum can treat a formal counterexample as a HYPOTHESIS about a plan gap — a
+ * formal fail at plan time is strong evidence the plan is missing something.
+ *
+ * Fail-open (PLAN-03): a missing/empty/corrupt ledger yields [] and exit 0 — never throw,
+ * never block planning on formal-tool availability.
+ *
+ * Path: CHECK_RESULTS_PATH env > .planning/formal/check-results.ndjson.
+ * Exports: extractFvFails
+ * CLI: CHECK_RESULTS_PATH=<file> node bin/extract-fv-fails.cjs [--json]  (exit 0 always)
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * @param {string} ndjsonText  raw check-results.ndjson content
+ * @returns {Array<{check_id,property,surface,summary,tool}>}  one hypothesis per fail
+ */
+function extractFvFails(ndjsonText) {
+  if (typeof ndjsonText !== 'string' || ndjsonText.trim().length === 0) return [];
+  const lines = ndjsonText.split('\n').filter((l) => l.trim().length > 0);
+  return lines
+    .map((l) => { try { return JSON.parse(l); } catch (_) { return null; } })
+    .filter((r) => r && r.result === 'fail')
+    .map((r) => ({
+      check_id: r.check_id || null,
+      property: r.property || null,
+      surface: r.surface || null,
+      tool: r.tool || null,
+      summary: r.summary || null,
+    }));
+}
+
+if (require.main === module) {
+  const ndjsonPath = process.env.CHECK_RESULTS_PATH ||
+    path.join(process.cwd(), '.planning', 'formal', 'check-results.ndjson');
+  let text = '';
+  try { text = fs.readFileSync(ndjsonPath, 'utf8'); } catch (_) { text = ''; } // fail-open
+  const fails = extractFvFails(text);
+  if (process.argv.includes('--json')) {
+    process.stdout.write(JSON.stringify(fails) + '\n');
+  } else if (fails.length === 0) {
+    process.stdout.write('No formal-verification failures — 0 plan-time hypotheses.\n');
+  } else {
+    process.stdout.write(fails.length + ' formal fail(s) → plan-time hypotheses:\n');
+    for (const f of fails) {
+      process.stdout.write('  - [' + (f.surface || '?') + '] ' + (f.check_id || '?') +
+        ' — property ' + (f.property || '?') + ': ' + (f.summary || '') + '\n');
+    }
+  }
+  process.exit(0); // fail-open: never non-zero
+}
+
+module.exports = { extractFvFails };

--- a/bin/extract-fv-fails.test.cjs
+++ b/bin/extract-fv-fails.test.cjs
@@ -1,0 +1,53 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const { extractFvFails } = require('./extract-fv-fails.cjs');
+
+const BIN = path.join(__dirname, 'extract-fv-fails.cjs');
+
+const NDJSON = [
+  { tool: 'run-tlc', result: 'pass', check_id: 'tla:quorum-safety', surface: 'quorum', property: 'Safety', summary: 'pass' },
+  { tool: 'run-tlc', result: 'fail', check_id: 'tla:quorum-liveness', surface: 'quorum', property: 'Liveness', summary: 'fail: counterexample found' },
+  { tool: 'run-tlc', result: 'inconclusive', check_id: 'tla:oscillation', surface: 'oscillation', property: 'NoOsc', summary: 'inconclusive' },
+].map((e) => JSON.stringify(e)).join('\n');
+
+test('extractFvFails identifies only result=fail entries as hypotheses', () => {
+  const fails = extractFvFails(NDJSON);
+  assert.strictEqual(fails.length, 1);
+  assert.strictEqual(fails[0].check_id, 'tla:quorum-liveness');
+  assert.strictEqual(fails[0].property, 'Liveness');
+});
+
+test('extractFvFails returns [] when all pass/inconclusive', () => {
+  const clean = NDJSON.split('\n').filter((l) => !l.includes('"fail"')).join('\n');
+  assert.deepStrictEqual(extractFvFails(clean), []);
+});
+
+test('fail-open: empty / non-string / corrupt input never throws', () => {
+  assert.deepStrictEqual(extractFvFails(''), []);
+  assert.deepStrictEqual(extractFvFails(null), []);
+  assert.deepStrictEqual(extractFvFails('not json\n{bad'), []);
+});
+
+test('CLI reads CHECK_RESULTS_PATH, emits fails JSON, exits 0 (fail-open)', () => {
+  const tmp = path.join(os.tmpdir(), 'fv-' + process.pid + '.ndjson');
+  fs.writeFileSync(tmp, NDJSON);
+  try {
+    const out = execFileSync(process.execPath, [BIN, '--json'], { env: { ...process.env, CHECK_RESULTS_PATH: tmp }, encoding: 'utf8' });
+    const fails = JSON.parse(out);
+    assert.strictEqual(fails.length, 1);
+    assert.strictEqual(fails[0].check_id, 'tla:quorum-liveness');
+  } finally { fs.unlinkSync(tmp); }
+});
+
+test('CLI exits 0 even when the ledger is missing (fail-open)', () => {
+  let code = 0;
+  try { execFileSync(process.execPath, [BIN, '--json'], { env: { ...process.env, CHECK_RESULTS_PATH: '/no/such/ledger.ndjson' }, encoding: 'utf8' }); }
+  catch (e) { code = e.status; }
+  assert.strictEqual(code, 0);
+});

--- a/core/workflows/plan-phase.md
+++ b/core/workflows/plan-phase.md
@@ -572,6 +572,24 @@ If the signal is absent, the delimiters don't match, or JSON.parse would fail: s
 - **`## CHECKPOINT REACHED`:** Present to user, get response, spawn continuation (step 12)
 - **`## PLANNING INCONCLUSIVE`:** Show attempts, offer: Add context / Retry / Manual
 
+## 9.5 Formal Verification Gate (plan-time hypotheses)
+
+Run formal model-checking on the phase's TLA+ models (`run-formal-verify.cjs --only=tla`) and surface any counterexamples as HYPOTHESES for the plan-checker and quorum. A formal FAIL at plan time is strong evidence the plan has a gap — feeding it in as a hypothesis (rather than discovering it at execute/verify) is the best-of-both-worlds fusion: **formal verification informs the quorum's plan review.**
+
+**Fail-open (PLAN-03):** if TLC is unavailable or the results ledger is missing/empty, produce zero hypotheses and continue — never block planning on formal-tool availability.
+
+```bash
+REQ="${HOME}/.claude/nf-bin/run-formal-verify.cjs"; [ -f "$REQ" ] || REQ="./bin/run-formal-verify.cjs"
+node "$REQ" --only=tla 2>/dev/null || true
+
+FVX="${HOME}/.claude/nf-bin/extract-fv-fails.cjs"; [ -f "$FVX" ] || FVX="./bin/extract-fv-fails.cjs"
+FV_HYPOTHESES=$(node "$FVX" --json 2>/dev/null || echo "[]")
+```
+
+`extract-fv-fails.cjs` reads `.planning/formal/check-results.ndjson` and returns every `result=fail` entry as `{ check_id, property, surface, summary }`. Each failing check becomes a plan-time hypothesis: *"formal check {check_id} failed on {property} — confirm the plan addresses this, or the phase will fail formal verification at gate time."*
+
+If `${FV_HYPOTHESES}` is non-empty, thread it into the plan-checker prompt (Step 10) as a `<formal_hypotheses>` block so the checker — and, on quorum review, every voter — evaluates whether the plan closes each formal gap. Empty → omit the block.
+
 ## 10. Spawn nf-plan-checker Agent
 
 ```bash
@@ -603,6 +621,11 @@ Checker prompt:
 </files_to_read>
 
 **Phase requirement IDs (MUST ALL be covered):** {phase_req_ids}
+
+${FV_HYPOTHESES != "[]" ? `<formal_hypotheses>
+Formal model-checking of this phase's TLA+ models produced these FAILING checks at plan time. Treat each as a hypothesis that the plan may have a gap — for every one, verify the plans explicitly address it, or flag it as an uncovered risk (a blocker):
+${FV_HYPOTHESES}
+</formal_hypotheses>` : ''}
 
 **Project instructions:** Verify plans honor project guidelines from CLAUDE.md context (already loaded)
 **Project skills:** Check .agents/skills/ directory (if exists) — verify plans account for project skill rules


### PR DESCRIPTION
Implements the long-standing **RED scaffold** (`plan-phase-fv-gate.test` PLAN-01/02/03, *"FAIL until step 8.3 is implemented"*) — the on-theme feature discovered during the GSD sync: **formal verification informs the planning quorum.**

New plan-phase **Step 9.5** (after planning, before the plan-checker): runs `run-formal-verify.cjs --only=tla`, extracts every `result=fail` from `check-results.ndjson`, and threads them into the plan-checker prompt as a `<formal_hypotheses>` block — so the checker and **every quorum voter** must confirm the plan closes each formal gap, instead of discovering it later at execute/verify time.

- `bin/extract-fv-fails.cjs` — pure `extractFvFails()` + CLI. **Fail-open (PLAN-03):** missing/empty/corrupt ledger → `[]` and exit 0, never blocks planning on formal-tool availability. 5 tests.

**Turns the 2 pre-existing RED scaffolds GREEN: 4/2 → 6/0.**

**Regression gate:** lint:isolation ✓, verify-hooks-sync ✓, 5/5 extract tests, plan-phase-fv-gate 6/0, fixture corpus unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)