### PR TITLE
chore(release): 0.44.1 (latest)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-## [0.44.0] - 2026-07-08 — Observability, OIDC publishing, cross-LLM delegation, and quorum hardening
+## [0.44.1] - 2026-07-08 — Observability, OIDC publishing, cross-LLM delegation, and quorum hardening
 
 ### Added
 - feat(skill): **`/nf:ultra-hard` — quorum-verified adversarial hardening to convergence.** A review panel fans out across security/correctness **dimensions** (`correctness,security,leak,recoverability,failure,input` by default, `--dimensions` to override), a **multi-model quorum verifies every candidate finding** (refute-by-default, majority-`real` to survive — so false positives are dropped, not fixed), and each **confirmed** finding is fixed **failing-test-first** — looping until two consecutive rounds surface zero new confirmed findings (convergence) or `--rounds N` is hit. It is `nf:harden` with independent eyes and a verification quorum, for set-once / high-stakes code (money, keys, migrations, auth) where one sequential reviewer demonstrably misses defects. Fixers run under hard constraints (never weaken/delete an existing guard or test to go green, never leak a secret, independently cross-check any money/crypto/identity result against an external reference), and the full suite must stay green after every fix. Flags: `--area <path>`, `--voters <N>`, `--test-cmd "<cmd>"`, `--commit`. New `commands/nf/ultra-hard.md` + `core/workflows/ultra-hard.md`; verified against the four skill lints (eval/state-parse/mcp/command-correctness). Proven on a real custodial-wallet key ceremony: a first quorum pass confirmed 38 findings (3/3-voted) on top of 17 manual, each fixed with a regression test.

--- a/docs/assets/terminal.svg
+++ b/docs/assets/terminal.svg
@@ -80,7 +80,7 @@
     <path d="M100.8,143.0 H96.6 V132.0" stroke="#7dcfff" stroke-width="1.5" stroke-linecap="square" fill="none"/>
     <line x1="100.8" y1="143.0" x2="109.2" y2="143.0" stroke="#7dcfff" stroke-width="1.5" stroke-linecap="square" fill="none"/>
     <path d="M109.2,143.0 H113.4 V132.0" stroke="#7dcfff" stroke-width="1.5" stroke-linecap="square" fill="none"/>
-    <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="198" xml:space="preserve"><tspan fill="#c0caf5">  nForma </tspan><tspan fill="#c0caf5">— Consensus before code. Proof before production. </tspan><tspan fill="#565f89">v0.44.0</tspan></text>
+    <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="198" xml:space="preserve"><tspan fill="#c0caf5">  nForma </tspan><tspan fill="#c0caf5">— Consensus before code. Proof before production. </tspan><tspan fill="#565f89">v0.44.1</tspan></text>
     <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="220" xml:space="preserve"><tspan fill="#565f89">  Built on GSD-CC by TÂCHES.</tspan></text>
     <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="264" xml:space="preserve"><tspan fill="#7dcfff">  The task of leadership is to create an alignment of strengths</tspan></text>
     <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="286" xml:space="preserve"><tspan fill="#7dcfff">   so strong that it makes the system’s weaknesses irrelevant.</tspan></text>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nforma.ai/nforma",
-  "version": "0.44.0",
+  "version": "0.44.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nforma.ai/nforma",
-      "version": "0.44.0",
+      "version": "0.44.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nforma.ai/nforma",
-  "version": "0.44.0",
+  "version": "0.44.1",
   "description": "nForma — Multi-agent coding orchestrator with quorum consensus and formal verification (TLA+, Alloy, PRISM). Consensus before code, proof before production.",
   "bin": {
     "nforma": "bin/nforma-cli.js",


### PR DESCRIPTION
Fresh 0.44.1 (0.44.0 tag/release exist from May but never npm-published, so bump to avoid the inconsistency). Same milestone content; on merge, `publish.yml` publishes to `@latest` via OIDC (trusted publisher now configured) + tags v0.44.1 + GitHub Release + aligns @next. All release gates green locally (npm ci, check:assets, lint:isolation, CHANGELOG [0.44.1], dedup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project version to `0.44.1`.
  * Adjusted the release notes header to match the new version number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->