### PR TITLE
fix(release): make the @next alignment actually authenticate (DIST-TAG-01)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -159,7 +159,15 @@ jobs:
           echo "$TAGS"
           LATEST=$(printf '%s' "$TAGS" | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).latest || ''")
           NEXT=$(printf '%s' "$TAGS" | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).next || ''")
-          if [ "$LATEST" = "$NEXT" ]; then
+          # An unreadable registry response must NOT read as a pass. Without this,
+          # `npm view` failing leaves LATEST and NEXT both empty, they compare equal,
+          # and the step cheerfully prints "invariant OK — next == latest == " while
+          # having verified nothing at all.
+          if [ -z "$LATEST" ] || [ -z "$NEXT" ]; then
+            echo "::warning::could not read dist-tags (npm view failed, or the package has no latest/next tag) — the invariant was NOT verified. Check by hand: npm view @nforma.ai/nforma dist-tags"
+          elif [ "$LATEST" != "$VERSION" ]; then
+            echo "::warning::@latest is ${LATEST} but this run published ${VERSION} — publish did not land where expected; not asserting the alias invariant against a version we did not ship"
+          elif [ "$LATEST" = "$NEXT" ]; then
             echo "invariant OK — next == latest == ${LATEST}"
           else
             echo "::warning::DIST-TAG DRIFT — latest=${LATEST} next=${NEXT}. Anyone installing @next gets the older build. Fix: npm dist-tag add @nforma.ai/nforma@${VERSION} next"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -121,20 +121,49 @@ jobs:
       - name: Publish via OIDC trusted publisher
         run: npm publish --access public --tag "${{ needs.context.outputs.dist_tag }}"
       - name: Align @next with @latest
-        # OIDC trusted publishing authorizes `npm publish` but NOT `npm dist-tag add`.
-        # Use the legacy NPM_TOKEN (GitHub repo secret) for dist-tag operations only —
-        # publish keeps using OIDC. `@next` and `@latest` must show the same version
-        # after every release (see CLAUDE.md invariant).
+        # OIDC trusted publishing authorizes `npm publish` but NOT `npm dist-tag add`,
+        # so this step needs token auth. `@next` and `@latest` must show the same
+        # version after every release (see CLAUDE.md invariant).
+        #
+        # DIST-TAG-01: this used to export NPM_TOKEN as a bare env var and nothing else.
+        # npm does NOT read NPM_TOKEN — auth comes from .npmrc (or NODE_AUTH_TOKEN with
+        # a setup-node registry-url). So the dist-tag call ran UNAUTHENTICATED, 401'd,
+        # and fell into the warning branch on every single release, blaming a token that
+        # was configured and fine. That is the recurring @next drift. Writing the
+        # .npmrc HERE is safe: it runs after the OIDC publish, so it cannot push publish
+        # onto the token path. The file holds the literal `${NPM_TOKEN}` reference (npm
+        # expands it at read time), not the secret itself, and is removed on exit.
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          if npm dist-tag add "@nforma.ai/nforma@${{ needs.context.outputs.version }}" next; then
-            echo "Aligned @next → ${{ needs.context.outputs.version }}"
-          else
-            echo "::warning::Could not align @next via NPM_TOKEN (token may be revoked or expired). Run: npm dist-tag add @nforma.ai/nforma@${{ needs.context.outputs.version }} next"
+          VERSION="${{ needs.context.outputs.version }}"
+          MANUAL="npm dist-tag add @nforma.ai/nforma@${VERSION} next"
+          if [ -z "${NPM_TOKEN}" ]; then
+            echo "::warning::NPM_TOKEN secret is not set, so @next cannot be aligned from CI. Run: ${MANUAL}"
+            exit 0
           fi
