### PR TITLE
feat(gsd): extract-learnings + forensics fused with formal/quorum/memory

### DIFF
--- a/commands/nf/extract-learnings.md
+++ b/commands/nf/extract-learnings.md
@@ -1,0 +1,32 @@
+---
+name: nf:extract-learnings
+description: Mine a completed phase's artifacts into LEARNINGS.md — decisions, lessons, patterns, surprises
+argument-hint: "[phase]"
+allowed-tools:
+  - Read
+  - Bash
+  - Glob
+  - Grep
+  - Write
+---
+
+<objective>
+Turn a completed phase's artifacts (PLAN.md, SUMMARY.md, VERIFICATION.md, UAT.md, STATE.md) into a structured `LEARNINGS.md` — what was decided and why, what surprised us, which patterns recurred — so the next phase and the next milestone start smarter.
+
+Ported from open-gsd/gsd-core's extract-learnings. **nForma fusion:** also mines the *formal* and *quorum* record — which invariants/models changed, what formal verification caught, and which quorum decisions were made — and feeds the durable ones into nForma's decision memory (`bin/memory-store.cjs`), so a learning isn't just a file, it's recalled in future sessions.
+</objective>
+
+<execution_context>
+@~/.claude/nf/workflows/extract-learnings.md
+</execution_context>
+
+<context>
+Phase number: $ARGUMENTS (optional — default: the most recently completed phase).
+</context>
+
+<process>
+1. Resolve the target phase; read its artifacts (PLAN/SUMMARY/VERIFICATION/UAT/STATE) — fail-open on any missing file.
+2. Synthesize four sections: **Decisions** (what + why), **Lessons** (what we'd do differently), **Patterns** (what recurred), **Surprises** (what we didn't expect).
+3. Fusion pass: add **Formal** (invariants/models added or changed, what formal-verify caught) and **Quorum** (notable consensus/BLOCK decisions) subsections from `.planning/formal/` and the quorum record.
+4. Write `${PHASE_DIR}/${PADDED_PHASE}-LEARNINGS.md`; record each durable decision into memory via `bin/memory-store.cjs`.
+</process>

--- a/commands/nf/forensics.md
+++ b/commands/nf/forensics.md
@@ -1,0 +1,34 @@
+---
+name: nf:forensics
+description: Post-mortem for a stuck or failed workflow — diagnose root cause from git + .planning state
+argument-hint: "[optional: what went wrong]"
+allowed-tools:
+  - Read
+  - Bash
+  - Glob
+  - Grep
+  - Write
+---
+
+<objective>
+Investigate what went wrong during a stuck or failed nForma workflow. Analyze git history, `.planning/` artifacts, and filesystem state to detect anomalies and produce a structured diagnostic report — so you understand the root cause and can act, instead of guessing.
+
+Ported from open-gsd/gsd-core's forensics. **nForma fusion:** on top of the generic anomalies, it probes the failure modes specific to our stack — a stuck/degraded quorum, a formal-verify failure or model-staleness, formal-artifact autocommit pollution, and circuit-breaker trips.
+
+Output: a redacted report in `.planning/forensics/`, presented inline. Read-only; never mutates project state.
+</objective>
+
+<execution_context>
+@~/.claude/nf/workflows/forensics.md
+</execution_context>
+
+<context>
+Arguments: $ARGUMENTS (optional — a description of the symptom to focus the investigation).
+</context>
+
+<process>
+1. Snapshot the evidence: `git log`/`status`/`diff` (recent commits, time gaps, uncommitted work, conflicts), `.planning/STATE.md`, and the active phase's artifacts.
+2. Detect generic anomalies: interrupted commits, orphaned artifacts, state/roadmap disagreement, long time-gaps, uncommitted work on a "complete" phase.
+3. **nForma-specific probes:** degraded/stuck quorum (roster all-UNAVAIL, below min_live_voters), formal-verify failures or stale models (`check-model-staleness`), formal-artifact autocommit pollution on a feature branch, circuit-breaker trips (`.claude/circuit-breaker-state.json`).
+4. Write a redacted report to `.planning/forensics/`, rank findings by severity, and present the most likely root cause with 2–3 concrete recovery options.
+</process>

