### PR TITLE
fix(solve): degraded-convergence guard (CE-5 quorum found this)

### DIFF
--- a/bin/nf-solve-degraded.test.cjs
+++ b/bin/nf-solve-degraded.test.cjs
@@ -1,0 +1,45 @@
+'use strict';
+
+// Degraded-convergence guard (CE-5 quorum dogfood finding): a skipped layer (residual -1)
+// must not read as "clean" in the aggregate. computeUnmeasuredLayers surfaces skipped layers
+// so a total===0 is never mistaken for a proven convergence when a layer didn't run.
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { computeUnmeasuredLayers } = require('./nf-solve.cjs');
+
+test('all layers measured (residual >= 0) → no unmeasured (not degraded)', () => {
+  const layers = { r_to_f: { residual: 0 }, f_to_t: { residual: 3 }, c_to_f: { residual: 0 } };
+  assert.deepStrictEqual(computeUnmeasuredLayers(layers), []);
+});
+
+test('a skipped layer (residual -1) is flagged unmeasured — the false-convergence hole', () => {
+  const layers = { r_to_f: { residual: 0 }, f_to_t: { residual: -1 }, c_to_f: { residual: 0 } };
+  assert.deepStrictEqual(computeUnmeasuredLayers(layers), ['f_to_t']);
+});
+
+test('multiple skipped layers all surface', () => {
+  const layers = { a: { residual: -1 }, b: { residual: 2 }, c: { residual: -1 } };
+  assert.deepStrictEqual(computeUnmeasuredLayers(layers).sort(), ['a', 'c']);
+});
+
+test('a clean total (0) with a skipped layer is DEGRADED, not converged', () => {
+  // Simulates the bug: r_to_f measured clean (0), but f_to_t was skipped (-1). The old
+  // aggregate would sum to 0 and read as "converged". The guard says: degraded.
+  const layers = { r_to_f: { residual: 0 }, f_to_t: { residual: -1 } };
+  const unmeasured = computeUnmeasuredLayers(layers);
+  const degraded = unmeasured.length > 0;
+  assert.strictEqual(degraded, true, 'a 0-residual total with a skipped layer must be degraded');
+});
+
+test('non-numeric / missing residual counts as unmeasured (not >= 0)', () => {
+  assert.deepStrictEqual(
+    computeUnmeasuredLayers({ a: {}, b: { residual: undefined }, c: { residual: 'x' }, d: { residual: 0 } }).sort(),
+    ['a', 'b', 'c']
+  );
+});
+
+test('bad input degrades to [] without throwing', () => {
+  assert.deepStrictEqual(computeUnmeasuredLayers(null), []);
+  assert.deepStrictEqual(computeUnmeasuredLayers(undefined), []);
+});

--- a/bin/nf-solve.cjs
+++ b/bin/nf-solve.cjs
@@ -4920,6 +4920,15 @@ function computeResidual() {
     (d_to_c.residual >= 0 ? d_to_c.residual : 0) +
     (p_to_f.residual >= 0 ? p_to_f.residual : 0);
 
+  // Degraded-convergence guard (found by the CE-5 quorum dogfood). The sum above coerces a
+  // skipped layer's residual (-1) to 0, so `total === 0` cannot distinguish "genuinely
+  // clean" from "measuring layers were skipped" — a false-convergence hole. Surface which
+  // forward layers were unmeasured so a clean total is never read as a proven convergence
+  // when layers did not run. Residual numbers are UNCHANGED (benchmark-neutral) — this only
+  // adds a qualifier.
+  const unmeasured_layers = computeUnmeasuredLayers({ r_to_f, f_to_t, c_to_f, t_to_c, f_to_c, r_to_d, d_to_c, p_to_f });
+  const degraded = unmeasured_layers.length > 0;
+
   const reverse_discovery_total =
     (c_to_r.residual >= 0 ? c_to_r.residual : 0) +
     (t_to_r.residual >= 0 ? t_to_r.residual : 0) +
@@ -5131,6 +5140,8 @@ function computeResidual() {
     model_stale,
     assembled_candidates,
     total,
+    degraded,
+    unmeasured_layers,
     automatable,
     manual,
     informational,
@@ -7249,11 +7260,25 @@ function persistSessionSummary(reportText, jsonText, converged, iterations, sess
   }
 }
 
+// Degraded-convergence guard (CE-5 quorum dogfood finding): the aggregate `total` sums
+// each layer as `(residual >= 0 ? residual : 0)`, so a SKIPPED layer (residual -1) is
+// coerced to 0 and a `total === 0` cannot tell "genuinely clean" from "layers didn't run".
+// Return the names of layers that were not measured (residual not a number >= 0), so a
+// clean total is never read as a proven convergence when a layer was skipped.
+function computeUnmeasuredLayers(layers) {
+  if (!layers || typeof layers !== 'object') return [];
+  return Object.keys(layers).filter((k) => {
+    const r = layers[k] && layers[k].residual;
+    return !(typeof r === 'number' && r >= 0);
+  });
+}
+
 // ── Exports (for testing) ────────────────────────────────────────────────────
 
 module.exports = {
   sweep: computeResidual,
   computeResidual,
+  computeUnmeasuredLayers,
   autoClose,
   formatReport,
   formatJSON,


### PR DESCRIPTION
**Closes the dogfood loop.** The live CE-5 quorum (from the quorum-thoroughness work) surfaced this in an extra deliberation round — opencode-1 and copilot-1 **independently** flagged it, and I verified it in code.

**Bug:** nf-solve's aggregate `total` sums each layer as `(residual >= 0 ? residual : 0)`, coercing a **skipped layer (`residual -1`)** to `0`. A `total === 0` can't tell "genuinely clean" from "the measuring layers didn't run" — a false-convergence hole.

**Fix (additive, benchmark-neutral):** compute `unmeasured_layers` + a `degraded` flag on the result. **Residual numbers unchanged → fixture corpus 8/8, no score shift.** Extracted `computeUnmeasuredLayers()` as an exported pure helper. 6 unit tests.

The old stop-at-first-unanimity quorum would have missed this — it only emerged in CE-5's extra review round. Wiring `degraded` into the convergence *decision* is a larger follow-on (#44).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved solver results so “clean” outputs are no longer reported when some layers were skipped during calculation.
  * Added clearer degraded-convergence reporting, including an indicator when not all layers were measured.
  * Handled missing or invalid layer results more safely, without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->