-      - name: Show dist-tags
-        run: npm dist-tag ls @nforma.ai/nforma || true
+          printf '//registry.npmjs.org/:_authToken=${NPM_TOKEN}\n' > .npmrc
+          trap 'rm -f .npmrc' EXIT
+          if npm dist-tag add "@nforma.ai/nforma@${VERSION}" next; then
+            echo "Aligned @next → ${VERSION}"
+          else
+            echo "::warning::npm dist-tag add failed with a configured NPM_TOKEN — the token is likely revoked, expired, or lacks publish rights on the package. Run: ${MANUAL}"
+          fi
+      # Verify the invariant instead of merely printing it: a silent warning above is
+      # how @next drifted release after release. Never fails the job — the package is
+      # already published by this point, and a red job would misreport that.
+      - name: Verify @next == @latest
+        run: |
+          VERSION="${{ needs.context.outputs.version }}"
+          TAGS=$(npm view @nforma.ai/nforma dist-tags --json 2>/dev/null || echo '{}')
+          echo "$TAGS"
+          LATEST=$(printf '%s' "$TAGS" | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).latest || ''")
+          NEXT=$(printf '%s' "$TAGS" | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).next || ''")
+          if [ "$LATEST" = "$NEXT" ]; then
+            echo "invariant OK — next == latest == ${LATEST}"
+          else
+            echo "::warning::DIST-TAG DRIFT — latest=${LATEST} next=${NEXT}. Anyone installing @next gets the older build. Fix: npm dist-tag add @nforma.ai/nforma@${VERSION} next"
+          fi
 
   # ── Git tag + GitHub Release (after a successful publish) ──
   # Recovery note: if publish succeeds but this job fails transiently, a re-run finds

--- a/bin/release-guards.test.cjs
+++ b/bin/release-guards.test.cjs
@@ -170,3 +170,52 @@ describe('publish.yml — CI-side prerelease rejection', () => {
     assert.doesNotMatch(YML, /mode=prerelease/, 'a prerelease mode was reintroduced');
   });
 });
+
+// ── DIST-TAG-01: the @next alignment must actually authenticate ───────────────
+// The align step used to do nothing but `env: NPM_TOKEN: ${{ secrets.NPM_TOKEN }}`.
+// npm does not read NPM_TOKEN — auth comes from .npmrc (or NODE_AUTH_TOKEN plus a
+// setup-node registry-url). So `npm dist-tag add` ran UNAUTHENTICATED, 401'd, and hit
+// the warning branch on every release while blaming a token that was configured and
+// working. That is the recurring @next drift the alias invariant kept tripping over.
+describe('publish.yml — @next alignment actually authenticates (DIST-TAG-01)', () => {
+  const YML = fs.readFileSync(path.join(REPO, '.github/workflows/publish.yml'), 'utf8');
+  const alignStep = (() => {
+    const start = YML.indexOf('- name: Align @next with @latest');
+    assert.ok(start !== -1, 'publish.yml lost its "Align @next with @latest" step');
+    const rest = YML.slice(start + 1);
+    const end = rest.indexOf('\n      - name:');
+    return rest.slice(0, end === -1 ? undefined : end);
+  })();
+
+  it('writes an .npmrc authToken rather than relying on a bare NPM_TOKEN env var', () => {
+    assert.match(
+      alignStep, /_authToken=\$\{NPM_TOKEN\}/,
+      'the align step must write //registry.npmjs.org/:_authToken=${NPM_TOKEN} into .npmrc — ' +
+      'exporting NPM_TOKEN alone is a no-op and the dist-tag call runs unauthenticated',
+    );
+  });
+
+  it('removes the .npmrc it wrote', () => {
+    assert.match(alignStep, /rm -f \.npmrc/, 'the temporary .npmrc must be cleaned up');
+  });
+
+  it('distinguishes "secret missing" from "token rejected" in its warnings', () => {
+    // The old message asserted the token "may be revoked or expired" in the one case
+    // where that was never the cause. A wrong diagnosis costs the next reader real time.
+    assert.match(alignStep, /NPM_TOKEN secret is not set/, 'must report an absent secret as absent');
+    assert.match(alignStep, /revoked, expired, or lacks publish rights/, 'must report a rejected token distinctly');
+  });
+
+  it('verifies the invariant after aligning, instead of only printing dist-tags', () => {
+    assert.match(YML, /- name: Verify @next == @latest/, 'publish.yml must verify the alias invariant');
+    assert.match(YML, /DIST-TAG DRIFT/, 'a drifted tag must be called out explicitly, not left to be eyeballed');
+  });
+
+  it('keeps the publish step on OIDC — no NODE_AUTH_TOKEN in any non-comment line', () => {
+    // Its presence forces the token path and defeats trusted publishing (CLAUDE.md).
+    // Comments naming it are fine — two of them exist precisely to warn against it —
+    // so strip comment lines before asserting rather than matching the whole file.
+    const code = YML.split('\n').filter(l => !/^\s*#/.test(l)).join('\n');
+    assert.doesNotMatch(code, /NODE_AUTH_TOKEN/, 'NODE_AUTH_TOKEN defeats OIDC trusted publishing');
+  });
+});

--- a/bin/release-guards.test.cjs
+++ b/bin/release-guards.test.cjs
@@ -219,3 +219,79 @@ describe('publish.yml — @next alignment actually authenticates (DIST-TAG-01)',
     assert.doesNotMatch(code, /NODE_AUTH_TOKEN/, 'NODE_AUTH_TOKEN defeats OIDC trusted publishing');
   });
 });
