### PR TITLE
feat(gsd): seeds — forward-looking idea capture, fused with formal

### DIFF
--- a/bin/seeds.cjs
+++ b/bin/seeds.cjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * bin/seeds.cjs — forward-looking idea capture ("seeds").
+ *
+ * Ported from open-gsd/gsd-core's capture/seeds. A seed is an idea that isn't a task yet:
+ * it carries a TRIGGER condition ("when X happens, do this") and parks in
+ * .planning/seeds/SEED-NNN-slug.md until the trigger fires or it's promoted to the roadmap.
+ * Fills a real gap — we had todos (do-now) but no way to park a conditional future idea.
+ *
+ * nForma fusion: a seed can be tagged `formal: true` (auto-detected from formal-relevant
+ * text, or --formal) so promotion routes through /nf:close-formal-gaps — a parked idea
+ * that changes a formally-modeled behavior lands as an invariant, not just a plan.
+ *
+ * Verbs:
+ *   plant <text> [--trigger <cond>] [--scope <area>] [--formal] [--root <dir>]
+ *   list [--status dormant|promoted|all] [--root <dir>] [--json]
+ *   promote <SEED-NNN> [--root <dir>]   (prints a ROADMAP 999.x backlog entry — non-destructive)
+ *
+ * Exports: slugify, nextSeedId, parseSeed, looksFormal
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const FORMAL_HINT_RE = /\b(invariant|tla\+?|alloy|prism|petri|formal|model[- ]check|state machine|liveness|safety property|deadlock)\b/i;
+
+function slugify(text) {
+  return String(text).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 48) || 'seed';
+}
+
+function looksFormal(text) { return FORMAL_HINT_RE.test(String(text || '')); }
+
+function seedsDir(root) { return path.join(root || process.cwd(), '.planning', 'seeds'); }
+
+function nextSeedId(dir) {
+  let max = 0;
+  try {
+    for (const f of fs.readdirSync(dir)) {
+      const m = f.match(/^SEED-(\d+)-/);
+      if (m) max = Math.max(max, parseInt(m[1], 10));
+    }
+  } catch (_) { /* dir may not exist yet */ }
+  return 'SEED-' + String(max + 1).padStart(3, '0');
+}
+
+function parseSeed(text) {
+  const fm = {};
+  const m = text.match(/^---\n([\s\S]*?)\n---/);
+  if (m) for (const line of m[1].split('\n')) {
+    const kv = line.match(/^(\w+):\s*(.*)$/);
+    if (kv) fm[kv[1]] = kv[2].replace(/^["']|["']$/g, '');
+  }
+  return fm;
+}
+
+function plant(root, textAndOpts) {
+  const { text, trigger, scope, formal, now } = textAndOpts;
+  const dir = seedsDir(root);
+  fs.mkdirSync(dir, { recursive: true });
+  const id = nextSeedId(dir);
+  const slug = slugify(text);
+  const isFormal = formal || looksFormal(text + ' ' + (trigger || ''));
+  const file = path.join(dir, id + '-' + slug + '.md');
+  const created = now || new Date().toISOString();
+  const body = [
+    '---',
+    'id: ' + id,
+    'title: ' + JSON.stringify(text),
+    'status: dormant',
+    'created: ' + created,
+    'trigger: ' + JSON.stringify(trigger || 'none — surface at next /nf:new-milestone'),
+    'scope: ' + JSON.stringify(scope || 'general'),
+    'formal: ' + (isFormal ? 'true' : 'false'),
+    '---',
+    '',
+    '# ' + text,
+    '',
+    '**Trigger:** ' + (trigger || 'none — review at next milestone planning.'),
+    isFormal ? '\n**Formal:** touches a formally-modeled behavior — on promotion, route through `/nf:close-formal-gaps` to land the invariant.\n' : '',
+  ].join('\n');
+  fs.writeFileSync(file, body);
+  return { id, path: file, formal: isFormal };
+}
+
+function list(root, status) {
+  const dir = seedsDir(root);
+  const out = [];
+  let files = [];
+  try { files = fs.readdirSync(dir).filter((f) => /^SEED-\d+-.*\.md$/.test(f)); } catch (_) { return out; }
+  for (const f of files) {
+    let fm = {};
+    try { fm = parseSeed(fs.readFileSync(path.join(dir, f), 'utf8')); } catch (_) { continue; }
+    if (status && status !== 'all' && fm.status !== status) continue;
+    out.push({ id: fm.id || f, title: fm.title || '', status: fm.status || 'dormant', trigger: fm.trigger || '', scope: fm.scope || '', formal: fm.formal === 'true', file: f });
+  }
+  out.sort((a, b) => a.id.localeCompare(b.id));
+  return out;
+}
+
+// ─── CLI ───────────────────────────────────────────────────────────────────
+if (require.main === module) {
+  const argv = process.argv.slice(2);
+  const verb = argv[0];
+  const get = (flag) => { const i = argv.indexOf(flag); return i !== -1 ? argv[i + 1] : undefined; };
+  const has = (flag) => argv.includes(flag);
+  const root = get('--root') || process.cwd();
+
+  try {
+    if (verb === 'plant') {
+      // text = all args after `plant` up to the first --flag
+      const textParts = [];
+      for (let i = 1; i < argv.length && !argv[i].startsWith('--'); i++) textParts.push(argv[i]);
+      const text = textParts.join(' ').trim();
+      if (!text) { process.stderr.write('usage: seeds plant <text> [--trigger C] [--scope S] [--formal]\n'); process.exit(1); }
+      const r = plant(root, { text, trigger: get('--trigger'), scope: get('--scope'), formal: has('--formal') });
+      process.stdout.write('Planted ' + r.id + (r.formal ? ' (formal)' : '') + ' → ' + path.relative(root, r.path) + '\n');
+      process.exit(0);
+    }
+    if (verb === 'list') {
+      const seeds = list(root, get('--status') || 'all');
+      if (has('--json')) { process.stdout.write(JSON.stringify(seeds, null, 2) + '\n'); process.exit(0); }
+      if (seeds.length === 0) { process.stdout.write('No seeds planted.\n'); process.exit(0); }
+      process.stdout.write('Seeds (' + seeds.length + '):\n');
+      for (const s of seeds) process.stdout.write('  ' + s.id + ' [' + s.status + (s.formal ? '·formal' : '') + '] ' + s.title + '  — trigger: ' + s.trigger + '\n');
+      process.exit(0);
+    }
+    if (verb === 'promote') {
+      const id = argv[1];
+      const seeds = list(root, 'all').filter((s) => s.id === id);
+      if (seeds.length === 0) { process.stderr.write('No such seed: ' + id + '\n'); process.exit(1); }
+      const s = seeds[0];
+      process.stdout.write('Add to ROADMAP.md backlog (999.x):\n\n');
+      process.stdout.write('### Phase 999.x: ' + s.title + '\n' + (s.formal ? '> Formal: route through /nf:close-formal-gaps on planning.\n' : '') + '> From ' + s.id + ' · scope: ' + s.scope + '\n');
+      process.exit(0);
+    }
+    process.stderr.write('usage: seeds <plant|list|promote> …\n'); process.exit(1);
+  } catch (e) { process.stderr.write('seeds error: ' + e.message + '\n'); process.exit(1); }
+}
+
+module.exports = { slugify, nextSeedId, parseSeed, looksFormal, plant, list, seedsDir };

--- a/bin/seeds.test.cjs
+++ b/bin/seeds.test.cjs
@@ -1,0 +1,75 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const { slugify, nextSeedId, looksFormal, plant, list } = require('./seeds.cjs');
+
+const BIN = path.join(__dirname, 'seeds.cjs');
+function tmp() { return fs.mkdtempSync(path.join(os.tmpdir(), 'seeds-')); }
+
+test('slugify + looksFormal', () => {
+  assert.strictEqual(slugify('Add a Retry Queue!'), 'add-a-retry-queue');
+  assert.strictEqual(looksFormal('add a TLA+ invariant for the wizard'), true);
+  assert.strictEqual(looksFormal('tweak the button color'), false);
+});
+
+test('plant writes a dormant seed and auto-numbers', () => {
+  const root = tmp();
+  try {
+    const a = plant(root, { text: 'first idea', now: '2026-07-05T00:00:00Z' });
+    const b = plant(root, { text: 'second idea', trigger: 'when we add auth', now: '2026-07-05T00:00:00Z' });
+    assert.strictEqual(a.id, 'SEED-001');
+    assert.strictEqual(b.id, 'SEED-002');
+    const seeds = list(root, 'all');
+    assert.strictEqual(seeds.length, 2);
+    assert.strictEqual(seeds[0].status, 'dormant');
+    assert.strictEqual(seeds[1].trigger, 'when we add auth');
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('fusion: a formally-relevant seed is auto-tagged formal', () => {
+  const root = tmp();
+  try {
+    const r = plant(root, { text: 'prove the state machine has no deadlock', now: '2026-07-05T00:00:00Z' });
+    assert.strictEqual(r.formal, true);
+    const s = list(root, 'all')[0];
+    assert.strictEqual(s.formal, true);
+    assert.match(fs.readFileSync(r.path, 'utf8'), /close-formal-gaps/);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('list --status filters; empty dir → []', () => {
+  const root = tmp();
+  try {
+    assert.deepStrictEqual(list(root, 'all'), []);
+    plant(root, { text: 'x', now: '2026-07-05T00:00:00Z' });
+    assert.strictEqual(list(root, 'dormant').length, 1);
+    assert.strictEqual(list(root, 'promoted').length, 0);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('CLI: plant then list --json; plant text before flags', () => {
+  const root = tmp();
+  try {
+    execFileSync(process.execPath, [BIN, 'plant', 'ship a retry queue', '--trigger', 'when load > 1k', '--scope', 'infra', '--root', root], { encoding: 'utf8' });
+    const out = execFileSync(process.execPath, [BIN, 'list', '--json', '--root', root], { encoding: 'utf8' });
+    const seeds = JSON.parse(out);
+    assert.strictEqual(seeds.length, 1);
+    assert.strictEqual(seeds[0].title, 'ship a retry queue');
+    assert.strictEqual(seeds[0].scope, 'infra');
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('CLI: promote prints a non-destructive backlog entry', () => {
+  const root = tmp();
+  try {
+    execFileSync(process.execPath, [BIN, 'plant', 'add liveness invariant', '--root', root], { encoding: 'utf8' });
+    const out = execFileSync(process.execPath, [BIN, 'promote', 'SEED-001', '--root', root], { encoding: 'utf8' });
+    assert.match(out, /Phase 999\.x: add liveness invariant/);
+    assert.match(out, /close-formal-gaps/); // auto-formal
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});

--- a/commands/nf/seed.md
+++ b/commands/nf/seed.md
@@ -1,0 +1,33 @@
+---
+name: nf:seed
+description: Capture a forward-looking idea (a "seed") with a trigger condition, or list/promote seeds
+argument-hint: "<idea text> [--trigger <when>] [--scope <area>] | list | promote <SEED-NNN>"
+allowed-tools:
+  - Read
+  - Bash
+  - Glob
+---
+
+<objective>
+Park an idea that isn't a task yet. A **seed** carries a TRIGGER ("when X, do this") and rests in `.planning/seeds/` until it fires or is promoted to the roadmap. Fills the gap between "do it now" (todos) and "forget it" — the substrate `/nf:new-milestone` and `/nf:autonomous` can consume.
+
+Ported from open-gsd/gsd-core's capture/seeds. **nForma fusion:** a seed touching a formally-modeled behavior is auto-tagged `formal`, so promotion routes through `/nf:close-formal-gaps` — a parked idea that changes a proven behavior lands as an invariant, not just a plan.
+</objective>
+
+<context>
+Arguments: $ARGUMENTS
+</context>
+
+<process>
+Dispatch to `bin/seeds.cjs` via the portable path:
+
+```bash
+REQ="${HOME}/.claude/nf-bin/seeds.cjs"; [ -f "$REQ" ] || REQ="./bin/seeds.cjs"
+```
+
+- **`list`** → `node "$REQ" list` — browse parked seeds (dormant/promoted, formal-tagged).
+- **`promote <SEED-NNN>`** → `node "$REQ" promote <id>` — print the ROADMAP 999.x backlog entry (non-destructive; you then add it to ROADMAP.md, and if it's `formal` run `/nf:close-formal-gaps`).
+- **anything else** → treat `$ARGUMENTS` as the idea text and plant it: `node "$REQ" plant "<text>" [--trigger <when>] [--scope <area>]`. Confirm the SEED id.
+
+Keep it one action per invocation. Never auto-edit ROADMAP.md — promote prints; the user applies.
+</process>


### PR DESCRIPTION
**Port #7** of the GSD-upstream-sync. A **seed** is an idea that isn't a task yet — it carries a TRIGGER ("when X, do this") and parks in `.planning/seeds/SEED-NNN-slug.md` until it fires or is promoted. Fills the gap between todos (do-now) and forgetting; the substrate `/nf:new-milestone` and `/nf:autonomous` can consume.

**nForma fusion:** a seed touching a formally-modeled behavior (invariant / TLA+ / state machine / liveness / deadlock …) is auto-tagged `formal`, so `promote` routes it through `/nf:close-formal-gaps` — a parked idea that changes a proven behavior lands as an invariant, not just a plan.

- `bin/seeds.cjs` — `plant` / `list` / `promote` (non-destructive: prints a ROADMAP 999.x entry, never edits ROADMAP.md). 6 tests.
- `commands/nf/seed.md` — thin dispatcher.

**Regression gate:** lint:isolation ✓, verify-hooks-sync ✓, 6/6 tests, skill lints ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)