### PR TITLE
ci(publish): use NPM_TOKEN for the @next-alignment step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -121,16 +121,17 @@ jobs:
       - name: Publish via OIDC trusted publisher
         run: npm publish --access public --tag "${{ needs.context.outputs.dist_tag }}"
       - name: Align @next with @latest
-        # Best-effort: OIDC trusted publishing authorizes `npm publish`, not necessarily
-        # `npm dist-tag add`. If the minted token can't move a dist-tag, do NOT fail the
-        # release (the publish already succeeded) — warn so it can be aligned manually
-        # (`npm dist-tag add @nforma.ai/nforma@<version> next`). `@next` and `@latest`
-        # must show the same version after every release (see CLAUDE.md invariant).
+        # OIDC trusted publishing authorizes `npm publish` but NOT `npm dist-tag add`.
+        # Use the legacy NPM_TOKEN (GitHub repo secret) for dist-tag operations only —
+        # publish keeps using OIDC. `@next` and `@latest` must show the same version
+        # after every release (see CLAUDE.md invariant).
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           if npm dist-tag add "@nforma.ai/nforma@${{ needs.context.outputs.version }}" next; then
             echo "Aligned @next → ${{ needs.context.outputs.version }}"
           else
-            echo "::warning::Could not align @next via OIDC (dist-tag may not be authorized by trusted publishing). Run: npm dist-tag add @nforma.ai/nforma@${{ needs.context.outputs.version }} next"
+            echo "::warning::Could not align @next via NPM_TOKEN (token may be revoked or expired). Run: npm dist-tag add @nforma.ai/nforma@${{ needs.context.outputs.version }} next"
           fi
       - name: Show dist-tags
         run: npm dist-tag ls @nforma.ai/nforma || true


### PR DESCRIPTION
OIDC trusted publishing authorizes 'npm publish' but not 'npm dist-tag add' — the dist-tag step runs as no-auth and silently fails with E401. The release therefore lands with @latest=0.44.2 and @next stuck at the previous version, breaking the documented '@next == @latest' invariant in CLAUDE.md.

This fix pipes the legacy NPM_TOKEN (already in GitHub repo secrets, created 2026-02-21) through env on the dist-tag step ONLY. 'npm publish' still uses OIDC. The token's dist-tag scope is the package (no IP allowlist needed for that scope), and the workflow falls back gracefully if the token is revoked/expired.

For 0.44.2 (the released PR #376), the NPM_TOKEN secret may itself be stale — user must regenerate on npmjs.com and re-add @next manually if needed.

For all future releases, this PR auto-aligns @next with @latest as part of the publish.yml pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved package release reliability by using an explicit authentication token when aligning the `@next` distribution tag.
  * Updated release warnings to clarify when authentication credentials may be invalid or expired.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->