+
+// ── The verify step is EXECUTED here, not read ────────────────────────────────
+// Asserting that publish.yml contains the right strings proves nothing about what the
+// shell does with them. This extracts the step's actual script and runs it against a
+// stubbed `npm view`, one run per registry response the step can meet. The case that
+// matters most is the unreadable one: with `|| echo '{}'` upstream, both tags come back
+// empty, compare EQUAL, and a naive check prints "invariant OK — next == latest == "
+// while having verified nothing. A verification that cannot fail is not a verification.
+describe('publish.yml — the @next verification actually discriminates (executed)', () => {
+  const YML = fs.readFileSync(path.join(REPO, '.github/workflows/publish.yml'), 'utf8');
+
+  function verifyScript() {
+    const start = YML.indexOf('- name: Verify @next == @latest');
+    assert.ok(start !== -1, 'publish.yml lost its "Verify @next == @latest" step');
+    const runIdx = YML.indexOf('run: |', start);
+    assert.ok(runIdx !== -1, 'the verify step must use a `run: |` block');
+    const body = YML.slice(YML.indexOf('\n', runIdx) + 1);
+    const lines = [];
+    for (const line of body.split('\n')) {
+      if (line.trim() === '') { lines.push(''); continue; }
+      if (!/^ {10}/.test(line)) break;           // dedent marks the end of the block
+      lines.push(line.slice(10));
+    }
+    return lines.join('\n').replace(/\$\{\{ needs\.context\.outputs\.version \}\}/g, '0.44.3');
+  }
+
+  // Stub `npm view` so no test ever reaches the real registry.
+  function runWith(tagsJson) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nf-verify-'));
+    const file = path.join(dir, 'verify.sh');
+    fs.writeFileSync(file,
+      `npm() { if [ "$1" = "view" ]; then printf %s '${tagsJson}'; else command npm "$@"; fi; }\n` +
+      verifyScript());
+    const r = spawnSync('bash', [file], { encoding: 'utf8', timeout: 30000 });
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch (_) {}
+    return { status: r.status, out: (r.stdout || '') + (r.stderr || '') };
+  }
+
+  it('reports OK only when both tags are present and equal', () => {
+    const r = runWith('{"latest":"0.44.3","next":"0.44.3"}');
+    assert.equal(r.status, 0);
+    assert.match(r.out, /invariant OK — next == latest == 0\.44\.3/);
+  });
+
+  it('reports DRIFT when the tags differ, naming the fix command', () => {
+    const r = runWith('{"latest":"0.44.3","next":"0.44.2"}');
+    assert.match(r.out, /DIST-TAG DRIFT/);
+    assert.match(r.out, /npm dist-tag add @nforma\.ai\/nforma@0\.44\.3 next/);
+    assert.doesNotMatch(r.out, /invariant OK/);
+  });
+
+  it('does NOT report OK when the registry response is unreadable', () => {
+    // The `|| echo '{}'` fallback: two empty strings compare equal.
+    const r = runWith('{}');
+    assert.doesNotMatch(r.out, /invariant OK/, 'an unverifiable state must never read as verified');
+    assert.match(r.out, /NOT verified/);
+  });
+
+  it('does NOT report OK when only one of the two tags exists', () => {
+    const r = runWith('{"latest":"0.44.3"}');
+    assert.doesNotMatch(r.out, /invariant OK/);
+    assert.match(r.out, /NOT verified/);
+  });
+
+  it('does not assert the invariant against a version this run did not publish', () => {
+    const r = runWith('{"latest":"0.44.1","next":"0.44.1"}');
+    assert.doesNotMatch(r.out, /invariant OK/, 'equal-but-wrong tags are not a passing publish');
+    assert.match(r.out, /did not land where expected/);
+  });
+
+  it('never fails the job — the package is already published by this point', () => {
+    for (const tags of ['{"latest":"0.44.3","next":"0.44.3"}', '{"latest":"0.44.3","next":"0.44.2"}', '{}']) {
+      assert.equal(runWith(tags).status, 0, `verify must exit 0 for ${tags}`);
+    }
+  });
+});


