### PR TITLE
fix(dogfood): 6 real skill-execution bugs found by running all 68 existing skills

### DIFF
--- a/bin/install-helpers.cjs
+++ b/bin/install-helpers.cjs
@@ -15,7 +15,7 @@ const path = require('path');
 
 // Runtime .mjs files that must be copied into nf-bin/ (the copy loop's primary
 // filter is the generic `*.cjs` match; these are the non-.cjs runtime files).
-const NF_BIN_RUNTIME_MJS = new Set(['unified-mcp-server.mjs']);
+const NF_BIN_RUNTIME_MJS = new Set(['unified-mcp-server.mjs', 'proximity-embed.mjs']);
 
 // Bundled non-code DATA files a runtime script loads by path relative to itself
 // (e.g. sast-sweep.cjs resolves sast-rules.yaml via __dirname). Without this they

--- a/bin/install-helpers.test.cjs
+++ b/bin/install-helpers.test.cjs
@@ -1380,3 +1380,10 @@ test('DP-19: reconstruction branch must not spread a non-object preset.env (stri
       'inherited vanilla env keys must survive a non-object preset.env reconstruction');
   } finally { fs.rmSync(dir, { recursive: true, force: true }); }
 });
+
+// Dogfood: proximity-embed.mjs must ship to nf-bin, else /nf:proximity's embedding step
+// (and nf-solve Phase 0) silently no-ops in every installed user project.
+test('DOGFOOD: proximity-embed.mjs is copied to nf-bin (runtime .mjs allowlist)', () => {
+  assert.strictEqual(shouldCopyToNfBin('proximity-embed.mjs'), true);
+  assert.strictEqual(shouldCopyToNfBin('unified-mcp-server.mjs'), true);
+});

--- a/bin/install.js
+++ b/bin/install.js
@@ -3078,6 +3078,32 @@ function install(isGlobal, runtime = 'claude') {
         // Unexpected error — skip silently (fail-open)
       }
     }
+
+    // Vendor `xstate` to nf-bin (fail-open). validate-traces.cjs / state-candidates.cjs
+    // `require('xstate')` at runtime; from the repo it resolves via the repo's node_modules,
+    // but an installed copy in ~/.claude/nf-bin/ has no complete xstate — a stale partial
+    // copy (dist + LICENSE, NO package.json) made `require('xstate')` fail, so those tools
+    // silently died in every user project. Guard on package.json (not just the dir) so this
+    // repairs the partial copy, not just a fresh install.
+    {
+      const { spawnSync: _spawnXs } = require('child_process');
+      try {
+        const nfBinRoot = path.join(os.homedir(), '.claude', 'nf-bin');
+        const xstatePkg = path.join(nfBinRoot, 'node_modules', 'xstate', 'package.json');
+        if (!fs.existsSync(xstatePkg)) {
+          console.log(`  ${cyan}↓${reset} Vendoring xstate to nf-bin...`);
+          const xsInstall = _spawnXs('npm', ['install', '--prefix', nfBinRoot, 'xstate'], { timeout: 120000 });
+          if (xsInstall.status === 0) {
+            console.log(`  ${green}✓${reset} xstate vendored`);
+          } else {
+            const errOut = xsInstall.stderr ? xsInstall.stderr.toString().slice(0, 120) : '';
+            console.log(`  ${yellow}⚠${reset} xstate vendoring skipped: npm returned non-zero${errOut ? ' (' + errOut + ')' : ''}`);
+          }
+        }
+      } catch (e) {
+        // fail-open
+      }
+    }
   } // end NF_INSTALL_SKIP_OPTIONAL guard
 
   // Validate hook path references point to real targets

