### PR TITLE
feat(gsd): eval pipeline (AI-feature audit) fused with quorum

### DIFF
--- a/bin/eval-score.cjs
+++ b/bin/eval-score.cjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * bin/eval-score.cjs — deterministic AI-feature evaluation score + verdict.
+ *
+ * Ported from open-gsd/gsd-core's `eval.score` query (their agents call it so scores are
+ * computed deterministically, never by hand). Given a dimension-coverage count and the
+ * status of 5 eval-infra components, returns coverage/infra/overall scores and a verdict.
+ *
+ * nForma fusion: a verdict within BORDERLINE_MARGIN of a threshold is flagged
+ * `quorum_recommended` — a multi-LLM fork should quorum-confirm whether an AI feature is
+ * truly production-ready rather than trust one judge on a borderline call.
+ *
+ * Weights: overall = 70% coverage + 30% infra. Infra: ok=1, partial=0.5, missing=0.
+ * Verdicts: ≥85 PRODUCTION READY · ≥60 NEEDS WORK · ≥30 SIGNIFICANT GAPS · else NOT IMPLEMENTED.
+ *
+ * Exports: scoreEval, INFRA_KEYS
+ * CLI: node bin/eval-score.cjs --covered N --total D --infra ok,partial,missing,ok,partial [--json]
+ */
+
+const INFRA_KEYS = ['tooling', 'dataset', 'cicd', 'guardrails', 'tracing'];
+const INFRA_VALUE = { ok: 1, partial: 0.5, missing: 0 };
+const THRESHOLDS = [
+  { min: 85, verdict: 'PRODUCTION READY' },
+  { min: 60, verdict: 'NEEDS WORK' },
+  { min: 30, verdict: 'SIGNIFICANT GAPS' },
+  { min: 0, verdict: 'NOT IMPLEMENTED' },
+];
+const BORDERLINE_MARGIN = 5; // points within a threshold boundary → quorum-confirm
+
+function clamp01(x) { return Math.max(0, Math.min(1, x)); }
+
+/**
+ * @param {number} covered  dimensions COVERED (PARTIAL counted as 0.5 by the caller's count)
+ * @param {number} total    total rubric dimensions
+ * @param {string[]} infra   5 statuses (ok|partial|missing), order = INFRA_KEYS
+ * @returns {{coverage_score,infra_score,overall_score,verdict,quorum_recommended}}
+ */
+function scoreEval(covered, total, infra) {
+  const cov = total > 0 ? clamp01(covered / total) : 0;
+  const infraList = Array.isArray(infra) ? infra : [];
+  const infraVals = INFRA_KEYS.map((_, i) => {
+    const v = String(infraList[i] || 'missing').toLowerCase();
+    return INFRA_VALUE[v] !== undefined ? INFRA_VALUE[v] : 0;
+  });
+  const infraScore = infraVals.reduce((a, b) => a + b, 0) / INFRA_KEYS.length;
+  const overall = Math.round((0.7 * cov + 0.3 * infraScore) * 100);
+  const verdict = (THRESHOLDS.find((t) => overall >= t.min) || THRESHOLDS[THRESHOLDS.length - 1]).verdict;
+  // borderline: within margin of ANY internal boundary (85/60/30)
+  const boundaries = [85, 60, 30];
+  const quorumRecommended = boundaries.some((b) => Math.abs(overall - b) <= BORDERLINE_MARGIN);
+  return {
+    coverage_score: Math.round(cov * 100),
+    infra_score: Math.round(infraScore * 100),
+    overall_score: overall,
+    verdict,
+    quorum_recommended: quorumRecommended,
+  };
+}
+
+if (require.main === module) {
+  const argv = process.argv.slice(2);
+  const get = (f) => { const i = argv.indexOf(f); return i !== -1 ? argv[i + 1] : undefined; };
+  const covered = parseFloat(get('--covered'));
+  const total = parseFloat(get('--total'));
+  const infra = (get('--infra') || '').split(',').map((s) => s.trim());
+  if (!Number.isFinite(covered) || !Number.isFinite(total)) {
+    process.stderr.write('usage: eval-score --covered N --total D --infra tooling,dataset,cicd,guardrails,tracing [--json]\n');
+    process.exit(1);
+  }
+  const r = scoreEval(covered, total, infra);
+  if (argv.includes('--json')) {
+    process.stdout.write(JSON.stringify(r) + '\n');
+  } else {
+    process.stdout.write('Overall: ' + r.overall_score + '/100 (coverage ' + r.coverage_score + ', infra ' + r.infra_score + ')\n');
+    process.stdout.write('Verdict: ' + r.verdict + (r.quorum_recommended ? '  — BORDERLINE: quorum-confirm recommended (/nf:quorum)' : '') + '\n');
+  }
+  process.exit(0);
+}
+
+module.exports = { scoreEval, INFRA_KEYS };

