### PR TITLE
chore(release): 0.44.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to nForma will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [0.44.2] - 2026-07-29 — Thread-persistent quorum loop, model-expanded slot roster, multi-repo scope, and goal delivery
 
 ### Added
 - feat(quorum): **opt-in thread persistence per slot** (`quorum.persistent_threads`, default false). The CE-5 full-convergence loop was stateless by design: each round spawns a fresh CLI invocation with prior-round outputs spliced into the prompt, and the convergence check diffs that prompt-injected state. With `persistent_threads: true`, slot CLIs keep a native conversation across rounds — `codex exec resume <thread_id>`, `-p --resume <session_id>`, or `-c` for CWD-scoped continue (agy, kimi). Round 1 captures the session id from stdout (codex JSONL `thread.started`, claude `--output-format json`) and persists it to `.planning/quorum/sessions/<slot>-<invocation>.json`; round 2+ reads the file and replaces the fresh argv template with the resume argv before `{prompt}` substitution. GC: every invocation sweeps session files >24h old, fail-open. Drop-guard mirrors the existing pattern (garbage `persistent_threads` warns + falls back to false; absent restores silently). New: `bin/quorum-resume.cjs` (helper), `bin/quorum-sessions-store.cjs` (scratch store), `bin/quorum-resume.test.cjs` (28 PURE tests, red-proven). Also fixes a latent path bug: `bin/call-quorum-slot.cjs` required `./config-loader` which resolves to a nonexistent path; corrected to `../hooks/config-loader`.
@@ -22,6 +22,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Removed
 - chore(release): retire the prerelease flow entirely — the alias policy makes a separate prerelease channel nonsensical (publishing `0.40.2-rc.1` to `@latest` would silently install the prerelease for every user, and `@next == @latest` means there is no separate surface to ship it on). Concretely: (1) `.github/workflows/publish.yml` no longer triggers on `v*-rc*` / `v*-next*` tag pushes, the `prerelease` branch in the `context` job is gone, the `Stamp version from tag (prerelease only)` step is gone, and the workflow now REFUSES any `package.json` version with a `-` suffix (errors instead of publishing). (2) `scripts/release.sh` is deleted — its sole job was the prerelease flow (bump `-rc.N`, push tag). The stable path remains `scripts/prepare-release.sh` (PR-based, the only release path now). (3) `release/{VERSION}-rc.N` branch naming is no longer a thing; CLAUDE.md "Git workflow" now restricts direct-to-main pushes to CI fixes only. (4) CLAUDE.md "CI gates to remember" replaces the "regex accepts prerelease suffixes" note with "**No prerelease versions**". Older rc tags in git history (e.g. `v0.44.0-rc.2`) remain inert; the workflow no longer matches them.
+
+
+## [Unreleased]
+
 
 ## [0.44.1] - 2026-07-08 — Observability, OIDC publishing, cross-LLM delegation, and quorum hardening
 

--- a/docs/assets/terminal.svg
+++ b/docs/assets/terminal.svg
@@ -80,7 +80,7 @@
     <path d="M100.8,143.0 H96.6 V132.0" stroke="#7dcfff" stroke-width="1.5" stroke-linecap="square" fill="none"/>
     <line x1="100.8" y1="143.0" x2="109.2" y2="143.0" stroke="#7dcfff" stroke-width="1.5" stroke-linecap="square" fill="none"/>
     <path d="M109.2,143.0 H113.4 V132.0" stroke="#7dcfff" stroke-width="1.5" stroke-linecap="square" fill="none"/>
-    <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="198" xml:space="preserve"><tspan fill="#c0caf5">  nForma </tspan><tspan fill="#c0caf5">— Consensus before code. Proof before production. </tspan><tspan fill="#565f89">v0.44.1</tspan></text>
+    <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="198" xml:space="preserve"><tspan fill="#c0caf5">  nForma </tspan><tspan fill="#c0caf5">— Consensus before code. Proof before production. </tspan><tspan fill="#565f89">v0.44.2</tspan></text>
     <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="220" xml:space="preserve"><tspan fill="#565f89">  Built on GSD-CC by TÂCHES.</tspan></text>
     <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="264" xml:space="preserve"><tspan fill="#7dcfff">  The task of leadership is to create an alignment of strengths</tspan></text>
     <text font-family="'SF Mono', 'Fira Code', 'JetBrains Mono', Consolas, monospace" font-size="14" y="286" xml:space="preserve"><tspan fill="#7dcfff">   so strong that it makes the system’s weaknesses irrelevant.</tspan></text>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nforma.ai/nforma",
-  "version": "0.44.1",
+  "version": "0.44.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nforma.ai/nforma",
-      "version": "0.44.1",
+      "version": "0.44.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nforma.ai/nforma",
-  "version": "0.44.1",
+  "version": "0.44.2",
   "description": "nForma — Multi-agent coding orchestrator with quorum consensus and formal verification (TLA+, Alloy, PRISM). Consensus before code, proof before production.",
   "bin": {
     "nforma": "bin/nforma-cli.js",

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -131,14 +131,7 @@ if $DRY_RUN; then
   echo "[dry-run] Would create branch ${BRANCH} from origin/main"
 else
   git fetch origin main --quiet
-  # Patch: idempotent branch create (handles existing branch)
-if git show-ref --verify --quiet refs/heads/"$BRANCH"; then
-  # Branch exists. Verify it tracks origin/main and is clean (no CI drift).
-  git checkout "$BRANCH" --quiet
-  git merge --ff-only origin/main --quiet || true
-else
   git checkout -b "$BRANCH" origin/main
-fi
 fi
 
 # ── Step 2: Bump package.json version ──

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -131,7 +131,14 @@ if $DRY_RUN; then
   echo "[dry-run] Would create branch ${BRANCH} from origin/main"
 else
   git fetch origin main --quiet
+  # Patch: idempotent branch create (handles existing branch)
+if git show-ref --verify --quiet refs/heads/"$BRANCH"; then
+  # Branch exists. Verify it tracks origin/main and is clean (no CI drift).
+  git checkout "$BRANCH" --quiet
+  git merge --ff-only origin/main --quiet || true
+else
   git checkout -b "$BRANCH" origin/main
+fi
 fi
 
 # ── Step 2: Bump package.json version ──


### PR DESCRIPTION
## Release 0.44.2

Automated release preparation via `scripts/prepare-release.sh`.

### Checklist (all verified locally before push)
- [x] package.json bumped to 0.44.2
- [x] package-lock.json synced (`npm install --package-lock-only`)
- [x] CHANGELOG entry for [0.44.2]
- [x] terminal.svg regenerated
- [x] `npm ci --ignore-scripts` passes
- [x] `check:assets` passes
- [x] `lint:isolation` passes
- [x] `test:ci` passes

### After merge
CI will automatically: test -> tag v0.44.2 -> create GitHub Release -> publish to npm @latest -> align @next dist-tag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Quorum threads now persist across sessions.
  - Added support for the Kimi CLI quorum family.
  - CE-5 workflows now support configurable maximum rounds.
  - `/nf:goal-writer` can target delivery destinations and generate doctrines and conditions.

- **Documentation**
  - Published release notes for version 0.44.2.
  - Added an empty Unreleased section for future changes.

- **Quality Improvements**
  - Strengthened release safeguards and skill/lint validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->