### PR TITLE
fix(ci): make OIDC publishing work (drop setup-node registry-url, use publishConfig)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -119,11 +119,13 @@ jobs:
       id-token: write   # required for OIDC trusted publishing
     steps:
       - uses: actions/checkout@v4
+      # NB: intentionally NO registry-url/scope here. setup-node's registry-url writes an
+      # .npmrc with `always-auth=true` + a placeholder `_authToken`, which forces npm down
+      # the (dummy) TOKEN path and it never attempts OIDC → E404. The registry + public
+      # access come from package.json `publishConfig` instead, leaving OIDC to authenticate.
       - uses: actions/setup-node@v4
         with:
           node-version: '22'   # setup-node resolves to the latest 22.x, always >= 22.14.0 (the OIDC trusted-publishing minimum)
-          registry-url: 'https://registry.npmjs.org'
-          scope: '@nforma.ai'
       - name: Update npm (>= 11.5.1 for trusted publishing)
         # ^11.5.1 = latest 11.x AND guaranteed >= 11.5.1 (the trusted-publishing
         # minimum), with no unattended jump to a new npm major.

--- a/package.json
+++ b/package.json
@@ -47,6 +47,10 @@
   ],
   "author": "nForma AI",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/nForma-AI/nForma.git"


### PR DESCRIPTION
The 0.44.x publish kept **E404**ing because `setup-node`'s `registry-url` writes an `.npmrc` with `always-auth=true` + a **placeholder `_authToken`** — so npm used (dummy) token auth and **never attempted OIDC**.

Fix: remove `registry-url`/`scope` from the publish job's setup-node, and pin the registry + `access: public` via package.json **`publishConfig`** instead. npm now has no token in `.npmrc` and authenticates via OIDC trusted publishing.

Version unchanged (0.44.1) — merging re-triggers `publish.yml`, which will publish 0.44.1 (still not on npm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)