--- a/bin/eval-score.test.cjs
+++ b/bin/eval-score.test.cjs
@@ -1,0 +1,63 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { execFileSync } = require('node:child_process');
+const path = require('node:path');
+const { scoreEval } = require('./eval-score.cjs');
+
+const BIN = path.join(__dirname, 'eval-score.cjs');
+
+test('full coverage + all infra ok → PRODUCTION READY', () => {
+  const r = scoreEval(5, 5, ['ok', 'ok', 'ok', 'ok', 'ok']);
+  assert.strictEqual(r.coverage_score, 100);
+  assert.strictEqual(r.infra_score, 100);
+  assert.strictEqual(r.overall_score, 100);
+  assert.strictEqual(r.verdict, 'PRODUCTION READY');
+});
+
+test('nothing covered / no infra → NOT IMPLEMENTED', () => {
+  const r = scoreEval(0, 5, ['missing', 'missing', 'missing', 'missing', 'missing']);
+  assert.strictEqual(r.overall_score, 0);
+  assert.strictEqual(r.verdict, 'NOT IMPLEMENTED');
+});
+
+test('partial infra is half-weight', () => {
+  const r = scoreEval(0, 5, ['partial', 'partial', 'partial', 'partial', 'partial']);
+  assert.strictEqual(r.infra_score, 50);
+  // overall = 0.7*0 + 0.3*0.5 = 0.15 → 15
+  assert.strictEqual(r.overall_score, 15);
+  assert.strictEqual(r.verdict, 'NOT IMPLEMENTED');
+});
+
+test('mid coverage → SIGNIFICANT GAPS / NEEDS WORK band', () => {
+  // covered 3/5=0.6, infra all ok=1 → 0.7*0.6 + 0.3*1 = 0.72 → 72 → NEEDS WORK
+  const r = scoreEval(3, 5, ['ok', 'ok', 'ok', 'ok', 'ok']);
+  assert.strictEqual(r.overall_score, 72);
+  assert.strictEqual(r.verdict, 'NEEDS WORK');
+});
+
+test('fusion: a score near a threshold flags quorum_recommended', () => {
+  // aim for ~85: coverage 1.0, infra: need 0.3*infra so overall lands ~83-87.
+  // coverage 0.8 (4/5), infra all ok → 0.7*0.8 + 0.3*1 = 0.86 → 86 → within 5 of 85 → borderline
+  const r = scoreEval(4, 5, ['ok', 'ok', 'ok', 'ok', 'ok']);
+  assert.strictEqual(r.overall_score, 86);
+  assert.strictEqual(r.quorum_recommended, true);
+});
+
+test('a clearly-non-borderline score does NOT flag quorum', () => {
+  const r = scoreEval(5, 5, ['ok', 'ok', 'ok', 'ok', 'ok']); // 100, far from any boundary
+  assert.strictEqual(r.quorum_recommended, false);
+});
+
+test('missing infra entries default to missing (not a crash)', () => {
+  const r = scoreEval(5, 5, ['ok']); // only 1 of 5 provided
+  assert.strictEqual(r.infra_score, 20); // 1/5
+  assert.strictEqual(r.verdict, 'NEEDS WORK'); // 0.7*1 + 0.3*0.2 = 0.76 → 76
+});
+
+test('CLI --json', () => {
+  const out = execFileSync(process.execPath, [BIN, '--covered', '5', '--total', '5', '--infra', 'ok,ok,ok,ok,ok', '--json'], { encoding: 'utf8' });
+  const r = JSON.parse(out);
+  assert.strictEqual(r.verdict, 'PRODUCTION READY');
+});

