### PR TITLE
docs(formal): relabel test-coverage metric as requirement→test TRACEABILITY (not behavioral coverage)

### DIFF
--- a/.planning/formal/unit-test-coverage.json
+++ b/.planning/formal/unit-test-coverage.json
@@ -1,5 +1,7 @@
 {
   "generated_at": "2026-06-30T12:35:17.345Z",
+  "metric": "requirement_to_test_traceability",
+  "metric_note": "covered = a test carries an explicit // @requirement <ID> annotation for this requirement. ANNOTATION-BASED TRACEABILITY, NOT behavioral test coverage. Do not read a low percentage as \"the code is untested\" — the suite has thousands of passing behavioral tests that are simply not @requirement-tagged.",
   "requirements": {
     "CONF-01": {
       "covered": true,

--- a/bin/formal-test-sync.cjs
+++ b/bin/formal-test-sync.cjs
@@ -455,9 +455,15 @@ function buildCoverageReport(formalAnnotations, testAnnotations, requirements) {
     stats: {
       total: totalReqs,
       formal_covered: formalCovered,
+      // `test_covered` = requirements with a test carrying an explicit
+      // `// @requirement <ID>` annotation. This is requirement→test TRACEABILITY,
+      // NOT behavioral coverage — a low value means untagged tests, not untested
+      // behavior. `metric` is emitted so downstream consumers can't misread it.
       test_covered: testCovered,
       both_covered: bothCovered,
       gap_count: gapCount,
+      metric: 'requirement_to_test_traceability',
+      metric_note: 'test_covered/gap_count measure @requirement-annotation traceability, NOT behavioral test coverage',
     },
   };
 }
@@ -885,6 +891,15 @@ function writeSidecar(coverageReport) {
 
   const sidecar = {
     generated_at: new Date().toISOString(),
+    // Self-documenting metric label so this file is never misread as behavioral
+    // test coverage. `covered` here means ONLY that some test carries an explicit
+    // `// @requirement <ID>` annotation linking it to this requirement — it is
+    // requirement→test TRACEABILITY, not "is the behavior tested". An unannotated
+    // test still exercises the behavior; a low percentage here does NOT mean the
+    // code is untested (the suite has thousands of passing behavioral tests that
+    // simply aren't @requirement-tagged).
+    metric: 'requirement_to_test_traceability',
+    metric_note: 'covered = a test carries an explicit `// @requirement <ID>` annotation for this requirement. ANNOTATION-BASED TRACEABILITY, NOT behavioral test coverage. Do not read a low percentage as "the code is untested".',
     requirements,
   };
 
@@ -898,10 +913,11 @@ function printSummary(coverageReport, constantsValidation, stubs) {
   const TAG_SUMMARY = '[formal-test-sync]';
 
   process.stdout.write(TAG_SUMMARY + ' Generated formal-test-sync report\n');
-  process.stdout.write(TAG_SUMMARY + '   Coverage gaps: ' + coverageReport.stats.gap_count + ' requirements with formal but no test\n');
-  process.stdout.write(TAG_SUMMARY + '   Both covered: ' + coverageReport.stats.both_covered + ' requirements with formal AND test\n');
-  process.stdout.write(TAG_SUMMARY + '   Formal covered: ' + coverageReport.stats.formal_covered + ' / ' + coverageReport.stats.total + '\n');
-  process.stdout.write(TAG_SUMMARY + '   Test covered: ' + coverageReport.stats.test_covered + ' / ' + coverageReport.stats.total + '\n');
+  process.stdout.write(TAG_SUMMARY + '   Metric: requirement→test TRACEABILITY (@requirement-tagged tests) — NOT behavioral test coverage\n');
+  process.stdout.write(TAG_SUMMARY + '   Traceability gaps: ' + coverageReport.stats.gap_count + ' requirements formally modeled but with no @requirement-tagged test\n');
+  process.stdout.write(TAG_SUMMARY + '   Both linked: ' + coverageReport.stats.both_covered + ' requirements with formal model AND @requirement-tagged test\n');
+  process.stdout.write(TAG_SUMMARY + '   Formal-modeled: ' + coverageReport.stats.formal_covered + ' property-links / ' + coverageReport.stats.total + ' requirements\n');
+  process.stdout.write(TAG_SUMMARY + '   @requirement-tagged tests: ' + coverageReport.stats.test_covered + ' / ' + coverageReport.stats.total + ' requirements (a low number means untagged tests, not untested behavior)\n');
 
   // Constants validation summary
   const mismatches = constantsValidation.filter(c => !c.match && c.config_path !== null);

--- a/bin/formal-test-sync.test.cjs
+++ b/bin/formal-test-sync.test.cjs
@@ -611,6 +611,7 @@ test('TC-INT-2: Full script with --report-only exits 0 with human-readable summa
   });
 
   assert.equal(result.status, 0, 'script should exit 0');
-  assert.match(result.stdout, /Coverage gaps/, 'output should mention coverage gaps');
+  assert.match(result.stdout, /Traceability gaps/, 'output should mention traceability gaps');
+  assert.match(result.stdout, /TRACEABILITY .* NOT behavioral test coverage/, 'summary must label the metric so it is not misread as behavioral coverage');
   assert.match(result.stdout, /Constants mismatches/, 'output should mention constants');
 });


### PR DESCRIPTION
## Why

Evaluated with nForma (`nf:formal-test-sync --report-only`) at your request. Its own verdict on `.planning/formal/unit-test-coverage.json`:

| | |
|---|---|
| Requirements | 458 |
| Formal property-links | **582** (comprehensive) |
| `@requirement`-tagged tests | **11** requirements |
| Traceability gaps (formal, no tagged test) | **421** |
| Stubs nForma would auto-generate | **0** |
| Constants validation | **7/7 match, 0 drift** |

The "~1%" is **annotation traceability**, *not* behavioral coverage — the repo has **809 test files / 2737 passing tests**. A green CI is not hollow. This exact misread led a 4-model quorum to rank a "test-coverage collapse" as the top risk, so this makes the metric self-documenting so it can't recur — human *or* quorum.

## What

Relabel at every surface, no behavioral change:
- **sidecar** `unit-test-coverage.json`: `metric: 'requirement_to_test_traceability'` + `metric_note` (also stamped onto the committed file — no full regen, which would write 421 stubs).
- **`--json` stats**: `metric` + `metric_note` fields (the machine-readable path a consumer/quorum reads).
- **summary**: `Test covered` → `@requirement-tagged tests (a low number means untagged tests, not untested behavior)`; `Coverage gaps` → `Traceability gaps`.

## Verification
- `TC-INT-2` updated to assert the metric is labelled TRACEABILITY / NOT behavioral coverage.
- Gated `formal-test-sync-safety.test.cjs` 5/5; `lint:isolation` ✓; residual numbers untouched.
- The 4 pre-existing slow-timeout failures in the (non-gated) `formal-test-sync.test.cjs` fail identically on `main` — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated traceability reporting to clearly label “coverage” as requirement-to-test traceability, not behavioral test coverage.
  * Added clearer metric and note details to the generated summary and sidecar output.
  * Improved summary wording to highlight traceability gaps and tagged-test counts more explicitly.

* **Tests**
  * Adjusted integration expectations to match the new traceability-focused terminology in the output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->