### PR TITLE
fix(circuit-breaker): false positive on interleaved merge commits

### DIFF
--- a/hooks/dist/nf-circuit-breaker.js
+++ b/hooks/dist/nf-circuit-breaker.js
@@ -390,6 +390,14 @@ function detectOscillation(fileSets, depth, hashes, gitRoot, options) {
     if (keyRunList.length >= depth) {
       const files = key.split('\0').filter(f => f.length > 0);
 
+      // An empty file-set key arises from merge commits: `git diff-tree` (no `-m`)
+      // attributes no files to a merge, so N interleaved merges in a one-PR-per-commit
+      // workflow produce N empty run-groups that exactly satisfy depth/min_cycles — a
+      // phantom "(unknown)" oscillation with no real file set. The reversion second-pass
+      // can't redeem it either (it diffs `files=[]` → the whole repo between merges).
+      // Never treat the empty set as an oscillation candidate.
+      if (files.length === 0) continue;
+
       // Second-pass reversion check (if hashes and gitRoot provided)
       if (hashes && gitRoot && hashes.length > 0) {
         // Collect all hashes from the oscillating run-groups (newest-first order preserved)
@@ -791,12 +799,13 @@ function buildBlockReason(state) {
     lines.push('');
   }
   lines.push(
-    'Invoke Oscillation Resolution Mode per R5 in CLAUDE.md — see core/workflows/oscillation-resolution-mode.md for the full procedure.',
+    'Invoke Oscillation Resolution Mode per R5 — see ~/.claude/nf/workflows/oscillation-resolution-mode.md for the full procedure.',
     '',
     'Read-only operations are still allowed (e.g. git log --oneline to review the commit history).',
     'You must manually commit a root-cause fix before write operations are unblocked.',
     '',
     "After committing the fix, run 'npx nforma --reset-breaker' to clear the circuit breaker state.",
+    "If this was deliberate iterative work rather than a bug loop, run 'npx nforma --disable-breaker' to dismiss and continue; re-enable with 'npx nforma --enable-breaker' when done.",
   );
   return lines.join('\n');
 }
@@ -828,7 +837,7 @@ function buildWarningNotice(state) {
   }
 
   lines.push(
-    'Invoke Oscillation Resolution Mode per R5 in CLAUDE.md — see core/workflows/oscillation-resolution-mode.md for the full procedure.',
+    'Invoke Oscillation Resolution Mode per R5 — see ~/.claude/nf/workflows/oscillation-resolution-mode.md for the full procedure.',
     '',
     'After committing the fix, run \'npx nforma --reset-breaker\' to clear the circuit breaker state.',
     'To temporarily disable the circuit breaker for deliberate iterative work, run \'npx nforma --disable-breaker\'.',

--- a/hooks/dist/nf-circuit-breaker.js
+++ b/hooks/dist/nf-circuit-breaker.js
@@ -802,10 +802,9 @@ function buildBlockReason(state) {
     'Invoke Oscillation Resolution Mode per R5 — see ~/.claude/nf/workflows/oscillation-resolution-mode.md for the full procedure.',
     '',
     'Read-only operations are still allowed (e.g. git log --oneline to review the commit history).',
-    'You must manually commit a root-cause fix before write operations are unblocked.',
-    '',
-    "After committing the fix, run 'npx nforma --reset-breaker' to clear the circuit breaker state.",
-    "If this was deliberate iterative work rather than a bug loop, run 'npx nforma --disable-breaker' to dismiss and continue; re-enable with 'npx nforma --enable-breaker' when done.",
+    'Write operations are blocked until you do ONE of the following:',
+    "- Commit a root-cause fix manually, then run 'npx nforma --reset-breaker' to clear this state; OR",
+    "- If this was deliberate iterative work rather than a bug loop, run 'npx nforma --disable-breaker' to dismiss and continue (re-enable later with 'npx nforma --enable-breaker').",
   );
   return lines.join('\n');
 }

--- a/hooks/nf-circuit-breaker.js
+++ b/hooks/nf-circuit-breaker.js
@@ -390,6 +390,14 @@ function detectOscillation(fileSets, depth, hashes, gitRoot, options) {
     if (keyRunList.length >= depth) {
       const files = key.split('\0').filter(f => f.length > 0);
 
+      // An empty file-set key arises from merge commits: `git diff-tree` (no `-m`)
+      // attributes no files to a merge, so N interleaved merges in a one-PR-per-commit
+      // workflow produce N empty run-groups that exactly satisfy depth/min_cycles — a
+      // phantom "(unknown)" oscillation with no real file set. The reversion second-pass
+      // can't redeem it either (it diffs `files=[]` → the whole repo between merges).
+      // Never treat the empty set as an oscillation candidate.
+      if (files.length === 0) continue;
+
       // Second-pass reversion check (if hashes and gitRoot provided)
       if (hashes && gitRoot && hashes.length > 0) {
         // Collect all hashes from the oscillating run-groups (newest-first order preserved)
@@ -791,12 +799,13 @@ function buildBlockReason(state) {
     lines.push('');
   }
   lines.push(
-    'Invoke Oscillation Resolution Mode per R5 in CLAUDE.md — see core/workflows/oscillation-resolution-mode.md for the full procedure.',
+    'Invoke Oscillation Resolution Mode per R5 — see ~/.claude/nf/workflows/oscillation-resolution-mode.md for the full procedure.',
     '',
     'Read-only operations are still allowed (e.g. git log --oneline to review the commit history).',
     'You must manually commit a root-cause fix before write operations are unblocked.',
     '',
     "After committing the fix, run 'npx nforma --reset-breaker' to clear the circuit breaker state.",
+    "If this was deliberate iterative work rather than a bug loop, run 'npx nforma --disable-breaker' to dismiss and continue; re-enable with 'npx nforma --enable-breaker' when done.",
   );
   return lines.join('\n');
 }
@@ -828,7 +837,7 @@ function buildWarningNotice(state) {
   }
 
   lines.push(
-    'Invoke Oscillation Resolution Mode per R5 in CLAUDE.md — see core/workflows/oscillation-resolution-mode.md for the full procedure.',
+    'Invoke Oscillation Resolution Mode per R5 — see ~/.claude/nf/workflows/oscillation-resolution-mode.md for the full procedure.',
     '',
     'After committing the fix, run \'npx nforma --reset-breaker\' to clear the circuit breaker state.',
     'To temporarily disable the circuit breaker for deliberate iterative work, run \'npx nforma --disable-breaker\'.',

--- a/hooks/nf-circuit-breaker.js
+++ b/hooks/nf-circuit-breaker.js
@@ -802,10 +802,9 @@ function buildBlockReason(state) {
     'Invoke Oscillation Resolution Mode per R5 — see ~/.claude/nf/workflows/oscillation-resolution-mode.md for the full procedure.',
     '',
     'Read-only operations are still allowed (e.g. git log --oneline to review the commit history).',
-    'You must manually commit a root-cause fix before write operations are unblocked.',
-    '',
-    "After committing the fix, run 'npx nforma --reset-breaker' to clear the circuit breaker state.",
-    "If this was deliberate iterative work rather than a bug loop, run 'npx nforma --disable-breaker' to dismiss and continue; re-enable with 'npx nforma --enable-breaker' when done.",
+    'Write operations are blocked until you do ONE of the following:',
+    "- Commit a root-cause fix manually, then run 'npx nforma --reset-breaker' to clear this state; OR",
+    "- If this was deliberate iterative work rather than a bug loop, run 'npx nforma --disable-breaker' to dismiss and continue (re-enable later with 'npx nforma --enable-breaker').",
   );
   return lines.join('\n');
 }

--- a/hooks/nf-circuit-breaker.test.js
+++ b/hooks/nf-circuit-breaker.test.js
@@ -2107,3 +2107,99 @@ test('CB-ADV-DASH: size-alternating oscillation on "--"-prefixed lines is caught
     fs.rmSync(repoDir, { recursive: true, force: true });
   }
 });
+
+// ── Merge-commit phantom-oscillation regression guards (CB-FP10 / CB-FP11) ──────
+// `git diff-tree` (no -m) attributes NO files to a merge commit, so three interleaved
+// --no-ff merges in a one-PR-per-commit workflow yield three EMPTY file-set run-groups
+// that exactly satisfy depth=3 and min_cycles=2. Pre-fix the breaker tripped on the
+// empty set and reported "Oscillating file set: (unknown)". The empty file-set must
+// never be an oscillation candidate. Reported as a false positive against nForma v0.44.1.
+
+// CB-FP10: end-to-end — real --no-ff merge commits interleaved with distinct-file
+// feature commits. The 6-commit window becomes [merge,feat,merge,feat,merge,feat];
+// the empty (merge) key forms 3 run-groups. Must NOT activate the breaker.
+test('CB-FP10: interleaved --no-ff merge commits do NOT trigger a phantom "(unknown)" oscillation', () => {
+  const repoDir = createTempGitRepo();
+  const run = (args) => spawnSync('git', args, { cwd: repoDir, encoding: 'utf8' });
+  // Force a deterministic identity (createTempGitRepo's space-split helper mangles quoted values).
+  run(['config', 'user.name', 'CB Test']);
+  run(['config', 'user.email', 'cb@example.com']);
+  try {
+    // Root commit — kept outside the commit_window=6 by the 6 commits below.
+    commitInRepo(repoDir, 'README.md', 'init\n', 'root');
+    const mainBranch = run(['rev-parse', '--abbrev-ref', 'HEAD']).stdout.trim();
+
+    // Three one-commit PRs merged with --no-ff, each touching a DISTINCT file so the
+    // feature commits form distinct file-set keys (only the merges share the empty key).
+    const prs = [
+      { branch: 'b1', file: 'explore_loop.sh', feat: 'feat: fix explore drip', merge: 'merge #1' },
+      { branch: 'b2', file: 'supervisor.sh', feat: 'feat: de-nest supervisor', merge: 'merge #2' },
+      { branch: 'b3', file: 'health_check.py', feat: 'feat: retire v2 drips', merge: 'merge #3' },
+    ];
+    for (const pr of prs) {
+      run(['checkout', '-b', pr.branch]);
+      commitInRepo(repoDir, pr.file, `${pr.file} content\n`, pr.feat);
+      run(['checkout', mainBranch]);
+      run(['merge', '--no-ff', '-m', pr.merge, pr.branch]);
+    }
+
+    const statePath = writeBreakerConfig(repoDir); // haiku off → detection is purely algorithmic
+
+    const { stdout, exitCode } = runHook({
+      tool_name: 'Bash',
+      tool_input: { command: 'echo write > output.txt', description: 'test', timeout: 5000 },
+      cwd: repoDir,
+      hook_event_name: 'PreToolUse',
+      tool_use_id: 'test-id',
+      session_id: 'test-session',
+      transcript_path: '/tmp/test.jsonl',
+      permission_mode: 'default',
+    });
+    assert.strictEqual(exitCode, 0, 'exit code must be 0');
+    assert.strictEqual(stdout, '', 'stdout must be empty — no oscillation detected');
+    assert(!fs.existsSync(statePath), 'state file must NOT be written — empty merge-derived file-set is not an oscillation candidate (CB-FP10)');
+  } finally {
+    fs.rmSync(repoDir, { recursive: true, force: true });
+  }
+});
+
+// CB-FP11: unit-level pin on detectOscillation — the synthetic interleaved-merge window
+// returns detected:false at depth=3 / min_cycles=2. Fast and git-free (gitRoot=null skips
+// the second pass; the primary gate is where the empty-set bug lived).
+test('CB-FP11: detectOscillation skips the empty (merge-derived) file-set as a candidate', () => {
+  // Newest→oldest: merge(empty) | featC | merge(empty) | featB | merge(empty) | featA(6 files)
+  const fileSets = [
+    [],
+    ['explore_loop.sh'],
+    [],
+    ['supervisor.sh'],
+    [],
+    ['explore_loop.sh', 'health_check.py', 'supervisor.sh', 'a', 'b', 'c', 'd'],
+  ];
+  const hashes = fileSets.map((_, i) => 'h' + i);
+  // Pre-fix the empty key had 3 run-groups (depth 3) and 2 cycles (min_cycles 2) → detected:true.
+  const res = detectOscillation(fileSets, 3, hashes, null, { minCycles: 2, rollbackDetection: true });
+  assert.strictEqual(res.detected, false, 'empty file-set from merge commits must not be an oscillation candidate (CB-FP11)');
+  assert.deepStrictEqual(res.fileSet, [], 'no file set should be reported for an all-merge window');
+});
+
+// CB-TC-BR4: the deny/block message must surface the legitimate-dismiss escape hatch
+// (--disable-breaker) so the agent is not pressured toward fabricating a "root-cause fix"
+// commit when the oscillation was iterative work. Also pins the corrected workflow doc path.
+test('CB-TC-BR4: Deny message surfaces --disable-breaker and the installed workflow path', () => {
+  const state = {
+    active: true,
+    file_set: ['any.js'],
+    activated_at: '2026-01-01T00:00:00Z',
+    commit_window_snapshot: [['any.js']],
+  };
+  const reason = buildBlockReason(state);
+  assert.ok(reason.includes('npx nforma --disable-breaker'), 'deny reason must surface --disable-breaker (legitimate-dismiss escape hatch)');
+  assert.ok(reason.includes('npx nforma --enable-breaker'), 'deny reason must mention how to re-enable');
+  // Existing pinned substrings must survive (CB-TC17 / CB-TC-BR1 / CB-TC-BR3 depend on these):
+  assert.ok(reason.includes('Oscillation Resolution Mode per R5'), 'deny reason must retain the R5 reference');
+  assert.ok(reason.includes('npx nforma --reset-breaker'), 'deny reason must retain --reset-breaker');
+  // P3: point at the installed location, not the dev-only core/workflows path
+  assert.ok(reason.includes('~/.claude/nf/workflows/oscillation-resolution-mode.md'), 'deny reason must reference the installed workflow path');
+  assert.ok(!reason.includes('core/workflows/oscillation-resolution-mode.md'), 'deny reason must NOT reference the dev-only core/workflows path');
+});

--- a/hooks/nf-circuit-breaker.test.js
+++ b/hooks/nf-circuit-breaker.test.js
@@ -655,6 +655,7 @@ test('CB-TC18: Project config oscillation_depth:2 triggers oscillation detection
 
 const {
   buildBlockReason,
+  buildWarningNotice,
   writeEvidenceSignature,
   checkPreemptiveEvidence,
   markEvidenceResolved,
@@ -2202,4 +2203,23 @@ test('CB-TC-BR4: Deny message surfaces --disable-breaker and the installed workf
   // P3: point at the installed location, not the dev-only core/workflows path
   assert.ok(reason.includes('~/.claude/nf/workflows/oscillation-resolution-mode.md'), 'deny reason must reference the installed workflow path');
   assert.ok(!reason.includes('core/workflows/oscillation-resolution-mode.md'), 'deny reason must NOT reference the dev-only core/workflows path');
+});
+
+// CB-TC-WN1: regression coverage for buildWarningNotice (the first-detection allow
+// notice) — mirrors CB-TC-BR4's assertions so the priority notice cannot regress
+// independently of buildBlockReason.
+test('CB-TC-WN1: Warning notice references the installed workflow path and dismiss commands', () => {
+  const state = {
+    active: true,
+    file_set: ['any.js'],
+    activated_at: '2026-01-01T00:00:00Z',
+    commit_window_snapshot: [['any.js']],
+  };
+  const notice = buildWarningNotice(state);
+  assert.ok(notice.includes('OSCILLATION DETECTED — PRIORITY NOTICE'), 'warning notice must carry its header');
+  assert.ok(notice.includes('Oscillation Resolution Mode per R5'), 'warning notice must retain the R5 reference');
+  assert.ok(notice.includes('~/.claude/nf/workflows/oscillation-resolution-mode.md'), 'warning notice must reference the installed workflow path');
+  assert.ok(!notice.includes('core/workflows/oscillation-resolution-mode.md'), 'warning notice must NOT reference the dev-only core/workflows path');
+  assert.ok(notice.includes('npx nforma --reset-breaker'), 'warning notice must include reset-breaker');
+  assert.ok(notice.includes('npx nforma --disable-breaker'), 'warning notice must include disable-breaker');
 });


### PR DESCRIPTION
## Problem

The circuit breaker tripped a false positive on a `feat/inference-crdb-unification` branch, reporting `Oscillating file set: (unknown)` and blocking all writes after three legitimate, separately-merged PRs touched the same `research/frontier/*` area.

## Root cause

`git diff-tree` (no `-m`) attributes **no files** to a merge commit, so the three interleaved `--no-ff` merges produced three **empty** file-set run-groups that exactly satisfied `oscillation_depth: 3` and `min_cycles: 2` (the defaults). The breaker detected "oscillation" on the *phantom empty set* (rendered `(unknown)`), not on the real feature files — none of which reached the threshold (1 run-group each). The convergence second-pass couldn't redeem it either: with `files=[]`, `git diff A B --` is not path-restricted, so it diffs the whole repo between merges.

Reproduced bit-exact against the reported 6-commit window via the exported `detectOscillation()`.

## Fixes

- **P1 — `detectOscillation`**: never treat an empty file-set key as an oscillation candidate (the merge-commit case). The existing convergence machinery (content-reversion fingerprinting, monotonic-shrink exemption, Haiku GENUINE/REFINEMENT reviewer, `min_cycles`) then handles genuine cases correctly.
- **P2 — `buildBlockReason`**: surface `--disable-breaker` / `--enable-breaker` in the deny/block message. Previously the escape hatch appeared only in the first-detection *allow* notice, so once blocked the agent was pressured toward fabricating a "root-cause fix" commit.
- **P3 — both message builders**: point at the installed workflow path (`~/.claude/nf/workflows/oscillation-resolution-mode.md`) instead of the dev-only `core/workflows/…` path that does not resolve in a consuming project.

## Tests

- `CB-FP10` — e2e: real `--no-ff` merge commits interleaved with distinct-file feature commits → no false positive.
- `CB-FP11` — unit pin: `detectOscillation` returns `detected:false` on the synthetic empty-interleaved window.
- `CB-TC-BR4` — deny message now includes `--disable-breaker` and the installed workflow path; retains pinned substrings.
- All **65** breaker tests pass (no regressions). `lint:isolation`, `check:assets`, `verify-hooks-sync` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented false oscillation warnings for merge commits with no changed files.
  * Updated circuit-breaker messages with clearer resolution guidance, including how to temporarily disable and re-enable the breaker during deliberate iterative work.
  * Added reset instructions and references to the installed workflow path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->