--- a/commands/nf/eval-review.md
+++ b/commands/nf/eval-review.md
@@ -1,0 +1,35 @@
+---
+name: nf:eval-review
+description: Audit an AI/LLM feature's evaluation coverage → scored EVAL-REVIEW.md with a production-readiness verdict
+argument-hint: "[phase or feature]"
+allowed-tools:
+  - Read
+  - Bash
+  - Glob
+  - Grep
+  - Write
+---
+
+<objective>
+Retroactively audit whether an AI/LLM feature is actually evaluated — not just built. Checks the planned eval rubric (faithfulness, hallucination, safety, schema, task-specific dimensions) against what's really implemented, scores it deterministically, and produces an `EVAL-REVIEW.md` with a production-readiness verdict + remediation plan.
+
+Ported from open-gsd/gsd-core's eval pipeline. **nForma fusion:** nForma is itself an LLM system (quorum + LLM-powered skills), so it should hold its own AI features to this bar. And because we have a real multi-LLM quorum, a **borderline verdict is confirmed by quorum** — `bin/eval-score.cjs` flags `quorum_recommended` when the score sits near a threshold, and this command routes that call to `/nf:quorum` for a multi-model second opinion instead of trusting one judge.
+
+Output: `${PHASE_DIR}/EVAL-REVIEW.md` — score, verdict, dimension coverage, infra audit, remediation.
+</objective>
+
+<execution_context>
+@~/.claude/nf/workflows/eval-review.md
+</execution_context>
+
+<context>
+Target: $ARGUMENTS — a phase number or an AI feature name (e.g. "quorum consensus"). Reads the phase's AI-SPEC.md / eval strategy if present.
+</context>
+
+<process>
+1. Identify the AI feature + its planned eval rubric (from AI-SPEC.md, REQUIREMENTS, or infer the dimensions the feature demands).
+2. Audit each dimension COVERED / PARTIAL / MISSING against the implementation (does an eval that targets the behavior actually run?), and the 5 infra components (tooling / dataset / cicd / guardrails / tracing) ok / partial / missing.
+3. Score deterministically via `bin/eval-score.cjs` — never compute by hand.
+4. If the result is `quorum_recommended` (borderline), offer to confirm the verdict via `/nf:quorum`.
+5. Write EVAL-REVIEW.md with the verbatim score/verdict + a remediation plan for every PARTIAL/MISSING.
+</process>