--- a/core/workflows/extract-learnings.md
+++ b/core/workflows/extract-learnings.md
@@ -1,0 +1,72 @@
+# Workflow: extract-learnings
+
+Mine a completed phase's artifacts into a structured LEARNINGS.md, and feed the durable decisions into nForma's memory. Ported from open-gsd/gsd-core, fused with the formal + quorum + memory layers.
+
+<step name="resolve_phase">
+Resolve the target phase.
+
+```bash
+PHASE="${ARGUMENTS}"
+PINFO=$(node ~/.claude/nf/bin/nf-tools.cjs find-phase "${PHASE:-}" 2>/dev/null || true)
+```
+
+- If `$ARGUMENTS` is empty, pick the most recently completed phase (highest-numbered phase whose `disk_status` is `complete` from `roadmap analyze`).
+- Establish `${PHASE_DIR}` and `${PADDED_PHASE}`. If the phase has no directory, report "phase not found / not yet run" and stop.
+
+Continue to read_artifacts.
+</step>
+
+<step name="read_artifacts">
+Read the phase's artifacts — **fail-open** on any that are missing (note "not found", never block):
+- `${PHASE_DIR}/*-PLAN.md` — what we intended, the task breakdown, must-haves.
+- `${PHASE_DIR}/*-SUMMARY.md` — what was actually built, deviations.
+- `${PHASE_DIR}/*-VERIFICATION.md` — what verification found (gaps, fixes).
+- `${PHASE_DIR}/*-UAT.md` — user-acceptance results.
+- `.planning/STATE.md` — session history, blockers hit.
+
+**Fusion sources:**
+- `.planning/formal/` — invariants/models added or changed for this phase; `check-results.ndjson` for what formal-verify caught (`bin/extract-fv-fails.cjs`).
+- Quorum record — notable consensus or BLOCK decisions during the phase (`node bin/memory-store.cjs query-quorum` and any quorum scoreboard).
+
+Continue to synthesize.
+</step>
+
+<step name="synthesize">
+Write `${PHASE_DIR}/${PADDED_PHASE}-LEARNINGS.md` with these sections — each item cited to its source artifact, no invention:
+
+```markdown
+# Phase ${PHASE} — Learnings
+
+## Decisions
+- {decision} — **why:** {rationale} (source: {artifact})
+
+## Lessons
+- {what we'd do differently next time}
+
+## Patterns
+- {what recurred — reusable approach or repeated pitfall}
+
+## Surprises
+- {what we didn't expect — assumption that proved wrong}
+
+## Formal
+- {invariant/model added or changed; what formal-verify caught or proved}
+
+## Quorum
+- {notable consensus / BLOCK and its resolution}
+```
+
+Be honest about uncertainty — a learning with no artifact backing is an opinion; mark it as such or omit it.
+
+Continue to persist_memory.
+</step>
+
+<step name="persist_memory">
+Feed the durable, reusable learnings into nForma's decision memory so they surface in future sessions (not just sit in a file):
+
+```bash
+node ~/.claude/nf/bin/nf-tools.cjs current-timestamp >/dev/null 2>&1 || true
+```
+
+For each **Decision** worth remembering, append it via `bin/memory-store.cjs append-decision` (and `append-quorum` for a notable quorum outcome). Skip ephemeral/phase-specific items — memory is for what changes how we work next time. Report the LEARNINGS.md path and how many decisions were persisted. Never overwrite an existing LEARNINGS.md without noting it.
+</step>

