### PR TITLE
feat(observe): standalone autodetection script for sentry-cli + gcx install/auth

### DIFF
--- a/bin/observe-tooling.cjs
+++ b/bin/observe-tooling.cjs
@@ -225,7 +225,9 @@ function runCli(argv, opts = {}) {
   // Collect source-type filters: `--source <type>` pairs and bare positionals.
   const sourceTypes = [];
   for (let i = 0; i < args.length; i++) {
-    if (args[i] === '--source' && args[i + 1]) { sourceTypes.push(args[++i]); }
+    // Only consume the next token as the value if it isn't itself a flag —
+    // otherwise `--source --strict` would swallow --strict as a filter value.
+    if (args[i] === '--source' && args[i + 1] && !args[i + 1].startsWith('-')) { sourceTypes.push(args[++i]); }
     else if (!args[i].startsWith('-')) { sourceTypes.push(args[i]); }
   }
   const statuses = detect(sourceTypes.length ? { sourceTypes } : {});

--- a/bin/observe-tooling.cjs
+++ b/bin/observe-tooling.cjs
@@ -187,6 +187,60 @@ function annotateResultsWithTooling(results, statuses) {
   return results;
 }
 
+/**
+ * PURE-ish CLI core (detect fn injectable for tests). Parses argv, runs
+ * detection, and returns { output, code } without touching process/stdout —
+ * so the entrypoint below stays a thin shell.
+ *
+ *   node bin/observe-tooling.cjs                 # probe all known CLIs, human report
+ *   node bin/observe-tooling.cjs --json          # machine-readable
+ *   node bin/observe-tooling.cjs --source grafana# only the CLI(s) backing grafana (gcx)
+ *   node bin/observe-tooling.cjs --strict        # exit 1 if any probed CLI is unhealthy
+ *
+ * @param {string[]} argv - args after the script name
+ * @param {object} [opts] - { detect } injectable detector for tests
+ * @returns {{ output: string, code: number }}
+ */
+function runCli(argv, opts = {}) {
+  const detect = (opts && opts.detect) || detectObserveTooling;
+  const args = Array.isArray(argv) ? argv : [];
+  if (args.includes('--help') || args.includes('-h')) {
+    return {
+      output: [
+        'Usage: node bin/observe-tooling.cjs [--json] [--strict] [--source <type> ...]',
+        '',
+        'Detects whether the CLIs backing observe sources are installed AND authenticated:',
+        '  sentry-cli  → sentry, sentry-feedback',
+        '  gcx         → grafana',
+        '',
+        '  --json           machine-readable output',
+        '  --strict         exit 1 if any probed CLI is missing/unauthenticated',
+        '  --source <type>  only probe CLIs backing this source type (repeatable)',
+      ].join('\n'),
+      code: 0,
+    };
+  }
+  const json = args.includes('--json');
+  const strict = args.includes('--strict');
+  // Collect source-type filters: `--source <type>` pairs and bare positionals.
+  const sourceTypes = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--source' && args[i + 1]) { sourceTypes.push(args[++i]); }
+    else if (!args[i].startsWith('-')) { sourceTypes.push(args[i]); }
+  }
+  const statuses = detect(sourceTypes.length ? { sourceTypes } : {});
+  const anyUnhealthy = statuses.some((s) => !s.healthy);
+  let output;
+  if (json) {
+    output = JSON.stringify({ tools: statuses, all_healthy: !anyUnhealthy }, null, 2);
+  } else if (statuses.length === 0) {
+    output = ' nForma > OBSERVE: no CLI-backed tools match the given --source filter';
+  } else {
+    output = renderToolingStatus(statuses);
+  }
+  return { output, code: strict && anyUnhealthy ? 1 : 0 };
+}
+
 module.exports = {
   OBSERVE_TOOLS,
   parseVersion,
@@ -194,4 +248,11 @@ module.exports = {
   detectObserveTooling,
   renderToolingStatus,
   annotateResultsWithTooling,
+  runCli,
 };
+
+if (require.main === module) {
+  const { output, code } = runCli(process.argv.slice(2));
+  process.stdout.write(output + '\n');
+  process.exit(code);
+}

--- a/bin/observe-tooling.test.cjs
+++ b/bin/observe-tooling.test.cjs
@@ -10,6 +10,7 @@ const {
   detectObserveTooling,
   renderToolingStatus,
   annotateResultsWithTooling,
+  runCli,
 } = require('./observe-tooling.cjs');
 
 // Real fixtures captured from the live CLIs.
@@ -172,5 +173,53 @@ describe('annotateResultsWithTooling', () => {
 
   it('is a no-op on non-array results', () => {
     assert.equal(annotateResultsWithTooling(null, []), null);
+  });
+});
+
+describe('runCli (autodetection script)', () => {
+  const healthy = { name: 'gcx', installed: true, authed: true, healthy: true, version: '0.4.2', sources: ['grafana'], hint: null };
+  const unhealthy = { name: 'sentry-cli', installed: false, authed: false, healthy: false, version: null, sources: ['sentry', 'sentry-feedback'], hint: 'brew install ...' };
+  const detectStub = (statuses) => { const fn = (opts) => { fn.lastOpts = opts; return statuses; }; return fn; };
+
+  it('human output renders the status table and exits 0 by default (even when unhealthy)', () => {
+    const { output, code } = runCli([], { detect: detectStub([healthy, unhealthy]) });
+    assert.equal(code, 0, 'a plain report never fails the process');
+    assert.match(output, /tooling preflight/);
+    assert.match(output, /✓ gcx/);
+    assert.match(output, /✗ sentry-cli/);
+  });
+
+  it('--json emits machine-readable status with all_healthy flag', () => {
+    const { output } = runCli(['--json'], { detect: detectStub([healthy, unhealthy]) });
+    const parsed = JSON.parse(output);
+    assert.equal(parsed.all_healthy, false);
+    assert.equal(parsed.tools.length, 2);
+    assert.equal(parsed.tools[0].name, 'gcx');
+  });
+
+  it('--strict exits 1 when any probed CLI is unhealthy, 0 when all healthy', () => {
+    assert.equal(runCli(['--strict'], { detect: detectStub([healthy, unhealthy]) }).code, 1);
+    assert.equal(runCli(['--strict'], { detect: detectStub([healthy]) }).code, 0);
+  });
+
+  it('--source filters detection to the backing CLI(s) via sourceTypes', () => {
+    const detect = detectStub([healthy]);
+    runCli(['--source', 'grafana'], { detect });
+    assert.deepEqual(detect.lastOpts, { sourceTypes: ['grafana'] });
+  });
+
+  it('empty status set (filter matches nothing) prints a friendly note, exit 0', () => {
+    const { output, code } = runCli(['--source', 'github'], { detect: detectStub([]) });
+    assert.equal(code, 0);
+    assert.match(output, /no CLI-backed tools match/);
+  });
+
+  it('--help prints usage and exits 0 without probing', () => {
+    let probed = false;
+    const { output, code } = runCli(['--help'], { detect: () => { probed = true; return []; } });
+    assert.equal(code, 0);
+    assert.equal(probed, false, 'help must not shell out');
+    assert.match(output, /Usage:/);
+    assert.match(output, /sentry-cli/);
   });
 });

--- a/bin/observe-tooling.test.cjs
+++ b/bin/observe-tooling.test.cjs
@@ -208,6 +208,15 @@ describe('runCli (autodetection script)', () => {
     assert.deepEqual(detect.lastOpts, { sourceTypes: ['grafana'] });
   });
 
+  it('--source does not swallow a following flag as its value', () => {
+    const detect = detectStub([unhealthy]);
+    // `--source --strict`: --strict must NOT be consumed as a source value,
+    // so no sourceTypes filter is applied AND --strict still takes effect.
+    const { code } = runCli(['--source', '--strict'], { detect });
+    assert.equal(detect.lastOpts && detect.lastOpts.sourceTypes, undefined, '--strict must not become a source filter');
+    assert.equal(code, 1, '--strict must still be honored (unhealthy → exit 1)');
+  });
+
   it('empty status set (filter matches nothing) prints a friendly note, exit 0', () => {
     const { output, code } = runCli(['--source', 'github'], { detect: detectStub([]) });
     assert.equal(code, 0);

--- a/commands/nf/observe.md
+++ b/commands/nf/observe.md
@@ -121,6 +121,16 @@ if (toolingStatus.length > 0) display(renderToolingStatus(toolingStatus));
 a missing binary, a crashed probe, or an odd exit code all degrade to
 `installed:false` / `healthy:false`. Keep `toolingStatus` in scope for Step 4c.
 
+The same detection is runnable standalone as an autodetection script — handy for
+setup/diagnostics without invoking observe:
+
+```bash
+node "$HOME/.claude/nf-bin/observe-tooling.cjs"                  # human report (or ./bin/… in-repo)
+node "$HOME/.claude/nf-bin/observe-tooling.cjs" --json           # machine-readable { tools, all_healthy }
+node "$HOME/.claude/nf-bin/observe-tooling.cjs" --source grafana # only the CLI(s) backing grafana
+node "$HOME/.claude/nf-bin/observe-tooling.cjs" --strict         # exit 1 if any probed CLI is missing/unauthenticated
+```
+
 ## Step 4: Dispatch parallel fetch
 
 Call `dispatchAll()` from `bin/observe-registry.cjs` — this dispatches ALL sources uniformly through the registry with per-source timeout. No special-casing per source type at this stage.


### PR DESCRIPTION
## What

Makes the existing tooling detection **directly runnable** as an autodetection script — you can now check whether `sentry-cli` and `gcx` are installed *and* authenticated without invoking `/nf:observe`:

```bash
node bin/observe-tooling.cjs                  # human report per CLI (install + auth + version)
node bin/observe-tooling.cjs --json           # { tools:[...], all_healthy }
node bin/observe-tooling.cjs --source grafana # only the CLI(s) backing that source (gcx)
node bin/observe-tooling.cjs --strict         # exit 1 if any probed CLI is missing/unauthenticated
```

Example (live):
```
 ✓ sentry-cli 3.6.0  authenticated  (sentry, sentry-feedback)
 ✓ gcx 0.4.2  authenticated  (grafana)
```

## How

- Adds a thin `require.main` entrypoint plus an injectable `runCli(argv, { detect })` core to `bin/observe-tooling.cjs` — reuses the already-tested `detectObserveTooling()` / `renderToolingStatus()`, no new file, no new install wiring (it's already synced to `~/.claude/nf-bin`).
- Default exit is always 0 (a report shouldn't fail your shell); `--strict` opts into a non-zero exit for scripting/setup gates.
- `--source <type>` reuses the `sourceTypes` allowlist so it only probes relevant CLIs.

## Tests

6 new `runCli` unit tests (injected detector — no shelling out): human + `--json` output, `--strict` exit codes, `--source`→`sourceTypes` mapping, empty-filter note, `--help` doesn't probe. **25/25** in `observe-tooling.test.cjs` (already gated in `test:ci`). Verified live against real `sentry-cli`/`gcx` and from the installed nf-bin path; `lint:isolation` + skill lints green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a standalone CLI command for checking tooling availability with human-readable and JSON output.
  * Added filters to check only specific source types and a strict mode for non-zero exit codes when issues are found.
  * Added a help mode and clearer messaging when no matching tools are found.

* **Bug Fixes**
  * Improved command behavior so it returns consistent output and exit codes without directly printing or exiting from the core logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->