### PR DESCRIPTION
`@next` has drifted behind `@latest` after **every** release — including 0.44.3, an hour ago. The recorded explanation has been "OIDC can't do `dist-tag add`", and the CI warning has been blaming a revoked or expired token. Both are wrong.

## What actually happens

`NPM_TOKEN` **is** configured — at repo scope *and* in the `npm-publish` environment. The align step did this and nothing else:

```yaml
env:
  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
run: npm dist-tag add ... next
```

**npm does not read `NPM_TOKEN`.** Auth comes from `.npmrc`, or from `NODE_AUTH_TOKEN` paired with a `setup-node` `registry-url`. So the call ran unauthenticated, 401'd, and landed in a warning branch whose text asserted the token "may be revoked or expired" — in the one case where that was never the cause.

That is the recurring drift, and it is why the manual `npm dist-tag add` fix was needed after every single release.

## Fix

The step writes `//registry.npmjs.org/:_authToken=${NPM_TOKEN}` to `.npmrc` for the duration of the call and removes it via `trap`. Safe here specifically because it runs **after** the OIDC publish, so it cannot push publish onto the token path; the file holds the literal `${NPM_TOKEN}` reference (npm expands at read time), never the secret value.

Warnings now distinguish **"secret is not set"** from **"token rejected"** — two different problems with two different fixes.

`Show dist-tags` becomes **`Verify @next == @latest`**: it reads the live tags and emits an explicit `DIST-TAG DRIFT` warning naming the exact fix command. It never fails the job — the package is already published by that point, and a red job would misreport a successful release. Printing tags for a human to eyeball is precisely what let this pass unnoticed release after release.

## Guards

5 new tests in `bin/release-guards.test.cjs`, mutation-proven: removing the `.npmrc` write fails two of them, dropping the verify step fails another.

The OIDC guard filters comment lines before asserting — two comments name `NODE_AUTH_TOKEN` specifically to warn against it, and my first version of that assertion flagged those comments as violations.

## Still needs a human, once

This PR fixes the *next* release. 0.44.3 is already out with `next: 0.44.2`, so it still needs the one-time manual fix from an authenticated machine:

```bash
npm dist-tag add @nforma.ai/nforma@0.44.3 next
```

## Unrelated, noticed while checking secrets

`gh api repos/nForma-AI/nForma/actions/secrets` lists `EVIL`, `EVILPWNED`, `EVIL_KEY`, `SAFE_KEY`, `TEST_KEY` alongside `NPM_TOKEN`. They look like leftovers from security testing. Deleting secrets is yours to decide, so I've left them — but stale credentials in a repo that publishes to npm are worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved package release publishing with authenticated distribution-tag alignment.
  * Added safeguards to clean up temporary credentials and skip tag alignment when authentication is unavailable.
  * Added post-release verification to confirm the `@next` and `@latest` tags exist and point to the published version.
  * Publishing now reports tag-alignment or verification issues as warnings without interrupting an otherwise successful release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->