--- a/core/workflows/forensics.md
+++ b/core/workflows/forensics.md
@@ -1,0 +1,56 @@
+# Workflow: forensics
+
+Post-mortem for a stuck/failed nForma workflow. Read-only evidence gathering → anomaly detection → ranked diagnostic report. Ported from open-gsd/gsd-core, fused with nForma-specific failure-mode probes.
+
+<step name="gather_evidence">
+Collect the evidence — all read-only. Never commit, reset, or mutate anything.
+
+```bash
+git log --oneline -20 2>/dev/null
+git log -20 --format='%ci %s' 2>/dev/null   # timestamps → detect long gaps / interrupted runs
+git status --short 2>/dev/null
+git diff --stat 2>/dev/null
+```
+
+Read `.planning/STATE.md` (current position, session history), the active phase's PLAN/SUMMARY/VERIFICATION, and note anything half-written.
+
+Continue to detect_anomalies.
+</step>
+
+<step name="detect_anomalies">
+**Generic anomalies (≥4 classes):**
+- Interrupted commit — staged/uncommitted work with no matching commit; a phase marked in-progress with no recent commits.
+- State ↔ roadmap disagreement — STATE.md says phase N, roadmap/disk says otherwise.
+- Orphaned artifacts — a PLAN with no SUMMARY, a SUMMARY with no verification, a VALIDATION.md with open gaps on a "complete" phase.
+- Time gap — a long stall between the last two commits (possible crash/abandon).
+- Uncommitted work on a "complete" phase.
+
+**nForma-specific probes (the fusion):**
+- **Quorum degraded/stuck** — check the last quorum run for an all-UNAVAIL roster or below-`min_live_voters` consensus; a planning command that never produced a decision. (`node bin/memory-store.cjs query-quorum` and any quorum scoreboard/cache under `.planning/.quorum-cache/`.)
+- **Formal failure / staleness** — `node bin/check-model-staleness.cjs` for models drifted from source; `bin/extract-fv-fails.cjs` for outstanding formal-verify FAILs in `check-results.ndjson`.
+- **Autocommit pollution** — formal artifacts (`.planning/formal/`) committed onto a feature branch by the spec-regen/stop hooks (a known nForma failure mode); flag if the current branch has such commits.
+- **Circuit-breaker trip** — `.claude/circuit-breaker-state.json` present/tripped (a false-positive breaker can silently stall a TDD loop).
+
+Continue to report.
+</step>
+
+<step name="report">
+Write a **redacted** report (strip secrets/tokens/absolute home paths) to `.planning/forensics/{timestamp}-forensics.md` and present inline:
+
+```markdown
+# Forensics — {symptom or "auto-detected"}
+
+## Most likely root cause
+{one-line diagnosis}
+
+## Findings (severity-ranked)
+| Severity | Finding | Evidence |
+|----------|---------|----------|
+| HIGH | {…} | {git ref / file:line / state} |
+
+## Recovery options
+1. {concrete action}  2. {…}  3. {…}
+```
+
+Rank by severity, lead with the single most likely root cause, and give concrete recovery actions (e.g. "reset the circuit breaker: `rm .claude/circuit-breaker-state.json`", "clean+push the polluted formal artifacts atomically", "re-run quorum with `--force-quorum` after providers recover"). Read-only — recommend actions, never take destructive ones. Optionally offer to open an issue.
+</step>


### PR DESCRIPTION
**Port #8** — two prompt-driven retrospective tools (low coupling).

**`/nf:extract-learnings`** — mines a completed phase's artifacts (PLAN/SUMMARY/VERIFICATION/UAT/STATE) into `LEARNINGS.md` (decisions/lessons/patterns/surprises). **Fusion:** adds **Formal** (invariants/models changed, what formal-verify caught) + **Quorum** subsections, and feeds durable decisions into decision memory (`memory-store.cjs append-decision`) so a learning is *recalled* next session. Distinct from our transcript-based `learning-extractor.cjs` — this is phase-artifact-based.

**`/nf:forensics`** — read-only post-mortem for a stuck/failed workflow: git + `.planning` anomaly scan → ranked report. **Fusion:** probes nForma failure modes — degraded/stuck quorum, formal-verify failures + model-staleness, formal-artifact autocommit pollution, circuit-breaker trips.

Both are command+workflow pairs; read-only / fail-open; reuse existing bins.

**Regression gate:** lint:isolation ✓, verify-hooks-sync ✓, skill lints ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new workflow to generate phase learnings from completed planning and verification artifacts.
  * Added a forensic workflow for diagnosing stuck or failed workflows with a structured report.
  * The learnings process now captures decisions and notable quorum outcomes in long-term memory.

* **Documentation**
  * Added user-facing guidance for producing learnings and post-mortem reports.
  * Reports now include ranked findings and recommended next steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->