--- a/core/workflows/eval-review.md
+++ b/core/workflows/eval-review.md
@@ -1,0 +1,69 @@
+# Workflow: eval-review
+
+Audit an AI/LLM feature's evaluation coverage, score it deterministically, and produce EVAL-REVIEW.md. Ported from open-gsd/gsd-core, fused with nForma's quorum (borderline verdicts are quorum-confirmed).
+
+<step name="identify_feature">
+Resolve the target from `$ARGUMENTS` (a phase number or a feature name).
+
+- Read the phase's `AI-SPEC.md` / eval strategy if present. If none exists, infer the rubric the feature demands — for an LLM feature that typically includes: **faithfulness/groundedness, hallucination, safety/refusal, output-schema conformance,** plus any task-specific dimension.
+- List the total rubric dimensions `D`. If there is genuinely no AI/LLM behavior here, report "not an AI feature — eval-review does not apply" and stop.
+
+Continue to audit_dimensions.
+</step>
+
+<step name="audit_dimensions">
+For each rubric dimension, classify against the **implementation** (be adversarial — "an eval file exists" ≠ "the behavior is evaluated"):
+- **COVERED** — an eval targeting this behavior exists and actually runs (automated or documented-manual).
+- **PARTIAL** — exists but incomplete / not automated / known gaps. (counts as 0.5)
+- **MISSING** — no implementation for this dimension.
+
+Count `covered` = (#COVERED) + 0.5·(#PARTIAL). Record, for each PARTIAL/MISSING, what was planned, what was found, and the specific remediation to reach COVERED.
+
+Then audit the **5 infra components** ok / partial / missing:
+- **tooling** — eval framework installed AND actually called (not just a dependency).
+- **dataset** — a reference dataset file exists and meets the size/composition spec.
+- **cicd** — evals run in CI, not only locally.
+- **guardrails** — each planned online guardrail is in the request path (not stubbed).
+- **tracing** — tracing configured and wrapping the actual AI calls.
+
+Continue to score.
+</step>
+
+<step name="score">
+Score deterministically — do NOT compute by hand:
+
+```bash
+REQ="${HOME}/.claude/nf-bin/eval-score.cjs"; [ -f "$REQ" ] || REQ="./bin/eval-score.cjs"
+node "$REQ" --covered <covered> --total <D> --infra <tooling>,<dataset>,<cicd>,<guardrails>,<tracing> --json
+```
+
+Parse `coverage_score`, `infra_score`, `overall_score`, `verdict`, `quorum_recommended`. Use them verbatim.
+
+**Fusion — borderline → quorum:** if `quorum_recommended` is true (the score sits within 5 points of a verdict boundary), the single-judge call is not trustworthy. Offer:
+
+> Verdict {V} is **borderline** ({score}/100). Confirm with a multi-model second opinion? → `/nf:quorum` "Is the {feature} AI evaluation production-ready given: {dimension summary}?"
+
+Continue to report.
+</step>
+
+<step name="report">
+Write `${PHASE_DIR}/EVAL-REVIEW.md`:
+
+```markdown
+# EVAL-REVIEW — {feature}
+
+**Overall:** {overall_score}/100  ·  **Verdict:** {verdict}{ (borderline — quorum-confirm) if flagged}
+Coverage {coverage_score} · Infra {infra_score}
+
+## Dimension coverage
+| Dimension | Status | Evidence | Remediation (if not COVERED) |
+
+## Infra
+| Component | Status | Note |
+
+## Remediation plan
+1. {highest-leverage gap → concrete action}
+```
+
+Lead with the verdict, list every PARTIAL/MISSING with a concrete path to COVERED, and — if borderline — the quorum-confirm offer. Never recompute or override the tool's score. Read-only except writing EVAL-REVIEW.md.
+</step>


### PR DESCRIPTION
**Port #10** of the GSD-upstream-sync. **eval-review** retroactively audits whether an AI/LLM feature is actually *evaluated* (not just built) — checks the rubric (faithfulness, hallucination, safety, schema, task-specific) + 5 infra components, scores it, and produces `EVAL-REVIEW.md` with a production-readiness verdict.

**nForma fusion:** nForma is itself an LLM system (quorum + LLM skills), so it should hold its own AI features to this bar — AND because we have a real multi-LLM quorum, a **borderline verdict is confirmed by quorum** instead of trusting one judge. `eval-score.cjs` flags `quorum_recommended` when the score sits within 5 points of a verdict boundary → routes to `/nf:quorum`.

- `bin/eval-score.cjs` — deterministic scorer reimplementing their `eval.score` query (70% coverage + 30% infra; 4 verdict bands; borderline detection). 8 tests.
- `commands/nf/eval-review.md` + workflow.

**Regression gate:** lint:isolation ✓, verify-hooks-sync ✓, 8/8 tests, skill lints ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)