--- a/bin/load-baseline-requirements.cjs
+++ b/bin/load-baseline-requirements.cjs
@@ -3,6 +3,18 @@
 
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
+
+// Resolve the baseline-requirements defaults dir portably. From the repo this is
+// ../core/defaults/... relative to bin/; but when this script is installed to
+// ~/.claude/nf-bin/, that repo-relative path points at the non-existent
+// ~/.claude/core/defaults/ — the installer places the defaults at ~/.claude/nf/defaults/.
+// Try the repo-local path, then fall back to the installed location.
+function resolveDefaultsBase() {
+  const repoLocal = path.resolve(__dirname, '../core/defaults/baseline-requirements');
+  if (fs.existsSync(repoLocal)) return repoLocal;
+  return path.join(os.homedir(), '.claude', 'nf', 'defaults', 'baseline-requirements');
+}
 
 /**
  * Load baseline requirements filtered by project profile.
@@ -12,7 +24,7 @@ const path = require('path');
  * @returns {Object} { profile, label, description, categories: [...], total }
  */
 function loadBaselineRequirements(profile, basePath) {
-  const defaultBasePath = path.resolve(__dirname, '../core/defaults/baseline-requirements');
+  const defaultBasePath = resolveDefaultsBase();
   const basePathToUse = basePath || defaultBasePath;
 
   // Read index.json
@@ -105,7 +117,7 @@ function loadBaselineRequirements(profile, basePath) {
  * @returns {Object} { profile, label, intent, categories, packs_applied, total }
  */
 function loadBaselineRequirementsFromIntent(intent, basePath) {
-  const defaultBasePath = path.resolve(__dirname, '../core/defaults/baseline-requirements');
+  const defaultBasePath = resolveDefaultsBase();
   const basePathToUse = basePath || defaultBasePath;
 
   // Validate base_profile

--- a/commands/nf/proximity.md
+++ b/commands/nf/proximity.md
@@ -35,7 +35,11 @@ Store parsed flags for use in downstream steps.
 
 ## Step 2: Build proximity graph
 
-Run: `node bin/formal-proximity.cjs`
+Run (portable — installed nf-bin primary, repo CWD fallback):
+```bash
+NFBIN="$HOME/.claude/nf-bin"; [ -f "$NFBIN/formal-proximity.cjs" ] || NFBIN="./bin"
+node "$NFBIN/formal-proximity.cjs"
+```
 
 - **If graph exists and `--rebuild` NOT set:** Skip build, report cached graph stats: "Graph cached (N nodes, E edges, U orphans)"
 - **If `--rebuild` is set:** Delete `.planning/formal/proximity-index.json` first, then run builder
@@ -54,7 +58,11 @@ node -e "require('@huggingface/transformers')" 2>/dev/null
 
 - **If dependency is NOT installed:** Skip silently (embeddings are optional).
 - **If dependency IS installed but `.planning/formal/embedding-cache.json` is missing or `--rebuild` is set:**
-  - Run: `node bin/proximity-embed.mjs --cache-only`
+  - Run (portable):
+    ```bash
+    NFBIN="$HOME/.claude/nf-bin"; [ -f "$NFBIN/proximity-embed.mjs" ] || NFBIN="./bin"
+    node "$NFBIN/proximity-embed.mjs" --cache-only
+    ```
   - Display: "Building embedding cache (local CPU, ~30s)..."
   - On completion: report vector count from output
 - **If cache exists and `--rebuild` NOT set:** Skip, report: "Embedding cache loaded (N vectors)"
@@ -65,7 +73,11 @@ Progress line: `[1.5/6] Checking embeddings...`
 
 ## Step 3: Discover candidates
 
-Run: `node bin/candidate-discovery.cjs --min-score <val> --max-hops <val> --top <val> --non-neighbor-top <val> --json`
+Run (portable):
+```bash
+NFBIN="$HOME/.claude/nf-bin"; [ -f "$NFBIN/candidate-discovery.cjs" ] || NFBIN="./bin"
+node "$NFBIN/candidate-discovery.cjs" --min-score <val> --max-hops <val> --top <val> --non-neighbor-top <val> --json
+```
 
 - Pass `--min-score` and `--max-hops` from parsed arguments
 - If `--top` not specified by user, pass `--top 0` (no limit — ensemble naturally caps at ~100 candidates)
@@ -85,7 +97,11 @@ If `--skip-eval` is set:
 Otherwise, attempt the script first:
 
 **4a. Try script:**
-- Run: `node bin/haiku-semantic-eval.cjs` via Bash
+- Run (portable) via Bash:
+```bash
+NFBIN="$HOME/.claude/nf-bin"; [ -f "$NFBIN/haiku-semantic-eval.cjs" ] || NFBIN="./bin"
+node "$NFBIN/haiku-semantic-eval.cjs"
+```
 - If exit code is 0: display verdict distribution from stderr output ("Evaluation complete (via: script). yes: X, no: Y, maybe: Z") and continue to Step 5. Done.
 - If exit code is non-zero: log the error, then proceed to 4b (sub-agent fallback).
 
@@ -116,7 +132,11 @@ Progress line: `[3/6] Running semantic evaluation (Haiku)...`
 
 ## Step 5: Compute semantic scores
 
-Run: `node bin/compute-semantic-scores.cjs --json`
+Run (portable):
+```bash
+NFBIN="$HOME/.claude/nf-bin"; [ -f "$NFBIN/compute-semantic-scores.cjs" ] || NFBIN="./bin"
+node "$NFBIN/compute-semantic-scores.cjs" --json
+```
 
 - Display per-gate score summary (A, B, C scores)
 - Show median, min, max for each gate
@@ -126,7 +146,11 @@ Progress line: `[4/6] Computing semantic scores...`
 
 ## Step 6: Generate pairings
 
-Run: `node bin/candidate-pairings.cjs --json`
+Run (portable):
+```bash
+NFBIN="$HOME/.claude/nf-bin"; [ -f "$NFBIN/candidate-pairings.cjs" ] || NFBIN="./bin"
+node "$NFBIN/candidate-pairings.cjs" --json
+```
 
 - Display pairing status summary:
   - Total pairings

--- a/core/bin/nf-tools.cjs
+++ b/core/bin/nf-tools.cjs
@@ -2185,6 +2185,10 @@ function cmdSummaryExtract(cwd, summaryPath, fields, raw) {
     tech_added: (fm['tech-stack'] && fm['tech-stack'].added) || [],
     patterns: fm['patterns-established'] || [],
     decisions: parseDecisions(fm['key-decisions']),
+    // requirements-completed: REQ-IDs this phase closed (audit-milestone's SUMMARY-frontmatter
+    // cross-check reads this — it was requesting a field summary-extract never emitted, so
+    // that arm of the 3-source status matrix always went null).
+    requirements_completed: fm['requirements-completed'] || fm['requirements_completed'] || [],
   };
 
   // If fields specified, filter to only those fields

--- a/core/workflows/debug.md
+++ b/core/workflows/debug.md
@@ -59,7 +59,7 @@ Pack Repowise intelligence context for the debug session. This injects hotspot r
 ```bash
 REPOWISE_CONTEXT=""
 if command -v node >/dev/null 2>&1; then
-  REPOWISE_CONTEXT=$(node ~/.claude/nf-bin/context-packer.cjs --hotspot --cochange --focus "$ARGUMENTS" --project-root="$(pwd)" 2>/dev/null || node bin/repowise/context-packer.cjs --hotspot --cochange --project-root="$(pwd)" 2>/dev/null || echo "")
+  REPOWISE_CONTEXT=$(node ~/.claude/nf-bin/repowise/context-packer.cjs --hotspot --cochange --focus "$ARGUMENTS" --project-root="$(pwd)" 2>/dev/null || node bin/repowise/context-packer.cjs --hotspot --cochange --project-root="$(pwd)" 2>/dev/null || echo "")
 fi
 ```
 

--- a/test/install-mcp-nfbin.test.cjs
+++ b/test/install-mcp-nfbin.test.cjs
@@ -43,9 +43,12 @@ describe('mcpArgsNeedMigration — repo-tree → nf-bin args migration (issue #2
 });
 
 describe('shouldCopyToNfBin — nf-bin copy filter (issue #200)', () => {
-  it('selects unified-mcp-server.mjs (the bug: .mjs was skipped)', () => {
+  it('selects runtime .mjs on the allowlist (the bug: .mjs was skipped)', () => {
     assert.equal(shouldCopyToNfBin('unified-mcp-server.mjs'), true);
     assert.ok(NF_BIN_RUNTIME_MJS.has('unified-mcp-server.mjs'));
+    // proximity-embed.mjs must ship too (dogfood: /nf:proximity + nf-solve Phase 0 need it)
+    assert.equal(shouldCopyToNfBin('proximity-embed.mjs'), true);
+    assert.ok(NF_BIN_RUNTIME_MJS.has('proximity-embed.mjs'));
   });
 
   it('still selects .cjs dispatch scripts', () => {
@@ -58,7 +61,7 @@ describe('shouldCopyToNfBin — nf-bin copy filter (issue #200)', () => {
   });
 
   it('does not select unrelated .mjs / other files', () => {
-    assert.equal(shouldCopyToNfBin('proximity-embed.mjs'), false);
+    assert.equal(shouldCopyToNfBin('some-random-tool.mjs'), false); // not on the allowlist
     assert.equal(shouldCopyToNfBin('README.md'), false);
     assert.equal(shouldCopyToNfBin('something.test.js'), false);
   });


### PR DESCRIPTION
Dogfooding all 68 pre-session skills (real embedded-logic execution against a sandbox, 6 parallel agents) surfaced **6 real "works-green-but-broken-in-real-execution" bugs** — the class unit tests miss because they cover pure helpers, not the installed invocation. Each is an independent, revertible commit:

1. **debug** — primary `context-packer` path missing `repowise/` → dead, silently skipped Repowise context in every user project.
2. **proximity** — 6 bare `node bin/*.cjs` → `Cannot find module` outside the repo root (lint:isolation only checks `require`, not `node bin/` prose).
3. **install / proximity-embed.mjs** — not in the nf-bin `.mjs` allowlist → embedding step no-op'd in installs.
4. **install / xstate** — nf-bin had a partial xstate (no package.json) → `state-candidates`/`validate-traces` crashed in installs; now vendored complete.
5. **sync-baselines** — defaults resolved to `~/.claude/core/defaults/` (repo layout) but install puts them at `~/.claude/nf/defaults/` → ENOENT in installs.
6. **audit-milestone** — `summary-extract` never emitted `requirements_completed`, so the SUMMARY cross-check arm was always null.

All verified fixed against both the repo and the installed nf-bin. Regression-gated: lint:isolation, install-helpers (+1 guard), load-baseline (33), nf-tools (201) all green. The rest of the 68 skills execute cleanly or are genuinely NEEDS-LIVE (quorum-fleet / GitHub / full orchestration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved installer support for additional runtime components and optional dependencies, helping set up more tools automatically.
  * Updated command guidance to work from either the local install or the user’s home-based tool directory.

* **Bug Fixes**
  * Fixed baseline requirements loading so it works across different install locations.
  * Added missing summary metadata output for extracted requirement details.
  * Improved fallback behavior so installer steps continue even if one optional package cannot be fetched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->